### PR TITLE
fix memory leak in hmm.bake() and discretedistribution.encode()

### DIFF
--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -1396,6 +1396,10 @@ cdef class DiscreteDistribution( Distribution ):
 
 		n = len(encoded_keys)
 		self.encoded_keys = encoded_keys
+
+		free(self.encoded_counts)
+		free(self.encoded_log_probability)
+
 		self.encoded_counts = <double*> calloc( n, sizeof(double) )
 		self.encoded_log_probability = <double*> calloc( n, sizeof(double) )
 		self.n = n

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -214,6 +214,9 @@ cdef class HiddenMarkovModel( Model ):
 		self.state_names = set()
 
 	def __dealloc__(self):
+		self.free_bake_buffers()
+
+	def free_bake_buffers(self):
 		free(self.in_transition_pseudocounts)
 		free(self.out_transition_pseudocounts)
 		free(self.tied_state_count)
@@ -228,6 +231,7 @@ cdef class HiddenMarkovModel( Model ):
 		free(self.in_transitions)
 		free(self.out_edge_count)
 		free(self.out_transitions)
+
 
 	def add_state(self, state):
 		"""Add a state to the given model. 
@@ -603,6 +607,8 @@ cdef class HiddenMarkovModel( Model ):
 		-------
 		None
 		"""
+
+		self.free_bake_buffers()
 
 		in_edge_count = numpy.zeros( len( self.graph.nodes() ), 
 			dtype=numpy.int32 ) 
@@ -980,6 +986,7 @@ cdef class HiddenMarkovModel( Model ):
 		except KeyError:
 			raise SyntaxError( "Model.end has been deleted, leaving the \
 				model with no end. Please ensure it has an end." )
+
 
 	def sample( self, length=0, path=False ):
 		"""Generate a sequence from the model. 


### PR DESCRIPTION
Hi,

This fixes a memory leak I encounter when an HMM object is baked more than once, like in the code below, where `model.copy()` also performs a `bake()` behind the scenes.

```python
models = []
for _ in xrange(5):
    model = HiddenMarkovModel()
    state = State(DiscreteDistribution({"a" : 0.25, "b": 0.25, "c" : 0.25, "d": 0.25}), name="a")
    model.add_transition(model.start, state, 1.0)
    model.add_transition(state, state, 1.0)
    model.add_transition(state, model.end, 1.0)
    model.bake()
    models.append(model)

def concat_models(models):
    new_model = models[0].copy()
    for idx in xrange(1, len(models)):
        model_copy = models[idx].copy()
        new_model.concatenate(model_copy, str(idx))
    new_model.bake()
    return new_model

while True:
    model = concat_models(models)
```