### PR TITLE
[WIP] remove gil

### DIFF
--- a/pomegranate/base.pxd
+++ b/pomegranate/base.pxd
@@ -13,3 +13,4 @@ cdef class Model( object ):
 	cdef public str name
 	cdef public list states, edges
 	cdef public object graph
+	cdef int n_edges, n_states

--- a/pomegranate/base.pxd
+++ b/pomegranate/base.pxd
@@ -12,7 +12,4 @@ cdef class State( object ):
 cdef class Model( object ):
 	cdef public str name
 	cdef public list states, edges
-	cdef object graph
-	cdef int [:] in_edge_count, in_transitions, out_edge_count, out_transitions
-	cdef double [:] in_transition_log_probabilities
-	cdef double [:] out_transition_log_probabilities
+	cdef public object graph

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -158,6 +158,8 @@ cdef class Model( object ):
 		self.name = name or str( id(self) )
 		self.states = []
 		self.edges = []
+		self.n_edges = 0
+		self.n_states = 0
 	
 	def __str__(self):
 		"""
@@ -172,6 +174,7 @@ cdef class Model( object ):
 		"""
 
 		self.states.append( n )
+		self.n_states += 1
 
 	def add_nodes( self, n ):
 		"""
@@ -203,6 +206,7 @@ cdef class Model( object ):
 
 		# Add the transition
 		self.edges.append( ( a, b ) )
+		self.n_edges += 1
 
 	def add_transition( self, a, b ):
 		"""
@@ -216,21 +220,21 @@ cdef class Model( object ):
 		Returns the number of nodes/states in the model
 		"""
 
-		return len( self.states )
+		return self.n_states
 
 	def state_count( self ):
 		"""
 		Returns the number of states present in the model.
 		"""
 
-		return len( self.states )
+		return self.n_states
 
 	def edge_count( self ):
 		"""
 		Returns the number of edges present in the model.
 		"""
 
-		return len( self.out_transition_log_probabilities )
+		return self.n_edges
 
 	def dense_transition_matrix( self ):
 		"""

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -9,44 +9,37 @@ ctypedef numpy.npy_intp SIZE_t
 cdef class Distribution:
 	cdef public str name
 	cdef public list parameters, summaries
-	cdef public bint frozen, is_numeric_type
-	cdef double _dlog_probability( self, double symbol ) nogil
-	cdef double _slog_probability( self, char* symbol ) nogil
+	cdef public bint frozen
+	cdef void _summarize( self, double* items, double* weights,
+		SIZE_t size ) nogil
 
 cdef class UniformDistribution( Distribution ):
 	cdef double start, end
-	cdef void _from_sample( self, double [:] items, double [:] weights, 
-		DOUBLE_t inertia, SIZE_t size ) nogil
-	cdef void _summarize( self, double [:] items, double [:] weights,
-		SIZE_t size ) nogil
+	cdef double _log_probability( self, double symbol )
 
 cdef class NormalDistribution( Distribution ):
 	cdef double mu, sigma 
-	cdef void _from_sample( self, numpy.ndarray items, numpy.ndarray weights,
-		DOUBLE_t inertia, DOUBLE_t min_std, SIZE_t size ) nogil
+	cdef double _log_probability( self, double symbol )
 
 cdef class LogNormalDistribution( Distribution ):
 	cdef double mu, sigma
-
-cdef class ExtremeValueDistribution( Distribution ):
-	cdef double mu, sigma, epsilon
+	cdef double _log_probability( self, double symbol )
 
 cdef class ExponentialDistribution( Distribution ):
 	cdef double rate
+	cdef double _log_probability( self, double symbol )
 
 cdef class BetaDistribution( Distribution ):
 	cdef double alpha, beta
+	cdef double _log_probability( self, double symbol )
 
 cdef class GammaDistribution( Distribution ):
 	cdef double alpha, beta
-
-cdef struct KeyValuePair:
-	char* key
-	double value
+	cdef double _log_probability( self, double symbol )
 
 cdef class DiscreteDistribution( Distribution ):
-	cdef KeyValuePair* records
 	cdef int n
+	cdef double _log_probability( self, symbol )
 
 cdef class LambdaDistribution( Distribution ):
 	pass
@@ -55,35 +48,39 @@ cdef class GaussianKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
+	cdef double _log_probability( self, double symbol )
 
 cdef class UniformKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
+	cdef double _log_probability( self, double symbol )
 
 cdef class TriangleKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
+	cdef double _log_probability( self, double symbol )
 
 cdef class MixtureDistribution( Distribution ):
 	cdef double [:] weights
 	cdef Distribution [:] distributions
 	cdef int n
+	cdef double _log_probability( self, double symbol )
 
 
 cdef class MultivariateDistribution( Distribution ):
 	pass
 
 
-#cdef class IndependentComponentsDistribution( MultivariateDistribution ):
-#	cdef double [:] weights
-#	cdef Distribution [:] distributions
-#	cdef int n
-#	cdef double _log_probability( self, obs symbol ) nogil
+cdef class IndependentComponentsDistribution( MultivariateDistribution ):
+	cdef double [:] weights
+	cdef Distribution [:] distributions
+	cdef int n
+	cdef double _log_probability( self, symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
-	cdef public int diagonal 
+	cdef public int diagonal
 
 cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double [:] _from_sample( self, int [:,:] items, 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -11,6 +11,7 @@ cdef class Distribution:
 	cdef public list parameters, summaries
 	cdef public bint frozen
 	cdef double _log_probability( self, double symbol ) nogil
+	cdef double _mv_log_probability( self, double* symbol, SIZE_t d ) nogil
 	cdef void _summarize( self, double* items, double* weights,
 		SIZE_t n, SIZE_t d ) nogil
 
@@ -66,7 +67,7 @@ cdef class MixtureDistribution( Distribution ):
 	cdef int n
 
 cdef class MultivariateDistribution( Distribution ):
-	pass
+	cdef SIZE_t d
 
 cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double [:] weights
@@ -75,9 +76,11 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double __log_probability( self, symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
-	cdef public numpy.ndarray mu, cov, cv_chol
-	cdef int d
+	cdef public numpy.ndarray mu, cov, cv_chol, inv_cov_ndarray
+	cdef double* inv_cov
+	cdef double* _mu
 	cdef double cv_log_det
+	cdef double _log_det
 
 cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double [:] _from_sample( self, int [:,:] items, 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -11,9 +11,8 @@ cdef class Distribution:
 	cdef public list parameters, summaries
 	cdef public bint frozen
 	cdef double _log_probability( self, double symbol ) nogil
-	cdef double _mv_log_probability( self, double* symbol, SIZE_t d ) nogil
-	cdef void _summarize( self, double* items, double* weights,
-		SIZE_t n, SIZE_t d ) nogil
+	cdef double _mv_log_probability( self, double* symbol ) nogil
+	cdef void _summarize( self, double* items, double* weights, SIZE_t n ) nogil
 
 cdef class UniformDistribution( Distribution ):
 	cdef double start, end
@@ -67,7 +66,7 @@ cdef class MixtureDistribution( Distribution ):
 	cdef int n
 
 cdef class MultivariateDistribution( Distribution ):
-	cdef SIZE_t d
+	cdef public SIZE_t d
 
 cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double [:] weights
@@ -76,11 +75,17 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double __log_probability( self, symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
-	cdef public numpy.ndarray mu, cov, cv_chol, inv_cov_ndarray
+	cdef public numpy.ndarray mu, cov, inv_cov_ndarray
 	cdef double* inv_cov
 	cdef double* _mu
-	cdef double cv_log_det
+	cdef double* _mu_new
+	cdef double* _cov
+	cdef double* _cov_new
 	cdef double _log_det
+	cdef double w_sum
+	cdef double* column_sum
+	cdef double* pair_sum
+	cdef void _from_summaries( self, double inertia )
 
 cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double [:] _from_sample( self, int [:,:] items, 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -9,49 +9,74 @@ cdef class Distribution( object ):
 	cdef public bint frozen
 
 cdef class UniformDistribution( Distribution ):
-	cdef double _log_probability( self, double a, double b, double symbol )
+	cdef double start, end
+	cdef public double _log_probability( self, double symbol ) nogil
 
-cdef class NormalDistribution( Distribution ): 
-	cdef double _log_probability( self, double symbol, double epsilon )
+cdef class NormalDistribution( Distribution ):
+	cdef double mu, sigma 
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class LogNormalDistribution( Distribution ):
-	cdef double _log_probability( self, double symbol )
+	cdef double mu, sigma
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class ExtremeValueDistribution( Distribution ):
-	cdef double _log_probability( self, double symbol )
+	cdef double mu, sigma, epsilon
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class ExponentialDistribution( Distribution ):
-	pass
+	cdef double rate
+	cdef public double _log_probability( self, double symbol ) nogil
+
+cdef class BetaDistribution( Distribution ):
+	cdef double alpha, beta
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class GammaDistribution( Distribution ):
-	pass
+	cdef double alpha, beta
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class InverseGammaDistribution( GammaDistribution ):
 	pass
 
 cdef class DiscreteDistribution( Distribution ):
-	pass
+	cdef dict dist
 
 cdef class LambdaDistribution( Distribution ):
 	pass
 
 cdef class GaussianKernelDensity( Distribution ):
-	cdef double _log_probability( self, double symbol )
+	cdef double [:] points, weights
+	cdef int n
+	cdef double bandwidth
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class UniformKernelDensity( Distribution ):
-	cdef double _log_probability( self, double symbol )
+	cdef double [:] points, weights
+	cdef int n
+	cdef double bandwidth
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class TriangleKernelDensity( Distribution ):
-	cdef double _log_probability( self, double symbol )
+	cdef double [:] points, weights
+	cdef int n
+	cdef double bandwidth
+	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class MixtureDistribution( Distribution ):
-	pass
+	cdef double [:] weights
+	cdef Distribution [:] distributions
+	cdef int n
+	cdef public double _log_probability( self, double symbol )
 
 cdef class MultivariateDistribution( Distribution ):
 	pass
 
-cdef class IndependentComponentDistribution( MultivariateDistribution ):
-	pass
+cdef class IndependentComponentsDistribution( MultivariateDistribution ):
+	cdef double [:] weights
+	cdef Distribution [:] distributions
+	cdef int n
+	cdef public double _log_probability( self, numpy.ndarray symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
 	cdef public int diagonal 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -11,7 +11,7 @@ cdef class Distribution:
 	cdef public list parameters, summaries
 	cdef public bint frozen
 	cdef void _summarize( self, double* items, double* weights,
-		SIZE_t size ) nogil
+		SIZE_t n, SIZE_t d ) nogil
 
 cdef class UniformDistribution( Distribution ):
 	cdef double start, end
@@ -80,7 +80,8 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double _log_probability( self, symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
-	cdef public int diagonal
+	cdef public numpy.ndarray mu, cov
+	cdef int d
 
 cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double [:] _from_sample( self, int [:,:] items, 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -68,10 +68,8 @@ cdef class MixtureDistribution( Distribution ):
 	cdef int n
 	cdef double _log_probability( self, double symbol )
 
-
 cdef class MultivariateDistribution( Distribution ):
 	pass
-
 
 cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double [:] weights

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -18,7 +18,7 @@ cdef class UniformDistribution( Distribution ):
 	cdef double start, end
 
 cdef class NormalDistribution( Distribution ):
-	cdef double mu, sigma 
+	cdef double mu, sigma, two_sigma_squared, log_sigma_sqrt_2_pi
 
 cdef class LogNormalDistribution( Distribution ):
 	cdef double mu, sigma

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -41,6 +41,7 @@ cdef class InverseGammaDistribution( GammaDistribution ):
 
 cdef class DiscreteDistribution( Distribution ):
 	cdef dict dist
+	cdef public double _log_probability( self, key )
 
 cdef class LambdaDistribution( Distribution ):
 	pass

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -3,45 +3,50 @@
 
 cimport numpy
 
-cdef class Distribution( object ):
+ctypedef numpy.npy_float64 DOUBLE_t 
+ctypedef numpy.npy_intp SIZE_t  
+
+cdef class Distribution:
 	cdef public str name
 	cdef public list parameters, summaries
-	cdef public bint frozen
+	cdef public bint frozen, is_numeric_type
+	cdef double _dlog_probability( self, double symbol ) nogil
+	cdef double _slog_probability( self, char* symbol ) nogil
 
 cdef class UniformDistribution( Distribution ):
 	cdef double start, end
-	cdef public double _log_probability( self, double symbol ) nogil
+	cdef void _from_sample( self, double [:] items, double [:] weights, 
+		DOUBLE_t inertia, SIZE_t size ) nogil
+	cdef void _summarize( self, double [:] items, double [:] weights,
+		SIZE_t size ) nogil
 
 cdef class NormalDistribution( Distribution ):
 	cdef double mu, sigma 
-	cdef public double _log_probability( self, double symbol ) nogil
+	cdef void _from_sample( self, numpy.ndarray items, numpy.ndarray weights,
+		DOUBLE_t inertia, DOUBLE_t min_std, SIZE_t size ) nogil
 
 cdef class LogNormalDistribution( Distribution ):
 	cdef double mu, sigma
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class ExtremeValueDistribution( Distribution ):
 	cdef double mu, sigma, epsilon
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class ExponentialDistribution( Distribution ):
 	cdef double rate
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class BetaDistribution( Distribution ):
 	cdef double alpha, beta
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class GammaDistribution( Distribution ):
 	cdef double alpha, beta
-	cdef public double _log_probability( self, double symbol ) nogil
 
-cdef class InverseGammaDistribution( GammaDistribution ):
-	pass
+cdef struct KeyValuePair:
+	char* key
+	double value
 
 cdef class DiscreteDistribution( Distribution ):
-	cdef dict dist
-	cdef public double _log_probability( self, key )
+	cdef KeyValuePair* records
+	cdef int n
 
 cdef class LambdaDistribution( Distribution ):
 	pass
@@ -50,34 +55,32 @@ cdef class GaussianKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class UniformKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class TriangleKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef public double _log_probability( self, double symbol ) nogil
 
 cdef class MixtureDistribution( Distribution ):
 	cdef double [:] weights
 	cdef Distribution [:] distributions
 	cdef int n
-	cdef public double _log_probability( self, double symbol )
+
 
 cdef class MultivariateDistribution( Distribution ):
 	pass
 
-cdef class IndependentComponentsDistribution( MultivariateDistribution ):
-	cdef double [:] weights
-	cdef Distribution [:] distributions
-	cdef int n
-	cdef public double _log_probability( self, numpy.ndarray symbol )
+
+#cdef class IndependentComponentsDistribution( MultivariateDistribution ):
+#	cdef double [:] weights
+#	cdef Distribution [:] distributions
+#	cdef int n
+#	cdef double _log_probability( self, obs symbol ) nogil
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
 	cdef public int diagonal 

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -10,36 +10,36 @@ cdef class Distribution:
 	cdef public str name
 	cdef public list parameters, summaries
 	cdef public bint frozen
+	cdef double _log_probability( self, double symbol ) nogil
 	cdef void _summarize( self, double* items, double* weights,
 		SIZE_t n, SIZE_t d ) nogil
 
 cdef class UniformDistribution( Distribution ):
 	cdef double start, end
-	cdef double _log_probability( self, double symbol )
 
 cdef class NormalDistribution( Distribution ):
 	cdef double mu, sigma 
-	cdef double _log_probability( self, double symbol )
 
 cdef class LogNormalDistribution( Distribution ):
 	cdef double mu, sigma
-	cdef double _log_probability( self, double symbol )
 
 cdef class ExponentialDistribution( Distribution ):
 	cdef double rate
-	cdef double _log_probability( self, double symbol )
 
 cdef class BetaDistribution( Distribution ):
 	cdef double alpha, beta
-	cdef double _log_probability( self, double symbol )
 
 cdef class GammaDistribution( Distribution ):
 	cdef double alpha, beta
-	cdef double _log_probability( self, double symbol )
 
 cdef class DiscreteDistribution( Distribution ):
+	cdef bint encoded_summary
 	cdef int n
-	cdef double _log_probability( self, symbol )
+	cdef dict dist, log_dist
+	cdef tuple encoded_keys
+	cdef double* encoded_counts
+	cdef double* encoded_log_probability
+	cdef double __log_probability( self, symbol )
 
 cdef class LambdaDistribution( Distribution ):
 	pass
@@ -48,25 +48,22 @@ cdef class GaussianKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef double _log_probability( self, double symbol )
 
 cdef class UniformKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef double _log_probability( self, double symbol )
 
 cdef class TriangleKernelDensity( Distribution ):
 	cdef double [:] points, weights
 	cdef int n
 	cdef double bandwidth
-	cdef double _log_probability( self, double symbol )
 
 cdef class MixtureDistribution( Distribution ):
+	cdef double* weights_p
 	cdef double [:] weights
 	cdef Distribution [:] distributions
 	cdef int n
-	cdef double _log_probability( self, double symbol )
 
 cdef class MultivariateDistribution( Distribution ):
 	pass
@@ -75,11 +72,12 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	cdef double [:] weights
 	cdef Distribution [:] distributions
 	cdef int n
-	cdef double _log_probability( self, symbol )
+	cdef double __log_probability( self, symbol )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
-	cdef public numpy.ndarray mu, cov
+	cdef public numpy.ndarray mu, cov, cv_chol
 	cdef int d
+	cdef double cv_log_det
 
 cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double [:] _from_sample( self, int [:,:] items, 

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -3,7 +3,7 @@
 
 cimport cython
 from cython.view cimport array as cvarray
-from libc.math cimport log as clog, sqrt as csqrt, exp as cexp
+from libc.math cimport log as clog, sqrt as csqrt, exp as cexp, lgamma, fabs
 import math, random, itertools as it, sys, bisect, json
 import networkx
 import scipy.stats, scipy.sparse, scipy.special, scipy.linalg
@@ -54,7 +54,7 @@ cdef class Distribution:
 	written by write().
 	"""
 
-	def __init__( self ):
+	def __cinit__( self ):
 		"""
 		Make a new Distribution with the given parameters. All parameters must 
 		be floats.
@@ -228,7 +228,7 @@ cdef class UniformDistribution( Distribution ):
 	A uniform distribution between two values.
 	"""
 
-	def __init__( self, start, end, frozen=False ):
+	def __cinit__( UniformDistribution self, double start, double end, bint frozen=False ):
 		"""
 		Make a new Uniform distribution over floats between start and end, 
 		inclusive. Start and end must not be equal.
@@ -236,6 +236,8 @@ cdef class UniformDistribution( Distribution ):
 		
 		# Store the parameters
 		self.parameters = [start, end]
+		self.start = start
+		self.end = end
 		self.summaries = []
 		self.name = "UniformDistribution"
 		self.frozen = frozen
@@ -245,13 +247,22 @@ cdef class UniformDistribution( Distribution ):
 		What's the probability of the given float under this distribution?
 		"""
 		
-		return self._log_probability( self.parameters[0], self.parameters[1], symbol )
+		return self._log_probability( symbol )
+		
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
+		"""
+		Cython optimized log probability calculation which does not require
+		the gil to be in place.
+		"""
 
-	cdef double _log_probability( self, double a, double b, double symbol ):
-		if symbol == a and symbol == b:
+		cdef double start = self.start
+		cdef double end = self.end
+
+		if symbol == start and symbol == end:
 			return 0
-		if symbol >= a and symbol <= b:
-			return _log( 1.0 / ( b - a ) )
+		if symbol >= start and symbol <= end:
+			return _log( 1.0 / ( end - start ) )
 		return NEGINF
 			
 	def sample( self ):
@@ -293,6 +304,8 @@ cdef class UniformDistribution( Distribution ):
 		prior_min, prior_max = self.parameters
 		self.parameters[0] = prior_min*inertia + numpy.min(items)*(1-inertia)
 		self.parameters[1] = prior_max*inertia + numpy.max(items)*(1-inertia)
+		self.start = self.parameters[0]
+		self.end = self.parameters[1]
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -338,6 +351,8 @@ cdef class UniformDistribution( Distribution ):
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_min*inertia + summaries[:,0].min()*(1-inertia), 
 							prior_max*inertia + summaries[:,1].max()*(1-inertia) ]
+		self.start = self.parameters[0]
+		self.end = self.parameters[1]
 		self.summaries = []
 
 cdef class NormalDistribution( Distribution ):
@@ -345,7 +360,7 @@ cdef class NormalDistribution( Distribution ):
 	A normal distribution based on a mean and standard deviation.
 	"""
 
-	def __init__( self, mean, std, frozen=False ):
+	def __cinit__( self, double mean, double std, bint frozen=False ):
 		"""
 		Make a new Normal distribution with the given mean mean and standard 
 		deviation std.
@@ -353,31 +368,29 @@ cdef class NormalDistribution( Distribution ):
 		
 		# Store the parameters
 		self.parameters = [mean, std]
+		self.mu = mean
+		self.sigma = std
 		self.summaries = []
 		self.name = "NormalDistribution"
 		self.frozen = frozen
 
-	def log_probability( self, symbol, epsilon=1E-4 ):
+	def log_probability( self, symbol ):
 		"""
 		What's the probability of the given float under this distribution?
 		
-		For distributions with 0 std, epsilon is the distance within which to 
-		consider things equal to the mean.
+		Distributions with 0 std are equivalent to delta functions, and should
+		be encoded using either a discrete or lambda distribution. 
 		"""
 
-		return self._log_probability( symbol, epsilon )
+		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol, double epsilon ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
-		Do the actual math here.
+		Cython optimized function, with nogil enabled. 
 		"""
 
-		cdef double mu = self.parameters[0], sigma = self.parameters[1]
-		if sigma == 0.0:
-			if abs( symbol - mu ) < epsilon:
-				return 0
-			else:
-				return NEGINF
+		cdef double mu = self.mu, sigma = self.sigma
   
 		return _log( 1.0 / ( sigma * SQRT_2_PI ) ) - ((symbol - mu) ** 2) /\
 			(2 * sigma ** 2)
@@ -451,6 +464,8 @@ cdef class NormalDistribution( Distribution ):
 		prior_mean, prior_std = self.parameters
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
 							prior_std*inertia + std*(1-inertia) ]
+		self.mu = self.parameters[0]
+		self.sigma = self.parameters[1]
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -513,6 +528,8 @@ cdef class NormalDistribution( Distribution ):
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia),
 							prior_std*inertia + std*(1-inertia) ]
+		self.mu = self.parameters[0]
+		self.sigma = self.parameters[1]
 		self.summaries = []
 
 cdef class LogNormalDistribution( Distribution ):
@@ -520,13 +537,15 @@ cdef class LogNormalDistribution( Distribution ):
 	Represents a lognormal distribution over non-negative floats.
 	"""
 
-	def __init__( self, mu, sigma, frozen=False ):
+	def __cinit__( self, double mu, double sigma, frozen=False ):
 		"""
 		Make a new lognormal distribution. The parameters are the mu and sigma
 		of the normal distribution, which is the the exponential of the log
 		normal distribution.
 		"""
 		self.parameters = [ mu, sigma ]
+		self.mu = mu
+		self.sigma = sigma
 		self.summaries = []
 		self.name = "LogNormalDistribution"
 		self.frozen = frozen
@@ -538,15 +557,17 @@ cdef class LogNormalDistribution( Distribution ):
 
 		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
 		Actually perform the calculations here, in the Cython-optimized
 		function.
 		"""
 
-		mu, sigma = self.parameters
-		return -clog( symbol * sigma * SQRT_2_PI ) \
-			- 0.5 * ( ( clog( symbol ) - mu ) / sigma ) ** 2
+		cdef double mu = self.mu, sigma = self.sigma
+
+		return -_log( symbol * sigma * SQRT_2_PI ) \
+			- 0.5 * ( ( _log( symbol ) - mu ) / sigma ) ** 2
 
 	def sample( self ):
 		"""
@@ -616,6 +637,8 @@ cdef class LogNormalDistribution( Distribution ):
 		prior_mean, prior_std = self.parameters
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
 							prior_std*inertia + std*(1-inertia) ]
+		self.mu = self.parameters[0]
+		self.sigma = self.parameters[1]
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -674,6 +697,8 @@ cdef class LogNormalDistribution( Distribution ):
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
 							prior_std*inertia + std*(1-inertia) ]
+		self.mu = self.parameters[0]
+		self.sigma = self.parameters[1]
 		self.summaries = []
 
 cdef class ExtremeValueDistribution( Distribution ):
@@ -681,14 +706,17 @@ cdef class ExtremeValueDistribution( Distribution ):
 	Represent a generalized extreme value distribution over floats.
 	"""
 
-	def __init__( self, mu, sigma, epsilon, frozen=True ):
+	def __cinit__( self, double mu, double sigma, double epsilon, bint frozen=True ):
 		"""
 		Make a new extreme value distribution, where mu is the location
 		parameter, sigma is the scale parameter, and epsilon is the shape
 		parameter. 
 		"""
 
-		self.parameters = [ float(mu), float(sigma), float(epsilon) ]
+		self.parameters = [ mu, sigma, epsilon ]
+		self.mu = mu
+		self.sigma = sigma
+		self.epsilon = epsilon
 		self.name = "ExtremeValueDistribution"
 		self.frozen = frozen
 
@@ -699,17 +727,19 @@ cdef class ExtremeValueDistribution( Distribution ):
 
 		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
 		Actually perform the calculations here, in the Cython-optimized
 		function.
 		"""
 
-		mu, sigma, epsilon = self.parameters
-		t = ( symbol - mu ) / sigma
+		cdef double mu = self.mu, sigma = self.sigma, epsilon = self.epsilon
+		cdef double t = ( symbol - mu ) / sigma 
+
 		if epsilon == 0:
-			return -clog( sigma ) - t - cexp( -t )
-		return -clog( sigma ) + clog( 1 + epsilon * t ) * (-1. / epsilon - 1) \
+			return -_log( sigma ) - t - cexp( -t )
+		return -_log( sigma ) + _log( 1 + epsilon * t ) * (-1. / epsilon - 1) \
 			- ( 1 + epsilon * t ) ** ( -1. / epsilon )
 
 cdef class ExponentialDistribution( Distribution ):
@@ -717,13 +747,14 @@ cdef class ExponentialDistribution( Distribution ):
 	Represents an exponential distribution on non-negative floats.
 	"""
 	
-	def __init__( self, rate, frozen=False ):
+	def __cinit__( self, double rate, bint frozen=False ):
 		"""
 		Make a new inverse gamma distribution. The parameter is called "rate" 
 		because lambda is taken.
 		"""
 
 		self.parameters = [rate]
+		self.rate = rate
 		self.summaries = []
 		self.name = "ExponentialDistribution"
 		self.frozen = frozen
@@ -732,8 +763,17 @@ cdef class ExponentialDistribution( Distribution ):
 		"""
 		What's the probability of the given float under this distribution?
 		"""
-		
-		return _log(self.parameters[0]) - self.parameters[0] * symbol
+
+		return self._log_probability( symbol )
+	
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
+		"""
+		Cython optimized function.
+		"""
+
+		cdef double rate = self.rate
+		return _log(rate) - rate * symbol
 		
 	def sample( self ):
 		"""
@@ -781,6 +821,7 @@ cdef class ExponentialDistribution( Distribution ):
 		rate = 1.0 / weighted_mean
 
 		self.parameters[0] = prior_rate*inertia + rate*(1-inertia)
+		self.rate = self.parameters[0]
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -828,6 +869,7 @@ cdef class ExponentialDistribution( Distribution ):
 		# of 0 being completely replacing the parameters, and an inertia of
 		# 1 being to ignore new training data.
 		self.parameters[0] = prior_rate*inertia + rate*(1-inertia)
+		self.rate = self.parameters[0]
 		self.summaries = []
 
 cdef class BetaDistribution( Distribution ):
@@ -843,6 +885,8 @@ cdef class BetaDistribution( Distribution ):
 		"""
 
 		self.parameters = [alpha, beta]
+		self.alpha = alpha
+		self.beta = beta
 		self.summaries = []
 		self.name = "BetaDistribution"
 		self.frozen = frozen
@@ -852,10 +896,19 @@ cdef class BetaDistribution( Distribution ):
 		What is the probability of the given float under this distribution?
 		"""
 
-		a, b = self.parameters
-		return ( _log(math.lgamma(a+b)) - _log(math.lgamma(a)) - 
-			_log(math.lgamma(b)) + (a-1)*_log(symbol) +
-			(b-1)*_log(1.-symbol) ) 
+		return self._log_probability( symbol )
+
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
+		"""
+		Cython optimized function.
+		"""
+
+		cdef double a = self.alpha, b = self.beta
+
+		return ( _log(lgamma(a+b)) - _log(lgamma(a)) - 
+			_log(lgamma(b)) + (a-1)*_log(symbol) +
+			(b-1)*_log(1.-symbol) )
 
 	def sample( self ):
 		"""
@@ -900,6 +953,8 @@ cdef class BetaDistribution( Distribution ):
 		beta = self.parameters[1]*inertia + failures*(1-inertia)
 
 		self.parameters = [ alpha, beta ]
+		self.alpha = alpha
+		self.beta = beta
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -942,6 +997,8 @@ cdef class BetaDistribution( Distribution ):
 		beta = self.parameters[1]*inertia + summaries[:,1].sum( axis=0 )*(1-inertia)
 
 		self.parameters = [ alpha, beta ]
+		self.alpha = alpha
+		self.beta = beta
 		self.summaries = []
 
 
@@ -954,13 +1011,15 @@ cdef class GammaDistribution( Distribution ):
 	cobbled together a solution here from less-reputable sources.
 	"""
 	
-	def __init__( self, alpha, beta, frozen=False ):
+	def __cinit__( self, double alpha, double beta, bint frozen=False ):
 		"""
 		Make a new gamma distribution. Alpha is the shape parameter and beta is 
 		the rate parameter.
 		"""
 		
 		self.parameters = [alpha, beta]
+		self.alpha = alpha
+		self.beta = beta
 		self.summaries = []
 		self.name = "GammaDistribution"
 		self.frozen = frozen
@@ -970,11 +1029,18 @@ cdef class GammaDistribution( Distribution ):
 		What's the probability of the given float under this distribution?
 		"""
 		
-		# Gamma pdf from Wikipedia (and stats class)
-		return (_log(self.parameters[1]) * self.parameters[0] - 
-			math.lgamma(self.parameters[0]) + 
-			_log(symbol) * (self.parameters[0] - 1) - 
-			self.parameters[1] * symbol)
+		return self._log_probability( symbol )
+
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
+		"""
+		Cython optimized calculation.
+		"""
+
+		cdef double alpha = self.alpha, beta = self.beta
+		
+		return (_log(beta) * alpha - lgamma(alpha) + _log(symbol) 
+			* (alpha - 1) - beta * symbol)
 		
 	def sample( self ):
 		"""
@@ -1092,7 +1158,9 @@ cdef class GammaDistribution( Distribution ):
 		# of 0 being completely replacing the parameters, and an inertia of
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_shape*inertia + shape*(1-inertia), 
-							prior_rate*inertia + rate*(1-inertia) ]    
+							prior_rate*inertia + rate*(1-inertia) ]
+		self.alpha = self.parameters[0]
+		self.beta = self.parameters[1]  
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -1220,6 +1288,8 @@ cdef class GammaDistribution( Distribution ):
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_shape*inertia + shape*(1-inertia), 
 							prior_rate*inertia + rate*(1-inertia) ]
+		self.alpha = self.parameters[0]
+		self.beta = self.parameters[1]
 		self.summaries = []  	
 
 cdef class InverseGammaDistribution( GammaDistribution ):
@@ -1231,7 +1301,7 @@ cdef class InverseGammaDistribution( GammaDistribution ):
 	GammaDistribution.
 	"""
 	
-	def __init__( self, alpha, beta, frozen=False ):
+	def __cinit__( self, alpha, beta, frozen=False ):
 		"""
 		Make a new inverse gamma distribution. Alpha is the shape parameter and 
 		beta is the scale parameter.
@@ -1293,7 +1363,7 @@ cdef class DiscreteDistribution(Distribution):
 	assuming that these probabilities will sum to 1.0. 
 	"""
 	
-	def __init__( self, characters, frozen=False ):
+	def __cinit__( self, dict characters, bint frozen=False ):
 		"""
 		Make a new discrete distribution with a dictionary of discrete
 		characters and their probabilities, checking to see that these
@@ -1303,6 +1373,7 @@ cdef class DiscreteDistribution(Distribution):
 		
 		# Store the parameters
 		self.parameters = [ characters ]
+		self.dist = characters
 		self.summaries = [ { key: 0 for key in characters.keys() } ]
 		self.name = "DiscreteDistribution"
 		self.frozen = frozen
@@ -1539,25 +1610,30 @@ cdef class GaussianKernelDensity( Distribution ):
 	the sum of the Gaussian distance of the new point from every other point.
 	"""
 
-	def __init__( self, points, bandwidth=1, weights=None, frozen=False ):
+	def __cinit__( self, points, bandwidth=1, weights=None, frozen=False ):
 		"""
 		Take in points, bandwidth, and appropriate weights. If no weights
 		are provided, a uniform weight of 1/n is provided to each point.
 		Weights are scaled so that they sum to 1. 
 		"""
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
 		
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
+		self.n = n
 		self.parameters = [ points, bandwidth, weights ]
+		self.points = points
+		self.weights = weights
+		self.bandwidth = bandwidth
 		self.summaries = []
 		self.name = "GaussianKernelDensity"
 		self.frozen = frozen
+
 
 	def log_probability( self, symbol ):
 		"""
@@ -1569,28 +1645,29 @@ cdef class GaussianKernelDensity( Distribution ):
 
 		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
 		Actually calculate it here.
 		"""
-		cdef double bandwidth = self.parameters[1]
-		cdef double mu, scalar = 1.0 / SQRT_2_PI
-		cdef int i = 0, n = len(self.parameters[0])
-		cdef double distribution_prob = 0, point_prob
 
-		for i in xrange( n ):
+		cdef double bandwidth = self.bandwidth
+		cdef double mu, w
+
+		cdef double scalar = 1.0 / SQRT_2_PI
+		cdef int i, n = self.n
+		cdef double prob
+
+		for i in range( n ):
 			# Go through each point sequentially
-			mu = self.parameters[0][i]
+			mu = self.points[i]
+			w = self.weights[i]
 
 			# Calculate the probability under that point
-			point_prob = scalar * \
-				cexp( -0.5 * (( mu-symbol ) / bandwidth) ** 2 )
-
-			# Scale that point according to the weight 
-			distribution_prob += point_prob * self.parameters[2][i]
+			prob += w * scalar * cexp(-0.5 * ((mu-symbol) / bandwidth)**2)
 
 		# Return the log of the sum of the probabilities
-		return _log( distribution_prob )
+		return _log( prob )
 
 	def sample( self ):
 		"""
@@ -1611,19 +1688,22 @@ cdef class GaussianKernelDensity( Distribution ):
 		if self.frozen == True:
 			return
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
 
 		# Get the weights, or assign uniform weights
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
 		# If no inertia, get rid of the previous points
 		if inertia == 0.0:
 			self.parameters[0] = points
 			self.parameters[2] = weights
+			self.points = points
+			self.weights = weights
+			self.n = self.points.shape[0]
 
 		# Otherwise adjust weights appropriately
 		else: 
@@ -1631,6 +1711,9 @@ cdef class GaussianKernelDensity( Distribution ):
 													  points ) )
 			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
 													  weights*(1-inertia) ) )
+			self.points = self.parameters[0]
+			self.weights = self.parameters[0]
+			self.n = self.points.shape[0]
 
 cdef class UniformKernelDensity( Distribution ):
 	"""
@@ -1639,21 +1722,26 @@ cdef class UniformKernelDensity( Distribution ):
 	the sum of the Gaussian distances of the new point from every other point.
 	"""
 
-	def __init__( self, points, bandwidth=1, weights=None, frozen=False ):
+	def __cinit__( self, points, bandwidth=1, weights=None, frozen=False ):
 		"""
 		Take in points, bandwidth, and appropriate weights. If no weights
 		are provided, a uniform weight of 1/n is provided to each point.
 		Weights are scaled so that they sum to 1. 
 		"""
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
+		
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
+		self.n = n
 		self.parameters = [ points, bandwidth, weights ]
+		self.points = points
+		self.weights = weights
+		self.bandwidth = bandwidth
 		self.summaries = []
 		self.name = "UniformKernelDensity"
 		self.frozen = frozen
@@ -1667,32 +1755,31 @@ cdef class UniformKernelDensity( Distribution ):
 
 		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
 		Actually do math here.
 		"""
 
-		cdef double mu
-		cdef double distribution_prob=0, point_prob
-		cdef int i = 0, n = len(self.parameters[0])
+		cdef double bandwidth = self.bandwidth
+		cdef double mu, w
 
-		for i in xrange( n ):
+		cdef int i, n = self.n
+		cdef double prob = 0.0 
+
+		for i in range( n ):
 			# Go through each point sequentially
-			mu = self.parameters[0][i]
+			mu = self.points[i]
+			w = self.weights[i]
 
 			# The good thing about uniform distributions if that
 			# you just need to check to make sure the point is within
 			# a bandwidth.
-			if abs( mu - symbol ) <= self.parameters[1]:
-				point_prob = 1
-			else:
-				point_prob = 0
-
-			# Properly weight the point before adding it to the sum
-			distribution_prob += point_prob * self.parameters[2][i]
+			if fabs( mu - symbol ) <= bandwidth:
+				prob += w
 
 		# Return the log of the sum of probabilities
-		return _log( distribution_prob )
+		return _log( prob )
 	
 	def sample( self ):
 		"""
@@ -1714,19 +1801,22 @@ cdef class UniformKernelDensity( Distribution ):
 		if self.frozen == True:
 			return
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
 
 		# Get the weights, or assign uniform weights
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
 		# If no inertia, get rid of the previous points
 		if inertia == 0.0:
 			self.parameters[0] = points
 			self.parameters[2] = weights
+			self.points = points
+			self.weights = weights
+			self.n = self.points.shape[0]
 
 		# Otherwise adjust weights appropriately
 		else: 
@@ -1734,6 +1824,9 @@ cdef class UniformKernelDensity( Distribution ):
 													  points ) )
 			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
 													  weights*(1-inertia) ) )
+			self.points = self.parameters[0]
+			self.weights = self.parameters[0]
+			self.n = self.points.shape[0]
 
 cdef class TriangleKernelDensity( Distribution ):
 	"""
@@ -1742,21 +1835,26 @@ cdef class TriangleKernelDensity( Distribution ):
 	the sum of the Gaussian distances of the new point from every other point.
 	"""
 
-	def __init__( self, points, bandwidth=1, weights=None, frozen=False ):
+	def __cinit__( self, points, bandwidth=1, weights=None, frozen=False ):
 		"""
 		Take in points, bandwidth, and appropriate weights. If no weights
 		are provided, a uniform weight of 1/n is provided to each point.
 		Weights are scaled so that they sum to 1. 
 		"""
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
+		
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
+		self.n = n
 		self.parameters = [ points, bandwidth, weights ]
+		self.points = points
+		self.weights = weights
+		self.bandwidth = bandwidth
 		self.summaries = []
 		self.name = "TriangleKernelDensity"
 		self.frozen = frozen
@@ -1770,30 +1868,30 @@ cdef class TriangleKernelDensity( Distribution ):
 
 		return self._log_probability( symbol )
 
-	cdef double _log_probability( self, double symbol ):
+	@cython.boundscheck(False)
+	cdef public double _log_probability( self, double symbol ) nogil:
 		"""
 		Actually do math here.
 		"""
 
-		cdef double bandwidth = self.parameters[1]
-		cdef double mu
-		cdef double distribution_prob=0, point_prob
-		cdef int i = 0, n = len(self.parameters[0])
+		cdef double bandwidth = self.bandwidth
+		cdef double mu, w
 
-		for i in xrange( n ):
+		cdef int i, n = self.n
+		cdef double prob = 0.0, hinge
+
+		for i in range( n ):
 			# Go through each point sequentially
-			mu = self.parameters[0][i]
+			mu = self.points[i]
+			w = self.weights[i]
 
 			# Calculate the probability for each point
-			point_prob = bandwidth - abs( mu - symbol ) 
-			if point_prob < 0:
-				point_prob = 0 
-
-			# Properly weight the point before adding to the sum
-			distribution_prob += point_prob * self.parameters[2][i]
+			hinge = bandwidth - fabs( mu - symbol ) 
+			if hinge > 0:
+				prob += hinge * w 
 
 		# Return the log of the sum of probabilities
-		return _log( distribution_prob )
+		return _log( prob )
 
 	def sample( self ):
 		"""
@@ -1815,19 +1913,22 @@ cdef class TriangleKernelDensity( Distribution ):
 		if self.frozen == True:
 			return
 
-		points = numpy.asarray( points )
-		n = len(points)
+		points = numpy.asarray( points, dtype=numpy.float64 )
+		n = points.shape[0]
 
 		# Get the weights, or assign uniform weights
 		if weights:
-			weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
-			weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n, dtype=numpy.float64 ) / n 
 
 		# If no inertia, get rid of the previous points
 		if inertia == 0.0:
 			self.parameters[0] = points
 			self.parameters[2] = weights
+			self.points = points
+			self.weights = weights
+			self.n = self.points.shape[0]
 
 		# Otherwise adjust weights appropriately
 		else: 
@@ -1835,6 +1936,9 @@ cdef class TriangleKernelDensity( Distribution ):
 													  points ) )
 			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
 													  weights*(1-inertia) ) )
+			self.points = self.parameters[0]
+			self.weights = self.parameters[0]
+			self.n = self.points.shape[0]
 
 cdef class MixtureDistribution( Distribution ):
 	"""
@@ -1843,19 +1947,26 @@ cdef class MixtureDistribution( Distribution ):
 	distributions. Can also specify weights for the distributions.
 	"""
 
-	def __init__( self, distributions, weights=None, frozen=False ):
+	def __cinit__( self, distributions, weights=None, frozen=False ):
 		"""
 		Take in the distributions and appropriate weights. If no weights
 		are provided, a uniform weight of 1/n is provided to each point.
 		Weights are scaled so that they sum to 1. 
 		"""
-		n = len(distributions)
-		if weights:
-			weights = numpy.array( weights ) / numpy.sum( weights )
-		else:
-			weights = numpy.ones(n) / n
+		
+		distributions = numpy.asarray( distributions, dtype=numpy.object_ )
+		n = distributions.shape[0]
 
+		if weights:
+			weights = numpy.array( weights, dtype=numpy.float64 ) / numpy.sum( weights )
+		else:
+			weights = numpy.ones(n, dtype=numpy.float64 ) / n
+
+		self.n = n
 		self.parameters = [ distributions, weights ]
+		self.distributions = distributions
+		self.weights = weights
+		self.distributions = distributions
 		self.name = "MixtureDistribution"
 		self.frozen = frozen
 
@@ -1877,9 +1988,27 @@ cdef class MixtureDistribution( Distribution ):
 		of both numeric and not-necessarily-numeric distributions. 
 		"""
 
-		(d, w), n = self.parameters, len(self.parameters)
-		return _log( numpy.sum([ cexp( d[i].log_probability(symbol) ) \
-			* w[i] for i in xrange(n) ]) )
+		return self._log_probability( symbol )
+
+	cdef public double _log_probability( self, double symbol ):
+		"""
+		Cython optimized function for distributions involving floats.
+		"""
+
+		cdef int i, n = self.n
+		cdef double w, prob = 0.0
+		cdef Distribution d
+
+		for i in range( n ):
+			# Go through each point sequentially
+			w = self.weights[i]
+			d = <Distribution>self.distributions[i]
+
+			# Calculate the probability for each point
+			prob += cexp( d.log_probability( symbol ) ) * w
+
+		# Return the log of the sum of probabilities
+		return _log( prob )	
 
 	def sample( self ):
 		"""
@@ -2011,34 +2140,40 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 	represent the mean of that event. Observations must now be tuples of
 	a length equal to the number of distributions passed in.
 
-	s1 = MultivariateDistribution([ ExponentialDistribution( 0.1 ), 
+	s1 = IndependentComponentsDistribution([ ExponentialDistribution( 0.1 ), 
 									NormalDistribution( 5, 2 ) ])
 	s1.log_probability( (5, 2 ) )
 	"""
 
-	def __init__( self, distributions, weights=None, frozen=False ):
+	def __cinit__( self, distributions, weights=None, frozen=False ):
 		"""
 		Take in the distributions and appropriate weights. If no weights
 		are provided, a uniform weight of 1/n is provided to each point.
 		Weights are scaled so that they sum to 1. 
 		"""
-		n = len(distributions)
+
+		distributions = numpy.array( distributions, dtype=numpy.object_ )
+		n = distributions.shape[0]
+
 		if weights:
-			weights = numpy.array( weights )
+			weights = numpy.array( weights, dtype=numpy.float64 )
 		else:
-			weights = numpy.ones(n)
+			weights = numpy.ones( n, dtype=numpy.float64 )
 
 		self.parameters = [ distributions, weights ]
-		self.name = "MultivariateDistribution"
+		self.distributions = distributions
+		self.weights = weights
+		self.n = n
+		self.name = "IndependentComponentsDistribution"
 		self.frozen = frozen
 
 	def __str__( self ):
 		"""
-		Return a string representation of the MultivariateDistribution.
+		Return a string representation of the IndependentComponentsDistribution.
 		"""
 
 		distributions = map( str, self.parameters[0] )
-		return "MultivariateDistribution({})".format(
+		return "IndependentComponentsDistribution({})".format(
 			distributions ).replace( "'", "" )
 
 	def log_probability( self, symbol ):
@@ -2048,8 +2183,23 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 		respective distribution, which is the sum of the log probabilities.
 		"""
 
-		return sum( d.log_probability( obs )*w for d, obs, w in izip( 
-			self.parameters[0], symbol, self.parameters[1] ) )
+		return self._log_probability( numpy.asarray(symbol) )
+
+	cdef public double _log_probability( self, numpy.ndarray symbol ):
+		"""
+		Cython optimized function.
+		"""
+
+		cdef int i, n = self.n
+		cdef double prob = 0.0
+
+		for i in range(n):
+			w = self.weights[i]
+			d = <Distribution>self.distributions[i]
+
+			prob += d.log_probability( symbol[i] ) + _log(w)
+
+		return prob
 
 	def sample( self ):
 		"""
@@ -2086,6 +2236,8 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 		for i, d in enumerate( self.parameters[0] ):
 			d.summarize( items[:,i], weights=weights )
 
+		self.distributions = numpy.asarray( self.parameters[0], dtype=numpy.object_ )
+
 	def from_summaries( self, inertia=0.0 ):
 		"""
 		Use the collected summary statistics in order to update the
@@ -2098,6 +2250,8 @@ cdef class IndependentComponentsDistribution( MultivariateDistribution ):
 
 		for d in self.parameters[0]:
 			d.from_summaries( inertia=inertia )
+
+		self.distributions = numpy.asarray( self.parameters[0], dtype=numpy.object_ )
 
 cdef class MultivariateGaussianDistribution( MultivariateDistribution ):
 	"""

--- a/pomegranate/fsm.pyx
+++ b/pomegranate/fsm.pyx
@@ -30,10 +30,6 @@ from distributions cimport *
 cimport base
 from base cimport *
 
-ctypedef numpy.npy_float64 DOUBLE_t 
-ctypedef numpy.npy_intp SIZE_t  
-
-
 cdef class FiniteStateMachine( Model ):
 	'''
 	A finite state machine. 

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -92,9 +92,9 @@ cdef class GeneralMixtureModel( Distribution ):
 		of a point is the sum of the probabilities of each distribution.
 		"""
 
-		return self._log_probability( numpy.array( point ) )
+		return self.__log_probability( numpy.array( point ) )
 
-	cdef double _log_probability( self, numpy.ndarray point ):
+	cdef double __log_probability( self, numpy.ndarray point ):
 		"""
 		Cython optimized function for calculating log probabilities.
 		"""

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -9,6 +9,7 @@ import math, random, itertools as it, sys, bisect, json
 import networkx
 
 from libc.stdlib cimport calloc, free, realloc
+from libc.string cimport memcpy, memset
 import time
 
 if sys.version_info[0] > 2:
@@ -76,22 +77,22 @@ cdef class HiddenMarkovModel( Model ):
 	"""
 
 	cdef public object start, end
-	cdef public int start_index, end_index, silent_start, n_states, n_edges
-	cdef double [:] in_transition_pseudocounts
-	cdef double [:] out_transition_pseudocounts
+	cdef public int start_index, end_index, silent_start
+	cdef DOUBLE_t* in_transition_pseudocounts
+	cdef DOUBLE_t* out_transition_pseudocounts
 	cdef double [:] state_weights
-	cdef int [:] tied_state_count
-	cdef int [:] tied
-	cdef int [:] tied_edge_group_size
-	cdef int [:] tied_edges_starts
-	cdef int [:] tied_edges_ends
+	cdef SIZE_t* tied_state_count
+	cdef SIZE_t* tied
+	cdef SIZE_t* tied_edge_group_size
+	cdef SIZE_t* tied_edges_starts
+	cdef SIZE_t* tied_edges_ends
 	cdef DOUBLE_t* in_transition_log_probabilities
 	cdef DOUBLE_t* out_transition_log_probabilities
 	cdef SIZE_t* in_edge_count
 	cdef SIZE_t* in_transitions
 	cdef SIZE_t* out_edge_count
 	cdef SIZE_t* out_transitions
-	cdef int finite
+	cdef int finite, n_tied_edge_groups
 
 	def __cinit__( self, name=None, start=None, end=None ):
 		"""
@@ -123,20 +124,36 @@ cdef class HiddenMarkovModel( Model ):
 
 		self.in_edge_count = NULL
 		self.in_transitions = NULL
+		self.in_transition_pseudocounts = NULL
 		self.in_transition_log_probabilities = NULL
 		self.out_edge_count = NULL
 		self.out_transitions = NULL
+		self.out_transition_pseudocounts = NULL
 		self.out_transition_log_probabilities = NULL
+
+		self.tied_state_count = NULL
+		self.tied = NULL
+		self.tied_edge_group_size = NULL
+		self.tied_edges_starts = NULL
+		self.tied_edges_ends = NULL
 
 	def __dealloc__( self ):
 		"""Destructor."""
 
 		free( self.in_edge_count )
 		free( self.in_transitions )
+		free( self.in_transition_pseudocounts )
 		free( self.in_transition_log_probabilities )
 		free( self.out_edge_count )
 		free( self.out_transitions )
+		free( self.out_transition_pseudocounts )
 		free( self.out_transition_log_probabilities )
+
+		free( self.tied_state_count )
+		free( self.tied )
+		free( self.tied_edge_group_size )
+		free( self.tied_edges_starts )
+		free( self.tied_edges_ends )
 
 	def add_state(self, state):
 		"""
@@ -365,7 +382,7 @@ cdef class HiddenMarkovModel( Model ):
 
 			# Reindex the states based on ones which are still there
 			prestates = self.graph.nodes()
-			indices = { prestates[i]: i for i in xrange( len( prestates ) ) }
+			indices = { prestates[i]: i for i in range( len( prestates ) ) }
 
 			# Go through all the edges, summing in and out edges
 			for a, b in self.graph.edges():
@@ -374,7 +391,7 @@ cdef class HiddenMarkovModel( Model ):
 				
 			# Go through each state, and if either in or out edges are 0,
 			# remove the edge.
-			for i in xrange( len( prestates ) ):
+			for i in range( len( prestates ) ):
 				if prestates[i] is self.start or prestates[i] is self.end:
 					continue
 
@@ -478,6 +495,10 @@ cdef class HiddenMarkovModel( Model ):
 
 		states = self.graph.nodes()
 		n, m = len(states), len(self.graph.edges())
+
+		self.n_edges = m
+		self.n_states = n
+
 		silent_states, normal_states = [], []
 
 		for state in states:
@@ -509,31 +530,31 @@ cdef class HiddenMarkovModel( Model ):
 		# We need a good way to get transition probabilities by state index that
 		# isn't N^2 to build or store. So we will need a reverse of the above
 		# mapping. It's awkward but asymptotically fine.
-		indices = { self.states[i]: i for i in xrange(n) }
+		indices = { self.states[i]: i for i in range(n) }
 
 		# Create a sparse representation of the tied states in the model. This
 		# is done in the same way of the transition, by having a vector of
 		# counts, and a vector of the IDs that the state is tied to.
-		self.tied_state_count = numpy.zeros( self.silent_start+1, 
-			dtype=numpy.int32 )
+		self.tied_state_count = <SIZE_t*> calloc( self.silent_start+1, sizeof(SIZE_t) )
+		for i in range( self.silent_start+1 ):
+			self.tied_state_count[i] = 0
 
-		for i in xrange( self.silent_start ):
-			for j in xrange( self.silent_start ):
+		for i in range( self.silent_start ): 
+			for j in range( self.silent_start ):
 				if i == j:
 					continue
 				if self.states[i].distribution is self.states[j].distribution:
 					self.tied_state_count[i+1] += 1
 
-		# Take the cumulative sum in order to get indexes instead of counts,
-		# with the last index being the total number of ties.
-		self.tied_state_count = numpy.cumsum( self.tied_state_count,
-			dtype=numpy.int32 )
+		for i in range( 1, self.silent_start+1 ):
+			self.tied_state_count[i] += self.tied_state_count[i-1]
 
-		self.tied = numpy.zeros( self.tied_state_count[-1], 
-			dtype=numpy.int32 ) - 1
+		self.tied = <SIZE_t*> calloc( self.tied_state_count[self.silent_start], sizeof(SIZE_t) )
+		for i in range( self.tied_state_count[self.silent_start] ):
+			self.tied[i] = -1
 
-		for i in xrange( self.silent_start ):
-			for j in xrange( self.silent_start ):
+		for i in range( self.silent_start ):
+			for j in range( self.silent_start ):
 				if i == j:
 					continue
 					
@@ -551,7 +572,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		# Unpack the state weights
 		self.state_weights = numpy.zeros( self.silent_start )
-		for i in xrange( self.silent_start ):
+		for i in range( self.silent_start ):
 			self.state_weights[i] = clog( self.states[i].weight )
 
 		# This holds numpy array indexed [a, b] to transition log probabilities 
@@ -559,27 +580,28 @@ cdef class HiddenMarkovModel( Model ):
 		# transitions are impossible.
 		self.in_transitions = <SIZE_t*> calloc( m, sizeof(SIZE_t) )
 		self.in_edge_count = <SIZE_t*> calloc( n+1, sizeof(SIZE_t) )
+		self.in_transition_pseudocounts = <DOUBLE_t*> calloc( m,
+			sizeof(DOUBLE_t) )
 		self.in_transition_log_probabilities = <DOUBLE_t*> calloc( m, 
 			sizeof(DOUBLE_t) )
+
 		self.out_transitions = <SIZE_t*> calloc( m, sizeof(SIZE_t) )
-		self.out_edge_count = <SIZE_t*> calloc( n+1, sizeof(SIZE_t) ) 
+		self.out_edge_count = <SIZE_t*> calloc( n+1, sizeof(SIZE_t) )
+		self.out_transition_pseudocounts = <DOUBLE_t*> calloc( m,
+			sizeof(DOUBLE_t) )
 		self.out_transition_log_probabilities = <DOUBLE_t*> calloc( m, 
 			sizeof(DOUBLE_t) )
 
-		for i in xrange(m):
-			self.in_transitions[i] = -1
-			self.out_transitions[i] = -1
-			self.in_transition_log_probabilities[i] = 0
-			self.out_transition_log_probabilities[i] = 0
-		for i in xrange(n+1):
-			self.in_edge_count[i] = 0
-			self.out_edge_count[i] = 0
+		memset( self.in_transitions, -1, m*sizeof(SIZE_t) )
+		memset( self.in_edge_count, 0, (n+1)*sizeof(SIZE_t) )
+		memset( self.in_transition_pseudocounts, 0, m*sizeof(DOUBLE_t) )
+		memset( self.in_transition_log_probabilities, 0, m*sizeof(DOUBLE_t) )
 
-		self.in_transition_pseudocounts = numpy.zeros( 
-			len( self.graph.edges() ) )
-		self.out_transition_pseudocounts = numpy.zeros(
-			len( self.graph.edges() ) )
-
+		memset( self.out_transitions, -1, m*sizeof(SIZE_t) )
+		memset( self.out_edge_count, 0, (n+1)*sizeof(SIZE_t) )
+		memset( self.out_transition_pseudocounts, 0, m*sizeof(DOUBLE_t) )
+		memset( self.out_transition_log_probabilities, 0, m*sizeof(DOUBLE_t) )
+		
 		# Now we need to find a way of storing in-edges for a state in a manner
 		# that can be called in the cythonized methods below. This is basically
 		# an inversion of the graph. We will do this by having two lists, one
@@ -589,7 +611,6 @@ cdef class HiddenMarkovModel( Model ):
 		# such a manner that all edges pointing to the same node are grouped
 		# together. This will allow us to run the algorithms in time
 		# nodes*edges instead of nodes*nodes.
-
 		for a, b in self.graph.edges_iter():
 			# Increment the total number of edges going to node b.
 			self.in_edge_count[ indices[b]+1 ] += 1
@@ -602,7 +623,6 @@ cdef class HiddenMarkovModel( Model ):
 			self.finite = 0
 		else:
 			self.finite = 1
-
 		# Take the cumulative sum so that we can associate array indices with
 		# in or out transitions
 		for i in xrange( 1, n+1 ):
@@ -665,12 +685,13 @@ cdef class HiddenMarkovModel( Model ):
 		# give all the edges in a group.
 		total_grouped_edges = sum( map( len, edge_groups.values() ) )
 
-		self.tied_edge_group_size = numpy.zeros( len( edge_groups.keys() )+1,
-			dtype=numpy.int32 )
-		self.tied_edges_starts = numpy.zeros( total_grouped_edges,
-			dtype=numpy.int32 )
-		self.tied_edges_ends = numpy.zeros( total_grouped_edges,
-			dtype=numpy.int32 )
+		self.n_tied_edge_groups = len(edge_groups.keys())+1
+		self.tied_edge_group_size = <SIZE_t*> calloc(len(edge_groups.keys())+1,
+			sizeof(SIZE_t) )
+		self.tied_edge_group_size[0] = 0
+
+		self.tied_edges_starts = <SIZE_t*> calloc( total_grouped_edges, sizeof(SIZE_t))
+		self.tied_edges_ends = <SIZE_t*> calloc( total_grouped_edges, sizeof(SIZE_t))
 
 		# Iterate across all the grouped edges and bin them appropriately.
 		for i, (name, edges) in enumerate( edge_groups.items() ):
@@ -683,9 +704,6 @@ cdef class HiddenMarkovModel( Model ):
 			for j, (start, end) in enumerate( edges ):
 				self.tied_edges_starts[n+j] = start
 				self.tied_edges_ends[n+j] = end
-
-		self.n_edges = m
-		self.n_states = n
 
 		# This holds the index of the start state
 		try:
@@ -885,7 +903,6 @@ cdef class HiddenMarkovModel( Model ):
 				f[i] = NEGINF
 			f[self.start_index] = 0.
 
-
 			for l in range( self.silent_start, m ):
 				# Handle transitions between silent states before the first symbol
 				# is emitted. No non-silent states have non-zero probability yet, so
@@ -1006,143 +1023,53 @@ cdef class HiddenMarkovModel( Model ):
 
 		cdef unsigned int D_SIZE = sizeof( double )
 		cdef int i = 0, ir, k, kr, l, li, n = len( sequence ), m = len( self.states )
-		cdef double [:,:] b, e
 		cdef double log_probability
 		cdef State s
 		cdef Distribution d
 		cdef SIZE_t* out_edges = self.out_edge_count
-		cdef double [:] c
 
-		# Initialize the DP table. Each entry i, k holds the log probability of
-		# emitting the remaining len(sequence) - i symbols and ending in the end
-		# state, given that we are in state k.
-		b = cvarray( shape=(n+1, m), itemsize=D_SIZE, format='d' )
-		c = numpy.zeros( (n+1) )
-
-		# Initialize the emission table, which contains the probability of
-		# each entry i, k holds the probability of symbol i being emitted
-		# by state k 
-		e = cvarray( shape=(n,self.silent_start), itemsize=D_SIZE, format='d' )
+		cdef DOUBLE_t* e = <DOUBLE_t*> calloc( n*self.silent_start, sizeof(DOUBLE_t) )
+		cdef numpy.ndarray b_ndarray = numpy.zeros( (n+1, m), dtype=numpy.float64 )
+		cdef DOUBLE_t* b = <DOUBLE_t*> b_ndarray.data
 
 		# Calculate the emission table
-		for k in xrange( n ):
-			for i in xrange( self.silent_start ):
-				e[k, i] = self.states[i].distribution.log_probability(
-					sequence[k] ) + self.state_weights[i]
+		for i in range( n ):
+			for l in range( self.silent_start ):
+				e[i + l*n] = self.states[l].distribution.log_probability(
+					sequence[i] ) + self.state_weights[l]
 
-		# We must end in the end state, having emitted len(sequence) symbols
-		if self.finite == 1:
-			for i in xrange(m):
-				b[n, i] = NEGINF
-			b[n, self.end_index] = 0
-		else:
-			for i in xrange(self.silent_start):
-				b[n, i] = 0.
-			for i in xrange(self.silent_start, m):
-				b[n, i] = NEGINF
+		with nogil:
+			# We must end in the end state, having emitted len(sequence) symbols
+			if self.finite == 1:
+				for i in range(m):
+					b[n*m + i] = NEGINF
+				b[n*m + self.end_index] = 0
+			else:
+				for i in range(self.silent_start):
+					b[n*m + i] = 0.
+				for i in range(self.silent_start, m):
+					b[n*m + i] = NEGINF
 
-		for kr in xrange( m-self.silent_start ):
-			if self.finite == 0:
-				break
-			# Cython arrays cannot go backwards, so modify the loop to account
-			# for this.
-			k = m - kr - 1
-
-			# Do the silent states' dependencies on each other.
-			# Doing it in reverse order ensures that anything we can 
-			# possibly transition to is already done.
-			
-			if k == self.end_index:
-				# We already set the log-probability for this, so skip it
-				continue
-
-			# This holds the log total probability that we go to
-			# current-step silent states and then continue from there to
-			# finish the sequence.
-			log_probability = NEGINF
-			for l in xrange( out_edges[k], out_edges[k+1] ):
-				li = self.out_transitions[l]
-				if li < k+1:
-					continue
-
-				# For each possible current-step silent state we can go to,
-				# take into account just transition probability
-				log_probability = pair_lse( log_probability,
-					b[n,li] + self.out_transition_log_probabilities[l] )
-
-			# Now this is the probability of reaching the end state given we are
-			# in this silent state.
-			b[n, k] = log_probability
-
-		for k in xrange( self.silent_start ):
-			if self.finite == 0:
-				break
-			# Do the non-silent states in the last step, which depend on
-			# current-step silent states.
-			
-			# This holds the total accumulated log probability of going
-			# to such states and continuing from there to the end.
-			log_probability = NEGINF
-			for l in xrange( out_edges[k], out_edges[k+1] ):
-				li = self.out_transitions[l]
-				if li < self.silent_start:
-					continue
-
-				# For each current-step silent state, add in the probability
-				# of going from here to there and then continuing on to the
-				# end of the sequence.
-				log_probability = pair_lse( log_probability,
-					b[n, li] + self.out_transition_log_probabilities[l] )
-
-			# Now we have summed the probabilities of all the ways we can
-			# get from here to the end, so we can fill in the table entry.
-			b[n, k] = log_probability
-
-		# Now that we're done with the base case, move on to the recurrence
-		for ir in xrange( n ):
-			#if self.finite == 0 and ir == 0:
-			#	continue
-			# Cython xranges cannot go backwards properly, redo to handle
-			# it properly
-			i = n - ir - 1
-			for kr in xrange( m-self.silent_start ):
-				k = m - kr - 1
-
-				# Do the silent states' dependency on subsequent non-silent
-				# states, iterating backwards to match the order we use later.
-				
-				# This holds the log total probability that we go to some
-				# subsequent state that emits the right thing, and then continue
-				# from there to finish the sequence.
-				log_probability = NEGINF
-				for l in xrange( out_edges[k], out_edges[k+1] ):
-					li = self.out_transitions[l]
-					if li >= self.silent_start:
-						continue
-
-					# For each subsequent non-silent state l, take into account
-					# transition and emission emission probability.
-					log_probability = pair_lse( log_probability,
-						b[i+1, li] + self.out_transition_log_probabilities[l] +
-						e[i, li] )
-
-				# We can't go from a silent state here to a silent state on the
-				# next symbol, so we're done finding the probability assuming we
-				# transition straight to a non-silent state.
-				b[i, k] = log_probability
-
-			for kr in xrange( m-self.silent_start ):
+			for kr in range( m-self.silent_start ):
+				if self.finite == 0:
+					break
+				# Cython arrays cannot go backwards, so modify the loop to account
+				# for this.
 				k = m - kr - 1
 
 				# Do the silent states' dependencies on each other.
 				# Doing it in reverse order ensures that anything we can 
 				# possibly transition to is already done.
 				
+				if k == self.end_index:
+					# We already set the log-probability for this, so skip it
+					continue
+
 				# This holds the log total probability that we go to
 				# current-step silent states and then continue from there to
 				# finish the sequence.
 				log_probability = NEGINF
-				for l in xrange( out_edges[k], out_edges[k+1] ):
+				for l in range( out_edges[k], out_edges[k+1] ):
 					li = self.out_transitions[l]
 					if li < k+1:
 						continue
@@ -1150,31 +1077,22 @@ cdef class HiddenMarkovModel( Model ):
 					# For each possible current-step silent state we can go to,
 					# take into account just transition probability
 					log_probability = pair_lse( log_probability,
-						b[i, li] + self.out_transition_log_probabilities[l] )
+						b[n*m + li] + self.out_transition_log_probabilities[l] )
 
-				# Now add this probability in with the probability accumulated
-				# from transitions to subsequent non-silent states.
-				b[i, k] = pair_lse( log_probability, b[i, k] )
+				# Now this is the probability of reaching the end state given we are
+				# in this silent state.
+				b[n*m + k] = log_probability
 
-			for k in xrange( self.silent_start ):
-				# Do the non-silent states in the current step, which depend on
-				# subsequent non-silent states and current-step silent states.
+			for k in range( self.silent_start ):
+				if self.finite == 0:
+					break
+				# Do the non-silent states in the last step, which depend on
+				# current-step silent states.
 				
 				# This holds the total accumulated log probability of going
 				# to such states and continuing from there to the end.
 				log_probability = NEGINF
-				for l in xrange( out_edges[k], out_edges[k+1] ):
-					li = self.out_transitions[l]
-					if li >= self.silent_start:
-						continue
-
-					# For each subsequent non-silent state l, take into account
-					# transition and emission emission probability.
-					log_probability = pair_lse( log_probability,
-						b[i+1, li] + self.out_transition_log_probabilities[l] +
-						e[i, li] )
-
-				for l in xrange( out_edges[k], out_edges[k+1] ):
+				for l in range( out_edges[k], out_edges[k+1] ):
 					li = self.out_transitions[l]
 					if li < self.silent_start:
 						continue
@@ -1183,15 +1101,106 @@ cdef class HiddenMarkovModel( Model ):
 					# of going from here to there and then continuing on to the
 					# end of the sequence.
 					log_probability = pair_lse( log_probability,
-						b[i, li] + self.out_transition_log_probabilities[l] )
+						b[n*m + li] + self.out_transition_log_probabilities[l] )
 
 				# Now we have summed the probabilities of all the ways we can
 				# get from here to the end, so we can fill in the table entry.
-				b[i, k] = log_probability
+				b[n*m + k] = log_probability
+
+			# Now that we're done with the base case, move on to the recurrence
+			for ir in range( n ):
+				#if self.finite == 0 and ir == 0:
+				#	continue
+				# Cython xranges cannot go backwards properly, redo to handle
+				# it properly
+				i = n - ir - 1
+				for kr in range( m-self.silent_start ):
+					k = m - kr - 1
+
+					# Do the silent states' dependency on subsequent non-silent
+					# states, iterating backwards to match the order we use later.
+					
+					# This holds the log total probability that we go to some
+					# subsequent state that emits the right thing, and then continue
+					# from there to finish the sequence.
+					log_probability = NEGINF
+					for l in range( out_edges[k], out_edges[k+1] ):
+						li = self.out_transitions[l]
+						if li >= self.silent_start:
+							continue
+
+						# For each subsequent non-silent state l, take into account
+						# transition and emission emission probability.
+						log_probability = pair_lse( log_probability,
+							b[(i+1)*m + li] + self.out_transition_log_probabilities[l] +
+							e[i + li*n] )
+
+					# We can't go from a silent state here to a silent state on the
+					# next symbol, so we're done finding the probability assuming we
+					# transition straight to a non-silent state.
+					b[i*m + k] = log_probability
+
+				for kr in range( m-self.silent_start ):
+					k = m - kr - 1
+
+					# Do the silent states' dependencies on each other.
+					# Doing it in reverse order ensures that anything we can 
+					# possibly transition to is already done.
+					
+					# This holds the log total probability that we go to
+					# current-step silent states and then continue from there to
+					# finish the sequence.
+					log_probability = NEGINF
+					for l in range( out_edges[k], out_edges[k+1] ):
+						li = self.out_transitions[l]
+						if li < k+1:
+							continue
+
+						# For each possible current-step silent state we can go to,
+						# take into account just transition probability
+						log_probability = pair_lse( log_probability,
+							b[i*m + li] + self.out_transition_log_probabilities[l] )
+
+					# Now add this probability in with the probability accumulated
+					# from transitions to subsequent non-silent states.
+					b[i*m + k] = pair_lse( log_probability, b[i*m + k] )
+
+				for k in range( self.silent_start ):
+					# Do the non-silent states in the current step, which depend on
+					# subsequent non-silent states and current-step silent states.
+					
+					# This holds the total accumulated log probability of going
+					# to such states and continuing from there to the end.
+					log_probability = NEGINF
+					for l in range( out_edges[k], out_edges[k+1] ):
+						li = self.out_transitions[l]
+						if li >= self.silent_start:
+							continue
+
+						# For each subsequent non-silent state l, take into account
+						# transition and emission emission probability.
+						log_probability = pair_lse( log_probability,
+							b[(i+1)*m + li] + self.out_transition_log_probabilities[l] +
+							e[i + li*n] )
+
+					for l in range( out_edges[k], out_edges[k+1] ):
+						li = self.out_transitions[l]
+						if li < self.silent_start:
+							continue
+
+						# For each current-step silent state, add in the probability
+						# of going from here to there and then continuing on to the
+						# end of the sequence.
+						log_probability = pair_lse( log_probability,
+							b[i*m + li] + self.out_transition_log_probabilities[l] )
+
+					# Now we have summed the probabilities of all the ways we can
+					# get from here to the end, so we can fill in the table entry.
+					b[i*m + k] = log_probability
 
 		# Now the DP table is filled in. 
 		# Return the entire table.
-		return b
+		return b_ndarray
 
 	def forward_backward( self, sequence, tie=False ):
 		"""
@@ -1244,7 +1253,7 @@ cdef class HiddenMarkovModel( Model ):
 		cdef double norm
 
 		cdef SIZE_t* out_edges = self.out_edge_count
-		cdef int [:] tied_states = self.tied_state_count
+		cdef SIZE_t* tied_states = self.tied_state_count
 
 		cdef State s
 		cdef Distribution d 
@@ -1261,8 +1270,8 @@ cdef class HiddenMarkovModel( Model ):
 		b = self.backward( sequence )
 
 		# Calculate the emission table
-		for k in xrange( n ):
-			for i in xrange( self.silent_start ):
+		for k in range( n ):
+			for i in range( self.silent_start ):
 				e[k, i] = self.states[i].distribution.log_probability(
 					sequence[k] ) + self.state_weights[i]
 
@@ -1270,7 +1279,7 @@ cdef class HiddenMarkovModel( Model ):
 			log_sequence_probability = f[ n, self.end_index ]
 		else:
 			log_sequence_probability = NEGINF
-			for i in xrange( self.silent_start ):
+			for i in range( self.silent_start ):
 				log_sequence_probability = pair_lse( 
 					log_sequence_probability, f[ n, i ] )
 		
@@ -1279,9 +1288,9 @@ cdef class HiddenMarkovModel( Model ):
 			print( "Warning: Sequence is impossible." )
 			return ( None, None )
 
-		for k in xrange( m ):
+		for k in range( m ):
 			# For each state we could have come from
-			for l in xrange( out_edges[k], out_edges[k+1] ):
+			for l in range( out_edges[k], out_edges[k+1] ):
 				li = self.out_transitions[l]
 				if li >= self.silent_start:
 					continue
@@ -1291,7 +1300,7 @@ cdef class HiddenMarkovModel( Model ):
 				# probability of sequence.
 				log_transition_emission_probability_sum = NEGINF
 
-				for i in xrange( n ):
+				for i in range( n ):
 					# For each character in the sequence
 					# Add probability that we start and get up to state k, 
 					# and go k->l, and emit the symbol from l, and go from l
@@ -1308,7 +1317,7 @@ cdef class HiddenMarkovModel( Model ):
 					log_transition_emission_probability_sum - 
 					log_sequence_probability )
 
-			for l in xrange( out_edges[k], out_edges[k+1] ):
+			for l in range( out_edges[k], out_edges[k+1] ):
 				li = self.out_transitions[l]
 				if li < self.silent_start:
 					continue
@@ -1318,7 +1327,7 @@ cdef class HiddenMarkovModel( Model ):
 				# probability of sequence.
 
 				log_transition_emission_probability_sum = NEGINF
-				for i in xrange( n+1 ):
+				for i in range( n+1 ):
 					# For each row in the forward DP table (where we can
 					# have transitions to silent states) of which we have 1 
 					# more than we have symbols...
@@ -1342,7 +1351,7 @@ cdef class HiddenMarkovModel( Model ):
 			if k < self.silent_start:
 				# Now think about emission probabilities from this state
 						  
-				for i in xrange( n ):
+				for i in range( n ):
 					# For each symbol that came out
 		   
 					# What's the weight of this symbol for that state?
@@ -1363,7 +1372,7 @@ cdef class HiddenMarkovModel( Model ):
 		if tie == 1:
 			visited = numpy.zeros( self.silent_start, dtype=numpy.int32 )
 
-			for k in xrange( self.silent_start ):
+			for k in range( self.silent_start ):
 				# Check to see if we have visited this a state within the set of
 				# tied states this state belongs yet. If not, this is the first
 				# state and we can calculate the tied probabilities here.
@@ -1373,11 +1382,11 @@ cdef class HiddenMarkovModel( Model ):
 
 				# Set that we have visited all of the other members of this set
 				# of tied states.
-				for l in xrange( tied_states[k], tied_states[k+1] ):
+				for l in range( tied_states[k], tied_states[k+1] ):
 					li = self.tied[l]
 					visited[li] = 1
 
-				for i in xrange( n ):
+				for i in range( n ):
 					# Begin the probability sum with the log probability of 
 					# being in the current state.
 					tied_state_log_probability = emission_weights[i, k]
@@ -1385,13 +1394,13 @@ cdef class HiddenMarkovModel( Model ):
 					# Go through all the states this state is tied with, and
 					# add up the probability of being in any of them, and
 					# updated the visited list.
-					for l in xrange( tied_states[k], tied_states[k+1] ):
+					for l in range( tied_states[k], tied_states[k+1] ):
 						li = self.tied[l]
 						tied_state_log_probability = pair_lse( 
 							tied_state_log_probability, emission_weights[i, li] )
 
 					# Now update them with the retrieved value
-					for l in xrange( tied_states[k], tied_states[k+1] ):
+					for l in range( tied_states[k], tied_states[k+1] ):
 						li = self.tied[l]
 						emission_weights[i, li] = tied_state_log_probability
 
@@ -1720,7 +1729,7 @@ cdef class HiddenMarkovModel( Model ):
 			log_sequence_probability = f[ n, self.end_index ]
 		else:
 			log_sequence_probability = NEGINF
-			for i in xrange( self.silent_start ):
+			for i in range( self.silent_start ):
 				log_sequence_probability = pair_lse( 
 					log_sequence_probability, f[ n, i ] )
 		
@@ -1729,9 +1738,9 @@ cdef class HiddenMarkovModel( Model ):
 			print( "Warning: Sequence is impossible." )
 			return ( None, None )
 
-		for k in xrange( m ):				
+		for k in range( m ):				
 			if k < self.silent_start:				  
-				for i in xrange( n ):
+				for i in range( n ):
 					# For each symbol that came out
 					# What's the weight of this symbol for that state?
 					# Probability that we emit index characters and then 
@@ -1817,7 +1826,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		# Get the number of groups of edges which are tied
 		groups = []
-		n = len( self.tied_edge_group_size )-1
+		n = self.n_tied_edge_groups-1
 		
 		# Go through each group one at a time
 		for i in xrange(n):
@@ -1893,6 +1902,22 @@ cdef class HiddenMarkovModel( Model ):
 		model.bake( verbose=verbose )
 		return model
 	
+	cpdef double [:,:] dense_transition_matrix( self ):
+		"""
+		Returns the dense transition matrix. Useful if the transitions of
+		somewhat small models need to be analyzed.
+		"""
+
+		m = self.n_states
+		transition_log_probabilities = numpy.zeros( (m, m) ) + NEGINF
+
+		for i in range(m):
+			for n in range( self.out_edge_count[i], self.out_edge_count[i+1] ):
+				transition_log_probabilities[i, self.out_transitions[n]] = \
+					self.out_transition_log_probabilities[n]
+
+		return transition_log_probabilities 
+
 	@classmethod
 	def from_matrix( cls, transition_probabilities, distributions, starts, ends,
 		state_names=None, name=None ):
@@ -2100,64 +2125,69 @@ cdef class HiddenMarkovModel( Model ):
 		The score is the sum of the likelihoods of all the sequences.
 		"""        
 
-		cdef double [:,:] transition_log_probabilities 
-		cdef double [:,:] expected_transitions, e, f, b
-		cdef double [:,:] emission_weights
 		cdef numpy.ndarray sequence
-		cdef double log_sequence_probability
-		cdef double sequence_probability_sum
-		cdef int k, i, l, li, m = len( self.states ), n, observation=0
-		cdef int characters_so_far = 0
+		cdef DOUBLE_t log_sequence_probability
+		cdef DOUBLE_t sequence_probability_sum
+		cdef SIZE_t k, i, l, li, m = len( self.states ), n, observation=0
+		cdef SIZE_t characters_so_far = 0
 		cdef object symbol
-		cdef double [:] weights
 
 		cdef SIZE_t* out_edges = self.out_edge_count
 		cdef SIZE_t* in_edges = self.in_edge_count
 
 		# Define several helped variables.
-		cdef int [:] visited
-		cdef int [:] tied_states = self.tied_state_count
+		cdef SIZE_t* tied_states = self.tied_state_count
+
+		cdef numpy.ndarray f_ndarray, b_ndarray
+		cdef DOUBLE_t* f
+		cdef DOUBLE_t* b
+		cdef DOUBLE_t* e = NULL
+		cdef DOUBLE_t* expected_transitions = <DOUBLE_t*> calloc( m*m, sizeof(DOUBLE_t) )
+		cdef DOUBLE_t* weights = NULL
+		cdef numpy.ndarray weights_ndarray
+		cdef DOUBLE_t* norm
+		cdef SIZE_t* visited = <SIZE_t*> calloc( self.silent_start, sizeof(SIZE_t) )
 
 		# Find the expected number of transitions between each pair of states, 
 		# given our data and our current parameters, but allowing the paths 
 		# taken to vary. (Indexed: from, to)
-		expected_transitions = numpy.zeros(( m, m ))
-
 		for sequence in sequences:
 			n = len( sequence )
+			weights_ndarray = numpy.zeros( n )
+			weights = <DOUBLE_t*> weights_ndarray.data
+
 			# Calculate the emission table
-			e = numpy.zeros(( n, self.silent_start )) 
-			for k in xrange( n ):
-				for i in xrange( self.silent_start ):
-					e[k, i] = self.states[i].distribution.log_probability( 
-						sequence[k] ) + self.state_weights[i]
+			e = <DOUBLE_t*> realloc( e, n*self.silent_start*sizeof(DOUBLE_t) )
+			for i in range( n ):
+				for l in range( self.silent_start ):
+					e[i + l*n] = self.states[l].distribution.log_probability( 
+						sequence[i] ) + self.state_weights[l]
 
 			# Get the overall log probability of the sequence, and fill in the
 			# the forward DP matrix.
-			f = self.forward( sequence )
+			f_ndarray = self.forward( sequence )
+			f = <DOUBLE_t*> f_ndarray.data
+
 			if self.finite == 1:
-				log_sequence_probability = f[ n, self.end_index ]
+				log_sequence_probability = f[n*m + self.end_index]
 			else:
 				log_sequence_probability = NEGINF
-				for i in xrange( self.silent_start ):
-					log_sequence_probability = pair_lse( f[n, i],
+				for i in range( self.silent_start ):
+					log_sequence_probability = pair_lse( f[n*m + i],
 						log_sequence_probability )
 
 			# Is the sequence impossible? If so, we can't train on it, so skip 
 			# it
 			if log_sequence_probability == NEGINF:
-				print( "Warning: skipped impossible sequence {}".format(sequence) )
 				continue
 
 			# Fill in the backward DP matrix.
-			b = self.backward(sequence)
+			b_ndarray = self.backward(sequence)
+			b = <DOUBLE_t*> b_ndarray.data
 
-			# Set the visited array to entirely 0s, meaning we haven't visited
-			# any states yet. 
-			visited = numpy.zeros( self.silent_start, dtype=numpy.int32 )
-			for k in xrange( m ):
+			for k in range( m ):
 				# For each state we could have come from
-				for l in xrange( out_edges[k], out_edges[k+1] ):
+				for l in range( out_edges[k], out_edges[k+1] ):
 					li = self.out_transitions[l]
 					if li >= self.silent_start:
 						continue
@@ -2166,25 +2196,25 @@ cdef class HiddenMarkovModel( Model ):
 					# Sum up probabilities that we later normalize by 
 					# probability of sequence.
 					log_transition_emission_probability_sum = NEGINF
-					for i in xrange( n ):
+					for i in range( n ):
 						# For each character in the sequence
 						# Add probability that we start and get up to state k, 
 						# and go k->l, and emit the symbol from l, and go from l
 						# to the end.
 						log_transition_emission_probability_sum = pair_lse( 
 							log_transition_emission_probability_sum, 
-							f[i, k] + 
+							f[i*m + k] + 
 							self.out_transition_log_probabilities[l] + 
-							e[i, li] + b[ i+1, li] )
+							e[i + li*n] + b[(i+1)*m + li] )
 
 					# Now divide by probability of the sequence to make it given
 					# this sequence, and add as this sequence's contribution to 
 					# the expected transitions matrix's k, l entry.
-					expected_transitions[k, li] += cexp(
+					expected_transitions[k*m + li] += cexp(
 						log_transition_emission_probability_sum - 
 						log_sequence_probability)
 
-				for l in xrange( out_edges[k], out_edges[k+1] ):
+				for l in range( out_edges[k], out_edges[k+1] ):
 					li = self.out_transitions[l]
 					if li < self.silent_start:
 						continue
@@ -2192,7 +2222,7 @@ cdef class HiddenMarkovModel( Model ):
 					# Sum up probabilities that we later normalize by 
 					# probability of sequence.
 					log_transition_emission_probability_sum = NEGINF
-					for i in xrange( n + 1 ):
+					for i in range( n + 1 ):
 						# For each row in the forward DP table (where we can
 						# have transitions to silent states) of which we have 1 
 						# more than we have symbols...
@@ -2203,16 +2233,17 @@ cdef class HiddenMarkovModel( Model ):
 						# table row, since no character is being emitted.
 						log_transition_emission_probability_sum = pair_lse( 
 							log_transition_emission_probability_sum, 
-							f[i, k] + self.out_transition_log_probabilities[l] 
-							+ b[i, li] )
+							f[i*m + k] + self.out_transition_log_probabilities[l] 
+							+ b[i*m + li] )
 
 					# Now divide by probability of the sequence to make it given
 					# this sequence, and add as this sequence's contribution to 
 					# the expected transitions matrix's k, l entry.
-					expected_transitions[k, li] += cexp(
+					expected_transitions[k*m + li] += cexp(
 						log_transition_emission_probability_sum -
 						log_sequence_probability )
 
+				memset( visited, 0, self.silent_start*sizeof(SIZE_t) )
 				if k < self.silent_start:
 					# If another state in the set of tied states has already
 					# been visited, we don't want to retrain.
@@ -2224,14 +2255,11 @@ cdef class HiddenMarkovModel( Model ):
 
 					# Mark that we've visited all other states in this state
 					# group.
-					for l in xrange( tied_states[k], tied_states[k+1] ):
+					for l in range( tied_states[k], tied_states[k+1] ):
 						li = self.tied[l]
 						visited[li] = 1
 
-					# Now think about emission probabilities from this state
-					weights = numpy.zeros( n )
-
-					for i in xrange( n ):
+					for i in range( n ):
 						# For each symbol that came out
 						# What's the weight of this symbol for that state?
 						# Probability that we emit index characters and then 
@@ -2242,15 +2270,15 @@ cdef class HiddenMarkovModel( Model ):
 						# According to http://www1.icsi.berkeley.edu/Speech/
 						# docs/HTKBook/node7_mn.html, we really should divide by
 						# sequence probability.
-						weights[i] = cexp( f[i+1, k] + b[i+1, k] - 
+						weights[i] = cexp( f[(i+1)*m + k] + b[(i+1)*m + k] - 
 							log_sequence_probability )
 						
-						for l in xrange( tied_states[k], tied_states[k+1] ):
+						for l in range( tied_states[k], tied_states[k+1] ):
 							li = self.tied[l]
-							weights[i] += cexp( f[i+1, li] + b[i+1, li] -
+							weights[i] += cexp( f[(i+1)*m + li] + b[(i+1)*m + li] -
 								log_sequence_probability )
 
-					self.states[k].distribution.summarize( sequence, weights )
+					self.states[k].distribution.summarize( sequence, weights_ndarray )
 
 		# We now have expected_transitions taking into account all sequences.
 		# And a list of all emissions, and a weighting of each emission for each
@@ -2259,45 +2287,46 @@ cdef class HiddenMarkovModel( Model ):
 		# probabilities)
 		# See http://stackoverflow.com/a/8904762/402891
 		# Only modifies transitions for states a transition was observed from.
-		cdef double [:] norm = numpy.zeros( m )
-		cdef double probability
+		norm = <DOUBLE_t*> calloc( m, sizeof(DOUBLE_t) )
+		cdef DOUBLE_t probability
 
-		cdef int [:] tied_edges = self.tied_edge_group_size
-		cdef double tied_edge_probability 
+		cdef SIZE_t* tied_edges = self.tied_edge_group_size
+		cdef DOUBLE_t tied_edge_probability
+		cdef SIZE_t start, end
 		# Go through the tied state groups and add transitions from each member
 		# in the group to the other members of the group.
 		# For each group defined.
-		for k in xrange( len( tied_edges )-1 ):
+		for k in range( self.n_tied_edge_groups-1 ):
 			tied_edge_probability = 0.
 
 			# For edge in this group, get the sum of the edges
-			for l in xrange( tied_edges[k], tied_edges[k+1] ):
+			for l in range( tied_edges[k], tied_edges[k+1] ):
 				start = self.tied_edges_starts[l]
 				end = self.tied_edges_ends[l]
-				tied_edge_probability += expected_transitions[start, end]
+				tied_edge_probability += expected_transitions[start*m + end]
 
 			# Update each entry
-			for l in xrange( tied_edges[k], tied_edges[k+1] ):
+			for l in range( tied_edges[k], tied_edges[k+1] ):
 				start = self.tied_edges_starts[l]
 				end = self.tied_edges_ends[l]
-				expected_transitions[start, end] = tied_edge_probability
+				expected_transitions[start*m + end] = tied_edge_probability
 
 		# Calculate the regularizing norm for each node
-		for k in xrange( m ):
-			for l in xrange( out_edges[k], out_edges[k+1] ):
+		for k in range( m ):
+			for l in range( out_edges[k], out_edges[k+1] ):
 				li = self.out_transitions[l]
-				norm[k] += expected_transitions[k, li] + \
+				norm[k] += expected_transitions[k*m + li] + \
 					transition_pseudocount + \
 					self.out_transition_pseudocounts[l] * use_pseudocount
 
 		# For every node, update the transitions appropriately
-		for k in xrange( m ):
+		for k in range( m ):
 			# Recalculate each transition out from that node and update
 			# the vector of out transitions appropriately
 			if norm[k] > 0:
-				for l in xrange( out_edges[k], out_edges[k+1] ):
+				for l in range( out_edges[k], out_edges[k+1] ):
 					li = self.out_transitions[l]
-					probability = ( expected_transitions[k, li] +
+					probability = ( expected_transitions[k*m + li] +
 						transition_pseudocount + 
 						self.out_transition_pseudocounts[l] * use_pseudocount)\
 						/ norm[k]
@@ -2307,10 +2336,10 @@ cdef class HiddenMarkovModel( Model ):
 
 			# Recalculate each transition in to that node and update the
 			# vector of in transitions appropriately 
-			for l in xrange( in_edges[k], in_edges[k+1] ):
+			for l in range( in_edges[k], in_edges[k+1] ):
 				li = self.in_transitions[l]
 				if norm[li] > 0:
-					probability = ( expected_transitions[li, k] +
+					probability = ( expected_transitions[li*m + k] +
 						transition_pseudocount +
 						self.in_transition_pseudocounts[l] * use_pseudocount )\
 						/ norm[li]
@@ -2318,8 +2347,8 @@ cdef class HiddenMarkovModel( Model ):
 						cexp( self.in_transition_log_probabilities[l] ) *
 						edge_inertia + probability * ( 1 - edge_inertia ) )
 
-		visited = numpy.zeros( self.silent_start, dtype=numpy.int32 )
-		for k in xrange( self.silent_start ):
+		memset( visited, 0, self.silent_start*sizeof(SIZE_t) )
+		for k in range( self.silent_start ):
 			# If this distribution has already been trained because it is tied
 			# to an earlier state, don't bother retraining it as that would
 			# waste time.
@@ -2330,7 +2359,7 @@ cdef class HiddenMarkovModel( Model ):
 			visited[k] = 1
 
 			# Mark that we've visited all states in this tied state group.
-			for l in xrange( tied_states[k], tied_states[k+1] ):
+			for l in range( tied_states[k], tied_states[k+1] ):
 				li = self.tied[l]
 				visited[li] = 1
 
@@ -2342,6 +2371,11 @@ cdef class HiddenMarkovModel( Model ):
 			# states are pointing to the same distribution object.
 			self.states[k].distribution.from_summaries( 
 				inertia=distribution_inertia )
+
+		free(e)
+		free(expected_transitions)
+		free(norm)
+		free(visited)
 
 	cdef void _train_viterbi( self, numpy.ndarray sequences, 
 		double transition_pseudocount, int use_pseudocount, 
@@ -2387,7 +2421,7 @@ cdef class HiddenMarkovModel( Model ):
 		cdef list labels
 		cdef State label
 		cdef list symbols = [ [] for i in xrange(m) ]
-		cdef int [:] tied_states = self.tied_state_count
+		cdef SIZE_t* tied_states = self.tied_state_count
 
 		# Define matrices for the transitions between states, and the weight of
 		# each emission for each state for training later.
@@ -2435,12 +2469,12 @@ cdef class HiddenMarkovModel( Model ):
 		cdef double [:] norm = numpy.zeros( m )
 		cdef double probability
 
-		cdef int [:] tied_edges = self.tied_edge_group_size
+		cdef SIZE_t* tied_edges = self.tied_edge_group_size
 		cdef int tied_edge_probability 
 		# Go through the tied state groups and add transitions from each member
 		# in the group to the other members of the group.
 		# For each group defined.
-		for k in xrange( len( tied_edges )-1 ):
+		for k in xrange( self.n_tied_edge_groups-1 ):
 			tied_edge_probability = 0
 
 			# For edge in this group, get the sum of the edges

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -2272,8 +2272,7 @@ cdef class HiddenMarkovModel( Model ):
 									log_sequence_probability )
 
 						with gil:
-							d = self.states[k].distribution
-						d._summarize( sequence, weights, n )
+							self.states[k].distribution.summarize( sequence_ndarray, weights_ndarray )
 
 			free(e)
 

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -65,18 +65,14 @@ def exp(value):
 	return numpy.exp(value)
 
 def log_probability( model, samples, n_jobs=1 ):
-	'''
-	Return the log probability of samples given a model.
-	'''
+	"""Return the log probability of samples given a model."""
 
 	return sum( Parallel( n_jobs=n_jobs, backend='threading' )( 
 		delayed( model.log_probability, check_pickle=False )( sample ) 
 		for sample in samples) )
 
 cdef class HiddenMarkovModel( Model ):
-	"""
-	Represents a Hidden Markov Model.
-	"""
+	"""A Hidden Markov Model implementation."""
 
 	cdef public object start, end
 	cdef public int start_index, end_index, silent_start
@@ -929,9 +925,9 @@ cdef class HiddenMarkovModel( Model ):
 		cdef SIZE_t i, k, ki, l, li
 		cdef SIZE_t p = self.silent_start, m = self.n_states
 		cdef SIZE_t dim = self.d
+		cdef Distribution d
 
 		cdef double log_probability
-		cdef Distribution d
 		cdef SIZE_t* in_edges = self.in_edge_count
 
 		cdef double* e = NULL
@@ -1041,8 +1037,8 @@ cdef class HiddenMarkovModel( Model ):
 					# Add the previous partial result and update the table entry
 					f[(i+1)*m + l] = pair_lse( f[(i+1)*m + l], log_probability )
 
-		if emissions is NULL:
-			free(e)
+			if emissions is NULL:
+				free(e)
 		return f
 
 	cpdef numpy.ndarray backward( self, sequence ):

--- a/pomegranate/utils.pxd
+++ b/pomegranate/utils.pxd
@@ -2,14 +2,15 @@
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
 from libc.math cimport log as clog, sqrt as csqrt, exp as cexp
+cimport numpy
 
 # Define some useful constants
-DEF NEGINF = float("-inf")
-DEF INF = float("inf")
-DEF SQRT_2_PI = 2.50662827463
+cdef double NEGINF = -numpy.inf
+cdef double INF = numpy.inf
+cdef double SQRT_2_PI = 2.50662827463
 
 # Useful speed optimized functions
-cdef inline double _log ( double x ):
+cdef inline double _log ( double x ) nogil:
 	'''
 	A wrapper for the c log function, by returning negative input if the
 	input is 0.
@@ -17,7 +18,7 @@ cdef inline double _log ( double x ):
 
 	return clog( x ) if x > 0 else NEGINF
 
-cdef inline int pair_int_max( int x, int y ):
+cdef inline int pair_int_max( int x, int y ) nogil:
 	'''
 	Calculate the maximum of a pair of two integers. This is
 	significantly faster than the Python function max().
@@ -25,7 +26,7 @@ cdef inline int pair_int_max( int x, int y ):
 
 	return x if x > y else y
 
-cdef inline double pair_lse( double x, double y ):
+cdef inline double pair_lse( double x, double y ) nogil:
 	'''
 	Perform log-sum-exp on a pair of numbers in log space..  This is calculated
 	as z = log( e**x + e**y ). However, this causes underflow sometimes

--- a/pomegranate/utils.pxd
+++ b/pomegranate/utils.pxd
@@ -1,47 +1,6 @@
 # utils.pxd
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
-from libc.math cimport log as clog, sqrt as csqrt, exp as cexp
-cimport numpy
-
-# Define some useful constants
-cdef double NEGINF = -numpy.inf
-cdef double INF = numpy.inf
-cdef double SQRT_2_PI = 2.50662827463
-
-# Useful speed optimized functions
-cdef inline double _log ( double x ) nogil:
-	'''
-	A wrapper for the c log function, by returning negative input if the
-	input is 0.
-	'''
-
-	return clog( x ) if x > 0 else NEGINF
-
-cdef inline int pair_int_max( int x, int y ) nogil:
-	'''
-	Calculate the maximum of a pair of two integers. This is
-	significantly faster than the Python function max().
-	'''
-
-	return x if x > y else y
-
-cdef inline double pair_lse( double x, double y ) nogil:
-	'''
-	Perform log-sum-exp on a pair of numbers in log space..  This is calculated
-	as z = log( e**x + e**y ). However, this causes underflow sometimes
-	when x or y are too negative. A simplification of this is thus
-	z = x + log( e**(y-x) + 1 ), where x is the greater number. If either of
-	the inputs are infinity, return infinity, and if either of the inputs
-	are negative infinity, then simply return the other input.
-	'''
-
-	if x == INF or y == INF:
-		return INF
-	if x == NEGINF:
-		return y
-	if y == NEGINF:
-		return x
-	if x > y:
-		return x + clog( cexp( y-x ) + 1 )
-	return y + clog( cexp( x-y ) + 1 )
+cdef inline double _log ( double x ) nogil
+cdef inline int pair_int_max( int x, int y ) nogil
+cdef inline double pair_lse( double x, double y ) nogil

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -1,0 +1,47 @@
+# utils.pyx
+# Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
+
+from libc.math cimport log as clog, sqrt as csqrt, exp as cexp
+cimport numpy
+
+# Define some useful constants
+DEF NEGINF = float("-inf")
+DEF INF = float("inf")
+DEF SQRT_2_PI = 2.50662827463
+
+# Useful speed optimized functions
+cdef inline double _log ( double x ) nogil:
+	'''
+	A wrapper for the c log function, by returning negative infinity if the
+	input is 0.
+	'''
+
+	return clog( x ) if x > 0 else NEGINF
+
+cdef inline int pair_int_max( int x, int y ) nogil:
+	'''
+	Calculate the maximum of a pair of two integers. This is
+	significantly faster than the Python function max().
+	'''
+
+	return x if x > y else y
+
+cdef inline double pair_lse( double x, double y ) nogil:
+	'''
+	Perform log-sum-exp on a pair of numbers in log space..  This is calculated
+	as z = log( e**x + e**y ). However, this causes underflow sometimes
+	when x or y are too negative. A simplification of this is thus
+	z = x + log( e**(y-x) + 1 ), where x is the greater number. If either of
+	the inputs are infinity, return infinity, and if either of the inputs
+	are negative infinity, then simply return the other input.
+	'''
+
+	if x == INF or y == INF:
+		return INF
+	if x == NEGINF:
+		return y
+	if y == NEGINF:
+		return x
+	if x > y:
+		return x + clog( cexp( y-x ) + 1 )
+	return y + clog( cexp( x-y ) + 1 )

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ filenames = [ "base",
               "distributions",
               "fsm",
               "hmm",
-              "gmm",
-              "utils"
+              "gmm"
             ]
 
 if not use_cython:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ filenames = [ "base",
               "distributions",
               "fsm",
               "hmm",
-              "gmm"
+              "gmm",
+              "utils"
             ]
 
 if not use_cython:
@@ -30,7 +31,7 @@ else:
     extensions = [
             Extension( "pomegranate.*", 
                        [ "pomegranate/*.pyx" ], 
-                       include_dirs=[np.get_include(), "."] )
+                       include_dirs=[np.get_include()] )
     ]
 
     extensions = cythonize( extensions )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ else:
     extensions = [
             Extension( "pomegranate.*", 
                        [ "pomegranate/*.pyx" ], 
-                       include_dirs=[np.get_include()] )
+                       include_dirs=[np.get_include(), "."] )
     ]
 
     extensions = cythonize( extensions )

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -406,8 +406,8 @@ def test_independent():
 	d = IndependentComponentsDistribution( [ NormalDistribution( 5, 2 ), ExponentialDistribution( 2 ) ],
 								  weights=[18., 1.] )
 
-	assert round( d.log_probability( (4,1) ), 4 ) == -32.5744
-	assert round( d.log_probability( (100, 0.001) ), 4 ) == -20334.5764
+	assert round( d.log_probability( (4,1) ), 4 ) == -0.1536
+	assert round( d.log_probability( (100, 0.001) ), 4 ) == -1126.1556
 
 	d.from_sample( [ (5, 1), (5.2, 1.7), (4.7, 1.9), (4.9, 2.4), (4.5, 1.2) ] )
 


### PR DESCRIPTION
This branch currently makes all HMM methods at least 2 times faster. Distributions range from being 20% faster (uniform distribution) to on average 2x faster (Gaussian, Exponential...), to 30x faster (kernel densities). The forward/backward algorithms are about twice as fast as well, and the gil is released for many functions in an attempt to add multithreaded training.

However, I've hit a road block as the gil must be reacquired to interact with distribution objects since not all of them (in particular, DiscreteDistributions) can have the gil removed nicely. 