### PR TITLE
Fixed segfault issue on Anaconda distribution

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -172,13 +172,13 @@ cdef class BayesianNetwork( Model ):
 		state, as ordered by self.states.
 		"""
 
-		indices = { state.name: i for i, state in enumerate( self.states ) }
+		indices = { state.distribution: i for i, state in enumerate( self.states ) }
 
 		# Go through each state and pass in the appropriate data for the
 		# update to the states
 		for i, state in enumerate( self.states ):
 			if isinstance( state.distribution, ConditionalProbabilityTable ):
-				idx = [ indices[ dist.name ] for dist in state.distribution.parameters[1] ] + [i]
+				idx = [ indices[ dist ] for dist in state.distribution.parameters[1] ] + [i]
 				data = [ [ item[i] for i in idx ] for item in items ]
 				state.distribution.from_sample( data, weights, inertia, pseudocount )
 			else:

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -63,9 +63,6 @@ cdef class State( object ):
 		# Save the weight, or default to the unit weight
 		self.weight = weight or 1.
 
-		# Bind the distribution to this state
-		self.distribution.name = name
-
 	def __str__( self ):
 		"""
 		The string representation of a state is the json, so call that format.

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -2395,7 +2395,7 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 		# data type so we can't cast it as a numpy array. There is a higher
 		# overhead of doing this in Python versus Cython, but easier to handle
 		# inconsistent datatypes.
-		int_items = numpy.zeros( (len(items), len(items[0])), dtype=numpy.int )
+		int_items = numpy.zeros( (len(items), len(items[0])), dtype=numpy.int32 )
 		hashes = self.parameters[2]
 		for j, h in enumerate( hashes ):
 			for i in xrange( len(items) ):
@@ -2418,7 +2418,7 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 		cdef int n = items.shape[0], d = items.shape[1]
 		cdef list k = self.parameters[3]
 		cdef tuple keys
-		cdef int [:] m = numpy.cumprod( [1]+k, dtype=numpy.int )
+		cdef int [:] m = numpy.cumprod( [1]+k, dtype=numpy.int32 )
 
 		# Go through each point and add it
 		for i in xrange( n ):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 setup(
     name='pomegranate',
-    version='0.2.8',
+    version='0.2.9',
     author='Jacob Schreiber',
     author_email='jmschreiber91@gmail.com',
     packages=['pomegranate'],

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -49,7 +49,8 @@ def test_normal():
 
 	d.from_sample( [ 5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4 ] )
 
-	assert d.parameters == [ 4.916666666666667, 0.75920279826202286 ]
+	assert round( d.parameters[0], 4 ) == 4.9167
+	assert round( d.parameters[1], 4 ) == 0.7592 
 	assert d.log_probability( 4 ) != e.log_probability( 4 )
 	assert d.log_probability( 4 ) == -1.3723678499651766
 	assert d.log_probability( 18 ) == -149.13140399454429
@@ -59,8 +60,9 @@ def test_normal():
 	assert d.log_probability( 1e100 ) == -4.9999999999999994e+219
 
 	d.from_sample( [ 0, 2, 3, 2, 100 ], weights=[ 0, 5, 2, 3, 200 ] )
-	assert d.parameters == [ 95.342857142857142, 20.827558927640887 ]
-	assert d.log_probability( 50 ) == -6.325011936564346
+	assert round( d.parameters[0], 4 ) == 95.3429
+	assert round( d.parameters[1], 4 ) == 20.8276
+	assert round( d.log_probability( 50 ), 8 ) == -6.32501194
 
 	d = NormalDistribution( 5, 2 )
 	d.from_sample( [ 0, 5, 3, 5, 7, 3, 4, 5, 2 ], inertia=0.5 )
@@ -83,7 +85,8 @@ def test_normal():
 
 	d.thaw()
 	d.from_sample( [ 5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4 ] )
-	assert d.parameters == [ 4.916666666666667, 0.75920279826202286 ]
+	assert round( d.parameters[0], 4 ) == 4.9167 
+	assert round( d.parameters[1], 4 ) == 0.7592
 
 @with_setup( setup, teardown )
 def test_uniform():


### PR DESCRIPTION
Fixes issue #19 

A segfault was raised due to states renaming distributions to give them unique identifiers for the Bayesian network data slicing. Instead of renaming, they are identified by a hash on the distribution object itself. This may need to be reworked should distribution tying for Bayesian networks be added, but it works for now and is more justified than the hack before.