### PR TITLE
Add support for serialization in GMM and HMM

### DIFF
--- a/pomegranate/MarkovChain.pyx
+++ b/pomegranate/MarkovChain.pyx
@@ -48,13 +48,16 @@ cdef class MarkovChain(object):
 		self.k = len(distributions) - 1
 		self.distributions = distributions
 
+	def __reduce__(self):
+		return self.__class__, (self.distributions,)
+
 	def log_probability(self, sequence):
 		"""Calculate the log probability of the sequence under the model.
 
 		This calculates the first slices of increasing size under the
 		corresponding first few components of the model until size k is reached,
-		at which all slices are evaluated under the final component. 
-		
+		at which all slices are evaluated under the final component.
+
 		Parameters
 		----------
 		sequence : array-like
@@ -124,12 +127,12 @@ cdef class MarkovChain(object):
 			a sequence of variable length
 
 		weights : array-like, shape (n_samples,), optional
-			The initial weights of each sample. If nothing is passed in then 
+			The initial weights of each sample. If nothing is passed in then
 			each sample is assumed to be the same weight. Default is None.
 
 		inertia : double, optional
 			The weight of the previous parameters of the model. The new
-			parameters will roughly be old_param*inertia + new_param*(1-inertia), 
+			parameters will roughly be old_param*inertia + new_param*(1-inertia),
 			so an inertia of 0 means ignore the old parameters, whereas an
 			inertia of 1 means ignore the new parameters. Default is 0.0.
 
@@ -154,7 +157,7 @@ cdef class MarkovChain(object):
 			a sequence of variable length
 
 		weights : array-like, shape (n_samples,), optional
-			The initial weights of each sample. If nothing is passed in then 
+			The initial weights of each sample. If nothing is passed in then
 			each sample is assumed to be the same weight. Default is None.
 
 		Returns
@@ -180,7 +183,7 @@ cdef class MarkovChain(object):
 				symbols = [ sequence[j] for sequence in sequences if len(sequence) > j+self.k ]
 			else:
 				symbols = [ sequence[j:j+self.k+1] for sequence in sequences if len(sequence) > j+self.k ]
-			
+
 			self.distributions[-1].summarize(symbols, weights)
 
 	def from_summaries(self, inertia=0.0):
@@ -188,12 +191,12 @@ cdef class MarkovChain(object):
 
 		Fit the parameters of the model to the sufficient statistics gathered
 		during the summarize calls. This should return an exact update.
-		
+
 		Parameters
 		----------
 		inertia : double, optional
 			The weight of the previous parameters of the model. The new
-			parameters will roughly be old_param*inertia + new_param*(1-inertia), 
+			parameters will roughly be old_param*inertia + new_param*(1-inertia),
 			so an inertia of 0 means ignore the old parameters, whereas an
 			inertia of 1 means ignore the new parameters. Default is 0.0.
 
@@ -210,7 +213,7 @@ cdef class MarkovChain(object):
 
 		Parameters
 		----------
-		separators : tuple, optional 
+		separators : tuple, optional
 		    The two separaters to pass to the json.dumps function for formatting.
 		    Default is (',', ' : ').
 
@@ -224,7 +227,7 @@ cdef class MarkovChain(object):
 		    A properly formatted JSON object.
 		"""
 
-		model = { 
+		model = {
 		            'class' : 'MarkovChain',
 		            'distributions'  : [ json.loads( d.to_json() ) for d in self.distributions ]
 		        }
@@ -247,6 +250,6 @@ cdef class MarkovChain(object):
 		"""
 
 		d = json.loads( s )
-		distributions = [ Distribution.from_json( json.dumps(j) ) for j in d['distributions'] ] 
+		distributions = [ Distribution.from_json( json.dumps(j) ) for j in d['distributions'] ]
 		model = MarkovChain( distributions )
 		return model

--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -36,7 +36,7 @@ cdef class NaiveBayes( object ):
     weights : list or numpy.ndarray or None, default None
         The prior probabilities of the components. If None is passed in then
         defaults to the uniformly distributed priors.
-    
+
     Attributes
     ----------
     models : list
@@ -63,7 +63,7 @@ cdef class NaiveBayes( object ):
            [-0.26751248, -1.4493653 ],
            [-1.09861229, -0.40546511]])
     """
-    
+
     cdef public object models
     cdef void** models_ptr
     cdef numpy.ndarray summaries
@@ -72,12 +72,12 @@ cdef class NaiveBayes( object ):
     cdef public int d
 
     def __init__( self, models=None, weights=None ):
-        if not callable(models) and not isinstance(models, list): 
+        if not callable(models) and not isinstance(models, list):
             raise ValueError("must either give initial models or constructor")
 
         self.summaries = None
         self.d = 0
-        
+
         if type(models) is list:
             if len(models) < 2:
                 raise ValueError("must have at least two models for comparison")
@@ -96,7 +96,7 @@ cdef class NaiveBayes( object ):
                 self.d = models[0].d
                 if sum([self.d == model.d for model in models]) != len(models):
                     raise TypeError("mis-matching dimensions between hidden markov models")
-            
+
             self.summaries = numpy.zeros(len(models))
 
             self.models = numpy.array( models )
@@ -110,6 +110,9 @@ cdef class NaiveBayes( object ):
             self.weights_ptr = <double*> (<numpy.ndarray> self.weights).data
 
         self.models = models
+
+    def __reduce__( self ):
+        return self.__class__, (self.models, self.weights)
 
     def __str__( self ):
         try:
@@ -138,7 +141,7 @@ cdef class NaiveBayes( object ):
         Returns
         -------
         self : object
-            Returns the fitted model 
+            Returns the fitted model
         """
 
         self.summarize( X, y, weights )
@@ -227,7 +230,7 @@ cdef class NaiveBayes( object ):
         Returns
         -------
         self : object
-            Returns the fitted model 
+            Returns the fitted model
         """
 
         n = len(self.models)
@@ -244,7 +247,7 @@ cdef class NaiveBayes( object ):
 
         self.summaries = numpy.zeros(n)
         return self
-    
+
     cpdef predict_log_proba( self, X ):
         """Return the normalized log probability of samples under the model.
 
@@ -280,7 +283,7 @@ cdef class NaiveBayes( object ):
 
         for i in range(n):
             total = NEGINF
-            
+
             for j in range(m):
                 r[i, j] = self.models[j].log_probability( X[i] ) + logw[j]
                 total = pair_lse( total, r[i, j] )
@@ -323,7 +326,7 @@ cdef class NaiveBayes( object ):
 
         for i in range(n):
             total = 0.
-            
+
             for j in range(m):
                 r[i, j] = cexp(self.models[j].log_probability( X[i] )) * self.weights[j]
                 total += r[i, j]

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -125,11 +125,11 @@ cdef class HiddenMarkovModel( Model ):
 	>>> model.add_transition( s2, s3, 0.10 )
 	>>> model.add_transition( s3, s3, 0.70 )
 	>>> model.add_transition( s3, model.end, 0.30 )
-	>>> model.bake() 
+	>>> model.bake()
 	>>>
 	>>> print model.log_probability(list('ACGACTATTCGAT'))
 	-4.31828085576
-	>>> print ", ".join( state.name for i, state in model.viterbi(list('ACGACTATTCGAT'))[1] ) 
+	>>> print ", ".join( state.name for i, state in model.viterbi(list('ACGACTATTCGAT'))[1] )
 	example-start, s1, s2, s2, s2, s2, s2, s2, s2, s2, s2, s2, s2, s3, example-end
 	"""
 
@@ -168,7 +168,7 @@ cdef class HiddenMarkovModel( Model ):
 		# State objects, so they're guaranteed never to conflict when composing
 		# two distinct models
 		self.graph = networkx.DiGraph()
-		
+
 		# Save the start and end or mae one up
 		self.start = start or State( None, name=self.name + "-start" )
 		self.end = end or State( None, name=self.name + "-end" )
@@ -178,7 +178,7 @@ cdef class HiddenMarkovModel( Model ):
 		self.n_states = 0
 		self.discrete = 0
 		self.multivariate = 0
-		
+
 		# Put start and end in the graph
 		self.graph.add_node(self.start)
 		self.graph.add_node(self.end)
@@ -205,6 +205,101 @@ cdef class HiddenMarkovModel( Model ):
 	def __dealloc__(self):
 		self.free_bake_buffers()
 
+	def __getstate__(self):
+		"""Return model representation in a dictionary."""
+
+		state = {
+			'class' :  'HiddenMarkovModel',
+			'name' :   self.name,
+			'start' :  self.start,
+			'end' :    self.end,
+			'states' : self.states,
+			'end_index' :    self.end_index,
+			'start_index' :  self.start_index,
+			'silent_index' : self.silent_start
+		}
+
+		indices = { state: i for i, state in enumerate( self.states )}
+
+		# Get the number of groups of edges which are tied
+		groups = []
+		n = self.n_tied_edge_groups-1
+
+		# Go through each group one at a time
+		for i in xrange(n):
+			# Create an empty list for that group
+			groups.append( [] )
+
+			# Go through each edge in that group
+			start, end = self.tied_edge_group_size[i], self.tied_edge_group_size[i+1]
+
+			# Add each edge as a tuple of indices
+			for j in xrange( start, end ):
+				groups[i].append( ( self.tied_edges_starts[j], self.tied_edges_ends[j] ) )
+
+		# Now reverse this into a dictionary, such that each pair of edges points
+		# to a label (a number in this case)
+		d = { tup : i for i in xrange(n) for tup in groups[i] }
+
+		# Get all the edges from the graph
+		edges = []
+		for start, end, data in self.graph.edges_iter( data=True ):
+			# If this edge is part of a group of tied edges, annotate this group
+			# it is a part of
+			s, e = indices[start], indices[end]
+			prob, pseudocount = math.e**data['probability'], data['pseudocount']
+			edge = (s, e)
+			edges.append( ( s, e, prob, pseudocount, d.get( edge, None ) ) )
+
+		state['edges'] = edges
+
+		# Get distribution tie information
+		ties = []
+		for i in xrange( self.silent_start ):
+			start, end = self.tied_state_count[i], self.tied_state_count[i+1]
+
+			for j in xrange( start, end ):
+				ties.append( ( i, self.tied[j] ) )
+
+		state['distribution ties'] = ties
+
+		return state
+
+	def __reduce__(self):
+		return self.__class__, tuple(), self.__getstate__()
+
+	def __setstate__( self, state ):
+		"""Deserialize object for unpickling.
+
+		Parameters
+		----------
+		state :
+			The model state, (see `__reduce__()` documentation from the pickle protocol).
+		"""
+
+		self.name = state['name']
+
+		# Load all the states from JSON formatted strings
+		states = state['states']
+		for i, j in state['distribution ties']:
+			# Tie appropriate states together
+			states[i].tie( states[j] )
+
+		# Add all the states to the model
+		self.add_states( states )
+
+		# Indicate appropriate start and end states
+		self.start = states[ state['start_index'] ]
+		self.end = states[ state['end_index'] ]
+
+		# Add all the edges to the model
+		for start, end, probability, pseudocount, group in state['edges']:
+			self.add_transition( states[start], states[end], probability,
+				pseudocount, group )
+
+		# Bake the model
+		self.bake( verbose=False )
+
 	def free_bake_buffers(self):
 		free(self.in_transition_pseudocounts)
 		free(self.out_transition_pseudocounts)
@@ -223,9 +318,9 @@ cdef class HiddenMarkovModel( Model ):
 
 
 	def add_state(self, state):
-		"""Add a state to the given model. 
-		
-		The state must not already be in the model, nor may it be part of any 
+		"""Add a state to the given model.
+
+		The state must not already be in the model, nor may it be part of any
 		other model that will eventually be combined with this one.
 
 		Parameters
@@ -237,7 +332,7 @@ cdef class HiddenMarkovModel( Model ):
 		-------
 		None
 		"""
-		
+
 		if state.name in self.state_names:
 			raise ValueError("A state with name '{}' already exists".format(state.name))
 
@@ -246,7 +341,7 @@ cdef class HiddenMarkovModel( Model ):
 
 	def add_states( self, *states ):
 		"""Add multiple states to the model at the same time.
-		
+
 		Parameters
 		----------
 		states : list or generator
@@ -278,7 +373,7 @@ cdef class HiddenMarkovModel( Model ):
 		By specifying a group as a string, you can tie edges together by giving
 		them the same group. This means that a transition across one edge in the
 		group counts as a transition across all edges in terms of training.
-		
+
 		Parameters
 		----------
 		a : State
@@ -304,14 +399,14 @@ cdef class HiddenMarkovModel( Model ):
 		-------
 		None
 		"""
-		
+
 		pseudocount = pseudocount or probability
-		self.graph.add_edge(a, b, probability=log(probability), 
+		self.graph.add_edge(a, b, probability=log(probability),
 			pseudocount=pseudocount, group=group )
 
 	def add_transitions( self, a, b, probabilities, pseudocounts=None,
 		groups=None ):
-		"""Add many transitions at the same time, 
+		"""Add many transitions at the same time,
 
 		Parameters
 		----------
@@ -335,7 +430,7 @@ cdef class HiddenMarkovModel( Model ):
 		None
 
 		Examples
-		-------- 
+		--------
 		>>> model.add_transitions([model.start, s1], [s1, model.end], [1., 1.])
 		>>> model.add_transitions([model.start, s1, s2, s3], s4, [0.2, 0.4, 0.3, 0.9])
 		>>> model.add_transitions(model.start, [s1, s2, s3], [0.6, 0.2, 0.05])
@@ -353,7 +448,7 @@ cdef class HiddenMarkovModel( Model ):
 			for start, end, probability, pseudocount, group in edges:
 				self.add_transition( start, end, probability, pseudocount, group )
 
-		# Allow for multiple transitions to a specific state 
+		# Allow for multiple transitions to a specific state
 		elif isinstance( a, list ) and isinstance( b, State ):
 			edges = izip( a, probabilities, pseudocounts, groups )
 			for start, probability, pseudocount, group in edges:
@@ -367,7 +462,7 @@ cdef class HiddenMarkovModel( Model ):
 
 	def dense_transition_matrix( self ):
 		"""Returns the dense transition matrix.
-		
+
 		Parameters
 		----------
 		None
@@ -387,7 +482,7 @@ cdef class HiddenMarkovModel( Model ):
 				transition_log_probabilities[i, self.out_transitions[n]] = \
 					self.out_transition_log_probabilities[n]
 
-		return transition_log_probabilities 
+		return transition_log_probabilities
 
 	def copy( self ):
 		"""Returns a deep copy of the HMM.
@@ -405,11 +500,11 @@ cdef class HiddenMarkovModel( Model ):
 		return HiddenMarkovModel.from_json( self.to_json() )
 
 	def freeze_distributions( self ):
-		"""Freeze all the distributions in model. 
+		"""Freeze all the distributions in model.
 
-		Upon training only edges will be updated. The parameters of 
+		Upon training only edges will be updated. The parameters of
 		distributions will not be affected.
-		
+
 		Parameters
 		----------
 		None
@@ -424,7 +519,7 @@ cdef class HiddenMarkovModel( Model ):
 				state.distribution.freeze()
 
 	def thaw_distributions( self ):
-		"""Thaw all distributions in the model. 
+		"""Thaw all distributions in the model.
 
 		Upon training distributions will be updated again.
 
@@ -448,13 +543,13 @@ cdef class HiddenMarkovModel( Model ):
 		Parameters
 		----------
 		other : HiddenMarkovModel
-			The other model to add 
+			The other model to add
 
 		Returns
 		-------
 		None
 		"""
-		
+
 		self.graph = networkx.union(self.graph, other.graph)
 
 	def concatenate( self, other, suffix='', prefix='' ):
@@ -463,7 +558,7 @@ cdef class HiddenMarkovModel( Model ):
 		Concatenate this model to another model in such a way that a single
 		probability 1 edge is added between self.end and other.start. Rename
 		all other states appropriately by adding a suffix or prefix if needed.
-		
+
 		Parameters
 		----------
 		other : HiddenMarkovModel
@@ -500,8 +595,8 @@ cdef class HiddenMarkovModel( Model ):
 
 	def draw( self, **kwargs ):
 		"""Draw this model's graph using NetworkX and matplotlib.
-		
-		Note that this relies on networkx's built-in graphing capabilities (and 
+
+		Note that this relies on networkx's built-in graphing capabilities (and
 		not Graphviz) and thus can't draw self-loops.
 
 		See networkx.draw_networkx() for the keywords you can pass in.
@@ -515,7 +610,7 @@ cdef class HiddenMarkovModel( Model ):
 		-------
 		None
 		"""
-		
+
 		if pygraphviz is not None:
 			G = pygraphviz.AGraph(directed=True)
 			done_nodes = set()
@@ -552,16 +647,16 @@ cdef class HiddenMarkovModel( Model ):
 			networkx.draw()
 		pyplot.show()
 
-	def bake( self, verbose=False, merge="All" ): 
+	def bake( self, verbose=False, merge="All" ):
 		"""Finalize the topology of the model.
 
 		Finalize the topology of the model and assign a numerical index to
 		every state. This method must be called before any of the probability-
 		calculating methods.
-		
-		This fills in self.states (a list of all states in order) and 
-		self.transition_log_probabilities (log probabilities for transitions), 
-		as well as self.start_index and self.end_index, and self.silent_start 
+
+		This fills in self.states (a list of all states in order) and
+		self.transition_log_probabilities (log probabilities for transitions),
+		as well as self.start_index and self.end_index, and self.silent_start
 		(the index of the first silent state).
 
 		Parameters
@@ -599,11 +694,11 @@ cdef class HiddenMarkovModel( Model ):
 
 		self.free_bake_buffers()
 
-		in_edge_count = numpy.zeros( len( self.graph.nodes() ), 
-			dtype=numpy.int32 ) 
-		out_edge_count = numpy.zeros( len( self.graph.nodes() ), 
+		in_edge_count = numpy.zeros( len( self.graph.nodes() ),
 			dtype=numpy.int32 )
-		
+		out_edge_count = numpy.zeros( len( self.graph.nodes() ),
+			dtype=numpy.int32 )
+
 		merge = merge.lower() if merge else None
 		while merge == 'all':
 			merge_count = 0
@@ -616,7 +711,7 @@ cdef class HiddenMarkovModel( Model ):
 			for a, b in self.graph.edges():
 				out_edge_count[ indices[a] ] += 1
 				in_edge_count[ indices[b] ] += 1
-				
+
 			# Go through each state, and if either in or out edges are 0,
 			# remove the edge.
 			for i in range( len( prestates ) ):
@@ -648,7 +743,7 @@ cdef class HiddenMarkovModel( Model ):
 			for state in self.graph.nodes():
 
 				# Perform log sum exp on the edges to see if they properly sum to 1
-				out_edges = round( sum( numpy.e**x['probability'] 
+				out_edges = round( sum( numpy.e**x['probability']
 					for x in self.graph.edge[state].values() ), 8 )
 
 				# The end state has no out edges, so will be 0
@@ -685,7 +780,7 @@ cdef class HiddenMarkovModel( Model ):
 					# Make sure the transition is an appropriate merger
 					if merge=='all' or ( merge=='partial' and b.is_silent() ):
 
-						# Go through every transition to that state 
+						# Go through every transition to that state
 						for x, y, d in self.graph.edges( data=True ):
 
 							# Make sure that the edge points to the current node
@@ -717,7 +812,7 @@ cdef class HiddenMarkovModel( Model ):
 		if merge in ['all', 'partial']:
 			# Detect whether or not there are loops of silent states by going
 			# through every pair of edges, and ensure that there is not a cycle
-			# of silent states.		
+			# of silent states.
 			for a, b, e in self.graph.edges( data=True ):
 				for x, y, d in self.graph.edges( data=True ):
 					if a is y and b is x and a.is_silent() and b.is_silent():
@@ -747,22 +842,22 @@ cdef class HiddenMarkovModel( Model ):
 		# transition between silent states must be from a lower-numbered state
 		# to a higher-numbered state. Since we ban loops of silent states, we
 		# can get away with this.
-		
+
 		# Get the subgraph of all silent states
 		silent_subgraph = self.graph.subgraph(silent_states)
-		
+
 		# Get the sorted silent states. Isn't it convenient how NetworkX has
 		# exactly the algorithm we need?
 		silent_states_sorted = networkx.topological_sort(silent_subgraph, nbunch=silent_states)
-		
+
 		# What's the index of the first silent state?
 		self.silent_start = len(normal_states)
 
 		# Save the master state ordering. Silent states are last and in
 		# topological order, so when calculationg forward algorithm
 		# probabilities we can just go down the list of states.
-		self.states = normal_states + silent_states_sorted 
-		
+		self.states = normal_states + silent_states_sorted
+
 		# We need a good way to get transition probabilities by state index that
 		# isn't N^2 to build or store. So we will need a reverse of the above
 		# mapping. It's awkward but asymptotically fine.
@@ -775,7 +870,7 @@ cdef class HiddenMarkovModel( Model ):
 		for i in range( self.silent_start+1 ):
 			self.tied_state_count[i] = 0
 
-		for i in range( self.silent_start ): 
+		for i in range( self.silent_start ):
 			for j in range( self.silent_start ):
 				if i == j:
 					continue
@@ -793,7 +888,7 @@ cdef class HiddenMarkovModel( Model ):
 			for j in range( self.silent_start ):
 				if i == j:
 					continue
-					
+
 				if self.states[i].distribution is self.states[j].distribution:
 					# Begin at the first index which belongs to state i...
 					start = self.tied_state_count[i]
@@ -811,21 +906,21 @@ cdef class HiddenMarkovModel( Model ):
 		for i in range( self.silent_start ):
 			self.state_weights[i] = _log( self.states[i].weight )
 
-		# This holds numpy array indexed [a, b] to transition log probabilities 
+		# This holds numpy array indexed [a, b] to transition log probabilities
 		# from a to b, where a and b are state indices. It starts out saying all
 		# transitions are impossible.
 		self.in_transitions = <int*> calloc( m, sizeof(int) )
 		self.in_edge_count = <int*> calloc( n+1, sizeof(int) )
 		self.in_transition_pseudocounts = <double*> calloc( m,
 			sizeof(double) )
-		self.in_transition_log_probabilities = <double*> calloc( m, 
+		self.in_transition_log_probabilities = <double*> calloc( m,
 			sizeof(double) )
 
 		self.out_transitions = <int*> calloc( m, sizeof(int) )
 		self.out_edge_count = <int*> calloc( n+1, sizeof(int) )
 		self.out_transition_pseudocounts = <double*> calloc( m,
 			sizeof(double) )
-		self.out_transition_log_probabilities = <double*> calloc( m, 
+		self.out_transition_log_probabilities = <double*> calloc( m,
 			sizeof(double) )
 
 		self.expected_transitions =  <double*> calloc( self.n_edges, sizeof(double) )
@@ -839,7 +934,7 @@ cdef class HiddenMarkovModel( Model ):
 		memset( self.out_edge_count, 0, (n+1)*sizeof(int) )
 		memset( self.out_transition_pseudocounts, 0, m*sizeof(double) )
 		memset( self.out_transition_log_probabilities, 0, m*sizeof(double) )
-		
+
 		# Now we need to find a way of storing in-edges for a state in a manner
 		# that can be called in the cythonized methods below. This is basically
 		# an inversion of the graph. We will do this by having two lists, one
@@ -902,11 +997,11 @@ cdef class HiddenMarkovModel( Model ):
 
 			self.out_transition_log_probabilities[start] = <double>data['probability']
 			self.out_transition_pseudocounts[start] = data['pseudocount']
-			self.out_transitions[start] = <int>indices[b]  
+			self.out_transitions[start] = <int>indices[b]
 
 			# If this edge belongs to a group, we need to add it to the
 			# dictionary. We only care about forward representations of
-			# the edges. 
+			# the edges.
 			group = data['group']
 			if group != None:
 				if group in edge_groups:
@@ -943,7 +1038,7 @@ cdef class HiddenMarkovModel( Model ):
 				self.tied_edges_starts[n+j] = start
 				self.tied_edges_ends[n+j] = end
 
-		dist = self.states[0].distribution 
+		dist = self.states[0].distribution
 		if isinstance( dist, DiscreteDistribution ):
 			self.discrete = 1
 			states = self.states[:self.silent_start]
@@ -958,7 +1053,7 @@ cdef class HiddenMarkovModel( Model ):
 		self.multivariate = self.d > 1
 
 		self.distributions = numpy.empty(self.silent_start, dtype='object')
-		for i in range(self.silent_start):	
+		for i in range(self.silent_start):
 			self.distributions[i] = self.states[i].distribution
 			if self.d != self.distributions[i].d:
 				raise ValueError("mis-matching inputs for states")
@@ -978,9 +1073,9 @@ cdef class HiddenMarkovModel( Model ):
 
 
 	def sample( self, length=0, path=False ):
-		"""Generate a sequence from the model. 
+		"""Generate a sequence from the model.
 
-		Returns the sequence generated, as a list of emitted items. The 
+		Returns the sequence generated, as a list of emitted items. The
 		model must have been baked first in order to run this method.
 
 		If a length is specified and the HMM is infinite (no edges to the
@@ -990,7 +1085,7 @@ cdef class HiddenMarkovModel( Model ):
 		itself to not take an end transition unless that is the only path,
 		making it not a true random sample on a finite model.
 
-		WARNING: If the HMM has no explicit end state, must specify a length 
+		WARNING: If the HMM has no explicit end state, must specify a length
 		to use.
 
 		Parameters
@@ -1009,7 +1104,7 @@ cdef class HiddenMarkovModel( Model ):
 			If path is true, return a tuple of (sample, path), otherwise return
 			just the samples.
 		"""
-		
+
 		if self.d == 0:
 			raise ValueError("must bake model before sampling")
 
@@ -1026,14 +1121,14 @@ cdef class HiddenMarkovModel( Model ):
 		for k in range( m ):
 			cumulative_probability = 0.
 			for l in range( out_edges[k], out_edges[k+1] ):
-				cumulative_probability += cexp( 
+				cumulative_probability += cexp(
 					self.out_transition_log_probabilities[l] )
-				cum_probabilities[l] = cumulative_probability 
+				cum_probabilities[l] = cumulative_probability
 
 		# This holds the numerical index of the state we are currently in.
 		# Start in the start state
 		i = self.start_index
-		
+
 		# Record the number of samples
 		cdef int n = 0
 		# Define the list of emissions, and the path of hidden states taken
@@ -1047,7 +1142,7 @@ cdef class HiddenMarkovModel( Model ):
 
 			# Add the state to the growing path
 			sequence_path.append( state )
-			
+
 			if not state.is_silent():
 				# There's an emission distribution, so sample from it
 				emissions.append( state.distribution.sample() )
@@ -1064,7 +1159,7 @@ cdef class HiddenMarkovModel( Model ):
 			# Generate a number between 0 and 1 to make a weighted decision
 			# as to which state to jump to next.
 			sample = random.random()
-			
+
 			# Save the last state id we were in
 			j = i
 
@@ -1102,7 +1197,7 @@ cdef class HiddenMarkovModel( Model ):
 					if cum_probabilities[k] > sample:
 						i = self.out_transitions[k]
 						break
-		
+
 		# Done! Return either emissions, or emissions and path.
 		if path:
 			sequence_path.append( self.end )
@@ -1110,7 +1205,7 @@ cdef class HiddenMarkovModel( Model ):
 		return emissions
 
 	cpdef double log_probability( self, sequence, check_input=True ):
-		"""Calculate the log probability of a single sequence. 
+		"""Calculate the log probability of a single sequence.
 
 		If a path is provided, calculate the log probability of that sequence
 		given the path.
@@ -1127,7 +1222,7 @@ cdef class HiddenMarkovModel( Model ):
 		Returns
 		-------
 		logp : double
-			The log probability of the sequence 
+			The log probability of the sequence
 		"""
 
 		if self.d == 0:
@@ -1172,27 +1267,27 @@ cdef class HiddenMarkovModel( Model ):
 		"""Run the forward algorithm on the sequence.
 
 		Calculate the probability of each observation being aligned to each
-		state by going forward through a sequence. Returns the full forward 
-		matrix. Each index i, j corresponds to the sum-of-all-paths log 
-		probability of starting at the beginning of the sequence, and aligning 
-		observations to hidden states in such a manner that observation i was 
-		aligned to hidden state j. Uses row normalization to dynamically scale 
+		state by going forward through a sequence. Returns the full forward
+		matrix. Each index i, j corresponds to the sum-of-all-paths log
+		probability of starting at the beginning of the sequence, and aligning
+		observations to hidden states in such a manner that observation i was
+		aligned to hidden state j. Uses row normalization to dynamically scale
 		each row to prevent underflow errors.
 
 		If the sequence is impossible, will return a matrix of nans.
 
-		See also: 
+		See also:
 			- Silent state handling taken from p. 71 of "Biological
 		Sequence Analysis" by Durbin et al., and works for anything which
 		does not have loops of silent states.
-			- Row normalization technique explained by 
+			- Row normalization technique explained by
 		http://www.cs.sjsu.edu/~stamp/RUA/HMM.pdf on p. 14.
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
-		
+
 		Returns
 		-------
 		matrix : array-like, shape (len(sequence), n_states)
@@ -1228,7 +1323,7 @@ cdef class HiddenMarkovModel( Model ):
 		free(f)
 		return f_ndarray
 
-	cdef double* _forward( self, double* sequence, void** distributions, 
+	cdef double* _forward( self, double* sequence, void** distributions,
 		int n, double* emissions ) nogil:
 		cdef int i, k, ki, l, li
 		cdef int p = self.silent_start, m = self.n_states
@@ -1247,15 +1342,15 @@ cdef class HiddenMarkovModel( Model ):
 			for l in range( self.silent_start ):
 				for i in range( n ):
 					if self.multivariate:
-						e[l*n + i] = (( <Distribution> distributions[l] )._mv_log_probability( sequence+i*dim ) + 
-							self.state_weights[l] ) 
+						e[l*n + i] = (( <Distribution> distributions[l] )._mv_log_probability( sequence+i*dim ) +
+							self.state_weights[l] )
 					else:
-						e[l*n + i] = (( <Distribution> distributions[l] )._log_probability( sequence[i] ) + 
+						e[l*n + i] = (( <Distribution> distributions[l] )._log_probability( sequence[i] ) +
 							self.state_weights[l] )
 		else:
 			e = emissions
 
-		# We must start in the start state, having emitted 0 symbols        
+		# We must start in the start state, having emitted 0 symbols
 		for i in range(m):
 			f[i] = NEGINF
 		f[self.start_index] = 0.
@@ -1268,9 +1363,9 @@ cdef class HiddenMarkovModel( Model ):
 				# Start state log-probability is already right. Don't touch it.
 				continue
 
-			# This holds the log total transition probability in from 
-			# all current-step silent states that can have transitions into 
-			# this state.  
+			# This holds the log total transition probability in from
+			# all current-step silent states that can have transitions into
+			# this state.
 			log_probability = NEGINF
 			for k in range( in_edges[l], in_edges[l+1] ):
 				ki = self.in_transitions[k]
@@ -1287,7 +1382,7 @@ cdef class HiddenMarkovModel( Model ):
 		for i in range( n ):
 			for l in range( self.silent_start ):
 				# Do the recurrence for non-silent states l
-				# This holds the log total transition probability in from 
+				# This holds the log total transition probability in from
 				# all previous states
 
 				log_probability = NEGINF
@@ -1298,13 +1393,13 @@ cdef class HiddenMarkovModel( Model ):
 					log_probability = pair_lse( log_probability,
 						f[i*m + ki] + self.in_transition_log_probabilities[k] )
 
-				# Now set the table entry for log probability of emitting 
+				# Now set the table entry for log probability of emitting
 				# index+1 characters and ending in state l
 				f[(i+1)*m + l] = log_probability + e[i + l*n]
 
 			for l in range( self.silent_start, m ):
 				# Now do the first pass over the silent states
-				# This holds the log total transition probability in from 
+				# This holds the log total transition probability in from
 				# all current-step non-silent states
 				log_probability = NEGINF
 				for k in range( in_edges[l], in_edges[l+1] ):
@@ -1323,8 +1418,8 @@ cdef class HiddenMarkovModel( Model ):
 				# Now the second pass through silent states, where we account
 				# for transitions between silent states.
 
-				# This holds the log total transition probability in from 
-				# all current-step silent states that can have transitions into 
+				# This holds the log total transition probability in from
+				# all current-step silent states that can have transitions into
 				# this state.
 				log_probability = NEGINF
 				for k in range( in_edges[l], in_edges[l+1] ):
@@ -1346,27 +1441,27 @@ cdef class HiddenMarkovModel( Model ):
 		"""Run the backward algorithm on the sequence.
 
 		Calculate the probability of each observation being aligned to each
-		state by going backward through a sequence. Returns the full backward 
-		matrix. Each index i, j corresponds to the sum-of-all-paths log 
-		probability of starting at the end of the sequence, and aligning 
-		observations to hidden states in such a manner that observation i was 
-		aligned to hidden state j. Uses row normalization to dynamically scale 
+		state by going backward through a sequence. Returns the full backward
+		matrix. Each index i, j corresponds to the sum-of-all-paths log
+		probability of starting at the end of the sequence, and aligning
+		observations to hidden states in such a manner that observation i was
+		aligned to hidden state j. Uses row normalization to dynamically scale
 		each row to prevent underflow errors.
 
 		If the sequence is impossible, will return a matrix of nans.
 
-		See also: 
+		See also:
 			- Silent state handling taken from p. 71 of "Biological
 		Sequence Analysis" by Durbin et al., and works for anything which
 		does not have loops of silent states.
-			- Row normalization technique explained by 
+			- Row normalization technique explained by
 		http://www.cs.sjsu.edu/~stamp/RUA/HMM.pdf on p. 14.
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
-		
+
 		Returns
 		-------
 		matrix : array-like, shape (len(sequence), n_states)
@@ -1402,7 +1497,7 @@ cdef class HiddenMarkovModel( Model ):
 		free(b)
 		return b_ndarray
 
-	cdef double* _backward( self, double* sequence, void** distributions, 
+	cdef double* _backward( self, double* sequence, void** distributions,
 		int n, double* emissions ) nogil:
 		cdef int i, ir, k, kr, l, li
 		cdef int p = self.silent_start, m = self.n_states
@@ -1421,10 +1516,10 @@ cdef class HiddenMarkovModel( Model ):
 			for l in range( self.silent_start ):
 				for i in range( n ):
 					if self.multivariate:
-						e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) + 
+						e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) +
 							self.state_weights[l])
 					else:
-						e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) + 
+						e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) +
 							self.state_weights[l])
 		else:
 			e = emissions
@@ -1448,9 +1543,9 @@ cdef class HiddenMarkovModel( Model ):
 			k = m - kr - 1
 
 			# Do the silent states' dependencies on each other.
-			# Doing it in reverse order ensures that anything we can 
+			# Doing it in reverse order ensures that anything we can
 			# possibly transition to is already done.
-			
+
 			if k == self.end_index:
 				# We already set the log-probability for this, so skip it
 				continue
@@ -1478,7 +1573,7 @@ cdef class HiddenMarkovModel( Model ):
 				break
 			# Do the non-silent states in the last step, which depend on
 			# current-step silent states.
-			
+
 			# This holds the total accumulated log probability of going
 			# to such states and continuing from there to the end.
 			log_probability = NEGINF
@@ -1509,7 +1604,7 @@ cdef class HiddenMarkovModel( Model ):
 
 				# Do the silent states' dependency on subsequent non-silent
 				# states, iterating backwards to match the order we use later.
-				
+
 				# This holds the log total probability that we go to some
 				# subsequent state that emits the right thing, and then continue
 				# from there to finish the sequence.
@@ -1534,9 +1629,9 @@ cdef class HiddenMarkovModel( Model ):
 				k = m - kr - 1
 
 				# Do the silent states' dependencies on each other.
-				# Doing it in reverse order ensures that anything we can 
+				# Doing it in reverse order ensures that anything we can
 				# possibly transition to is already done.
-				
+
 				# This holds the log total probability that we go to
 				# current-step silent states and then continue from there to
 				# finish the sequence.
@@ -1558,7 +1653,7 @@ cdef class HiddenMarkovModel( Model ):
 			for k in range( self.silent_start ):
 				# Do the non-silent states in the current step, which depend on
 				# subsequent non-silent states and current-step silent states.
-				
+
 				# This holds the total accumulated log probability of going
 				# to such states and continuing from there to the end.
 				log_probability = NEGINF
@@ -1594,7 +1689,7 @@ cdef class HiddenMarkovModel( Model ):
 
 	def forward_backward( self, sequence ):
 		"""Run the forward-backward algorithm on the sequence.
-		
+
 		This algorithm returns an emission matrix and a transition matrix. The
 		emission matrix returns the normalized probability that each each state
 		generated that emission given both the symbol and the entire sequence.
@@ -1603,17 +1698,17 @@ cdef class HiddenMarkovModel( Model ):
 
 		If the sequence is impossible, will return (None, None)
 
-		See also: 
+		See also:
 			- Forward and backward algorithm implementations. A comprehensive
 			description of the forward, backward, and forward-background
-			algorithm is here: 
+			algorithm is here:
 			http://en.wikipedia.org/wiki/Forward%E2%80%93backward_algorithm
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
-		
+
 		Returns
 		-------
 		emissions : array-like, shape (len(sequence), n_nonsilent_states)
@@ -1665,10 +1760,10 @@ cdef class HiddenMarkovModel( Model ):
 		for l in range( self.silent_start ):
 			for i in range( n ):
 				if self.multivariate:
-					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) +
 						self.state_weights[l])
 				else:
-					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) +
 						self.state_weights[l])
 
 		f = self._forward( sequence, distributions, n, e )
@@ -1679,9 +1774,9 @@ cdef class HiddenMarkovModel( Model ):
 		else:
 			log_sequence_probability = NEGINF
 			for i in range( self.silent_start ):
-				log_sequence_probability = pair_lse( 
+				log_sequence_probability = pair_lse(
 					log_sequence_probability, f[n*m + i] )
-		
+
 		# Is the sequence impossible? If so, don't bother calculating any more.
 		if log_sequence_probability == NEGINF:
 			print( "Warning: Sequence is impossible." )
@@ -1695,25 +1790,25 @@ cdef class HiddenMarkovModel( Model ):
 					continue
 
 				# For each state we could go to (and emit a character)
-				# Sum up probabilities that we later normalize by 
+				# Sum up probabilities that we later normalize by
 				# probability of sequence.
 				log_transition_emission_probability_sum = NEGINF
 
 				for i in range( n ):
 					# For each character in the sequence
-					# Add probability that we start and get up to state k, 
+					# Add probability that we start and get up to state k,
 					# and go k->l, and emit the symbol from l, and go from l
 					# to the end.
-					log_transition_emission_probability_sum = pair_lse( 
-						log_transition_emission_probability_sum, 
+					log_transition_emission_probability_sum = pair_lse(
+						log_transition_emission_probability_sum,
 						f[i*m + k] + self.out_transition_log_probabilities[l] +
 						e[i + li*n] + b[(i+1)*m + li] )
 
 				# Now divide by probability of the sequence to make it given
-				# this sequence, and add as this sequence's contribution to 
+				# this sequence, and add as this sequence's contribution to
 				# the expected transitions matrix's k, l entry.
 				expected_transitions[k*m + li] += cexp(
-					log_transition_emission_probability_sum - 
+					log_transition_emission_probability_sum -
 					log_sequence_probability )
 
 			for l in range( out_edges[k], out_edges[k+1] ):
@@ -1722,42 +1817,42 @@ cdef class HiddenMarkovModel( Model ):
 					continue
 
 				# For each silent state we can go to on the same character
-				# Sum up probabilities that we later normalize by 
+				# Sum up probabilities that we later normalize by
 				# probability of sequence.
 
 				log_transition_emission_probability_sum = NEGINF
 				for i in range( n+1 ):
 					# For each row in the forward DP table (where we can
-					# have transitions to silent states) of which we have 1 
+					# have transitions to silent states) of which we have 1
 					# more than we have symbols...
-						
-					# Add probability that we start and get up to state k, 
-					# and go k->l, and go from l to the end. In this case, 
-					# we use forward and backward entries from the same DP 
+
+					# Add probability that we start and get up to state k,
+					# and go k->l, and go from l to the end. In this case,
+					# we use forward and backward entries from the same DP
 					# table row, since no character is being emitted.
-					log_transition_emission_probability_sum = pair_lse( 
-						log_transition_emission_probability_sum, 
+					log_transition_emission_probability_sum = pair_lse(
+						log_transition_emission_probability_sum,
 						f[i*m + k] + self.out_transition_log_probabilities[l]
 						+ b[i*m + li] )
-					
+
 				# Now divide by probability of the sequence to make it given
-				# this sequence, and add as this sequence's contribution to 
+				# this sequence, and add as this sequence's contribution to
 				# the expected transitions matrix's k, l entry.
 				expected_transitions[k*m + li] += cexp(
 					log_transition_emission_probability_sum -
 					log_sequence_probability )
-				
+
 			if k < self.silent_start:
 				# Now think about emission probabilities from this state
-						  
+
 				for i in xrange( n ):
 					# For each symbol that came out
-		   
+
 					# What's the weight of this symbol for that state?
-					# Probability that we emit index characters and then 
-					# transition to state l, and that from state l we  
-					# continue on to emit len(sequence) - (index + 1) 
-					# characters, divided by the probability of the 
+					# Probability that we emit index characters and then
+					# transition to state l, and that from state l we
+					# continue on to emit len(sequence) - (index + 1)
+					# characters, divided by the probability of the
 					# sequence under the model.
 					# According to http://www1.icsi.berkeley.edu/Speech/
 					# docs/HTKBook/node7_mn.html, we really should divide by
@@ -1787,18 +1882,18 @@ cdef class HiddenMarkovModel( Model ):
 		silent states in the current step can trace back to other silent states
 		in the current step as well as states in the previous step.
 
-		See also: 
+		See also:
 			- Viterbi implementation described well in the wikipedia article
 			http://en.wikipedia.org/wiki/Viterbi_algorithm
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
 
 		Returns
 		-------
-		logp : double 
+		logp : double
 			The log probability of the sequence under the Viterbi path
 
 		path : list of tuples
@@ -1862,10 +1957,10 @@ cdef class HiddenMarkovModel( Model ):
 		for l in range( self.silent_start ):
 			for i in range( n ):
 				if self.multivariate:
-					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) +
 						self.state_weights[l])
 				else:
-					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) +
 						self.state_weights[l])
 
 		for i in range( m ):
@@ -1899,7 +1994,7 @@ cdef class HiddenMarkovModel( Model ):
 				# Do the recurrence for non-silent states l
 				# Start out saying the best likelihood we have is -inf
 				v[(i+1)*m + l] = NEGINF
-				
+
 				for k in range( in_edges[l], in_edges[l+1] ):
 					ki = self.in_transitions[k]
 
@@ -2008,23 +2103,23 @@ cdef class HiddenMarkovModel( Model ):
 	def predict_proba( self, sequence ):
 		"""Calculate the state probabilities for each observation in the sequence.
 
-		Run the forward-backward algorithm on the sequence and return the emission 
+		Run the forward-backward algorithm on the sequence and return the emission
 		matrix. This is the normalized probability that each each state
 		generated that emission given both the symbol and the entire sequence.
 
 		This is a sklearn wrapper for the forward backward algorithm.
 
-		See also: 
+		See also:
 			- Forward and backward algorithm implementations. A comprehensive
 			description of the forward, backward, and forward-background
-			algorithm is here: 
+			algorithm is here:
 			http://en.wikipedia.org/wiki/Forward%E2%80%93backward_algorithm
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
-		
+
 		Returns
 		-------
 		emissions : array-like, shape (len(sequence), n_nonsilent_states)
@@ -2039,23 +2134,23 @@ cdef class HiddenMarkovModel( Model ):
 	def predict_log_proba( self, sequence ):
 		"""Calculate the state log probabilities for each observation in the sequence.
 
-		Run the forward-backward algorithm on the sequence and return the emission 
+		Run the forward-backward algorithm on the sequence and return the emission
 		matrix. This is the log normalized probability that each each state
 		generated that emission given both the symbol and the entire sequence.
 
 		This is a sklearn wrapper for the forward backward algorithm.
 
-		See also: 
+		See also:
 			- Forward and backward algorithm implementations. A comprehensive
 			description of the forward, backward, and forward-background
-			algorithm is here: 
+			algorithm is here:
 			http://en.wikipedia.org/wiki/Forward%E2%80%93backward_algorithm
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
-		
+
 		Returns
 		-------
 		emissions : array-like, shape (len(sequence), n_nonsilent_states)
@@ -2085,23 +2180,23 @@ cdef class HiddenMarkovModel( Model ):
 		else:
 			log_sequence_probability = NEGINF
 			for i in range( self.silent_start ):
-				log_sequence_probability = pair_lse( 
+				log_sequence_probability = pair_lse(
 					log_sequence_probability, f[ n, i ] )
-		
+
 		# Is the sequence impossible? If so, don't bother calculating any more.
 		if log_sequence_probability == NEGINF:
 			print( "Warning: Sequence is impossible." )
 			return ( None, None )
 
-		for k in range( m ):				
-			if k < self.silent_start:				  
+		for k in range( m ):
+			if k < self.silent_start:
 				for i in range( n ):
 					# For each symbol that came out
 					# What's the weight of this symbol for that state?
-					# Probability that we emit index characters and then 
-					# transition to state l, and that from state l we  
-					# continue on to emit len(sequence) - (index + 1) 
-					# characters, divided by the probability of the 
+					# Probability that we emit index characters and then
+					# transition to state l, and that from state l we
+					# continue on to emit len(sequence) - (index + 1)
+					# characters, divided by the probability of the
 					# sequence under the model.
 					# According to http://www1.icsi.berkeley.edu/Speech/
 					# docs/HTKBook/node7_mn.html, we really should divide by
@@ -2122,7 +2217,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
 
 		algorithm : "map", "viterbi"
@@ -2130,12 +2225,12 @@ cdef class HiddenMarkovModel( Model ):
 
 		Returns
 		-------
-		logp : double 
+		logp : double
 			The log probability of the sequence under the Viterbi path
 
 		path : list of tuples
 			Tuples of (state index, state object) of the states along the
-			Viterbi path.	
+			Viterbi path.
 		"""
 
 		if self.d == 0:
@@ -2155,15 +2250,15 @@ cdef class HiddenMarkovModel( Model ):
 		notes/lecture5.pdf
 
 		WARNING: This may produce impossible sequences.
-		
+
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
 
 		Returns
 		-------
-		logp : double 
+		logp : double
 			The log probability of the sequence under the Viterbi path
 
 		path : list of tuples
@@ -2176,7 +2271,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		return self._maximum_a_posteriori( numpy.array( sequence ) )
 
-	
+
 	cdef tuple _maximum_a_posteriori( self, numpy.ndarray sequence ):
 		cdef int i, k, l, li
 		cdef int m=len(self.states), n=len(sequence)
@@ -2202,7 +2297,7 @@ cdef class HiddenMarkovModel( Model ):
 					maximum_index = l
 
 			path.append( ( maximum_index, self.states[maximum_index] ) )
-			log_probability_sum += maximum_emission_weight 
+			log_probability_sum += maximum_emission_weight
 
 		return log_probability_sum, path
 
@@ -2221,7 +2316,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
 
 		stop_threshold : double, optional
@@ -2287,9 +2382,9 @@ cdef class HiddenMarkovModel( Model ):
 		for i in range( len(sequences) ):
 			try:
 				sequences[i] = numpy.array( sequences[i], dtype='float64' )
-			except: 
-				sequences[i] = numpy.array( list( map( self.keymap.__getitem__, 
-													   sequences[i] ) ), 
+			except:
+				sequences[i] = numpy.array( list( map( self.keymap.__getitem__,
+													   sequences[i] ) ),
 											dtype='float64' )
 
 		if isinstance( sequences, numpy.ndarray ):
@@ -2297,7 +2392,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		with Parallel( n_jobs=n_jobs, backend='threading' ) as parallel:
 			while improvement > stop_threshold or iteration < min_iterations + 1:
-				self.from_summaries(transition_pseudocount, use_pseudocount, 
+				self.from_summaries(transition_pseudocount, use_pseudocount,
 					edge_inertia, distribution_inertia)
 
 				if iteration >= max_iterations + 1:
@@ -2335,7 +2430,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		raise Warning("Method is depricated. Use `fit` instead.")
 
-	def summarize( self, sequences, alg='baum-welch', n_jobs=1, parallel=None, 
+	def summarize( self, sequences, alg='baum-welch', n_jobs=1, parallel=None,
 		check_input=True ):
 		"""Summarize data into stored sufficient statistics for out-of-core
 		training. Only implemented for Baum-Welch training since Viterbi
@@ -2343,7 +2438,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		Parameters
 		----------
-		sequence : array-like 
+		sequence : array-like
 			An array (or list) of observations.
 
 		n_jobs : int, optional
@@ -2377,9 +2472,9 @@ cdef class HiddenMarkovModel( Model ):
 			for i in range( len(sequences) ):
 				try:
 					sequences[i] = numpy.array( sequences[i], dtype='float64' )
-				except: 
-					sequences[i] = numpy.array( list( map( self.keymap.__getitem__, 
-														   sequences[i] ) ), 
+				except:
+					sequences[i] = numpy.array( list( map( self.keymap.__getitem__,
+														   sequences[i] ) ),
 												dtype='float64' )
 
 		if isinstance( sequences, numpy.ndarray ):
@@ -2395,10 +2490,10 @@ cdef class HiddenMarkovModel( Model ):
 					sequence, self.distributions ) for sequence in sequences ]) )
 		else:
 			return sum( parallel([ delayed( self._viterbi_summarize, check_pickle=False )(
-					sequence, self.distributions ) for sequence in sequences ]) )		
+					sequence, self.distributions ) for sequence in sequences ]) )
 
 
-	def from_summaries( self, transition_pseudocount=0, 
+	def from_summaries( self, transition_pseudocount=0,
 		use_pseudocount=False, edge_inertia=0.0, distribution_inertia=0.0 ):
 		"""Fit the model to the stored summary statistics.
 
@@ -2431,7 +2526,7 @@ cdef class HiddenMarkovModel( Model ):
 		if self.summaries == 0:
 			return
 
-		self._from_summaries( transition_pseudocount, use_pseudocount, 
+		self._from_summaries( transition_pseudocount, use_pseudocount,
 			edge_inertia, distribution_inertia )
 
 		memset( self.expected_transitions, 0, self.n_edges*sizeof(double) )
@@ -2440,7 +2535,7 @@ cdef class HiddenMarkovModel( Model ):
 	def clear_summaries( self ):
 		"""Clear the summary statistics stored in the object.
 
-		Parameters 
+		Parameters
 		----------
 		None
 
@@ -2455,7 +2550,7 @@ cdef class HiddenMarkovModel( Model ):
 		for state in self.states[:self.silent_start]:
 			state.distribution.clear_summaries()
 
-	cpdef double _baum_welch_summarize( self, numpy.ndarray sequence_ndarray, 
+	cpdef double _baum_welch_summarize( self, numpy.ndarray sequence_ndarray,
 		numpy.ndarray distributions_ndarray ):
 		"""Python wrapper for the summarization step.
 
@@ -2474,7 +2569,7 @@ cdef class HiddenMarkovModel( Model ):
 
 		return log_sequence_probability
 
-	cdef double __baum_welch_summarize( self, double* sequence, void** distributions, 
+	cdef double __baum_welch_summarize( self, double* sequence, void** distributions,
 		int n ) nogil:
 		"""Collect sufficient statistics on a single sequence."""
 
@@ -2483,7 +2578,7 @@ cdef class HiddenMarkovModel( Model ):
 		cdef int dim = self.d
 
 		cdef double log_sequence_probability
-		cdef double log_transition_emission_probability_sum 
+		cdef double log_transition_emission_probability_sum
 
 		cdef double* expected_transitions = <double*> calloc(self.n_edges, sizeof(double))
 		cdef double* f
@@ -2501,10 +2596,10 @@ cdef class HiddenMarkovModel( Model ):
 		for l in range( self.silent_start ):
 			for i in range( n ):
 				if self.multivariate:
-					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._mv_log_probability( sequence+i*dim ) +
 						self.state_weights[l])
 				else:
-					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) + 
+					e[l*n + i] = ((<Distribution>distributions[l])._log_probability( sequence[i] ) +
 						self.state_weights[l])
 
 		f = self._forward( sequence, distributions, n, e )
@@ -2518,7 +2613,7 @@ cdef class HiddenMarkovModel( Model ):
 				log_sequence_probability = pair_lse( f[n*m + i],
 					log_sequence_probability )
 
-		# Is the sequence impossible? If so, we can't train on it, so skip 
+		# Is the sequence impossible? If so, we can't train on it, so skip
 		# it
 		if log_sequence_probability != NEGINF:
 			for k in range( m ):
@@ -2529,25 +2624,25 @@ cdef class HiddenMarkovModel( Model ):
 						continue
 
 					# For each state we could go to (and emit a character)
-					# Sum up probabilities that we later normalize by 
+					# Sum up probabilities that we later normalize by
 					# probability of sequence.
 					log_transition_emission_probability_sum = NEGINF
 					for i in range( n ):
 						# For each character in the sequence
-						# Add probability that we start and get up to state k, 
+						# Add probability that we start and get up to state k,
 						# and go k->l, and emit the symbol from l, and go from l
 						# to the end.
-						log_transition_emission_probability_sum = pair_lse( 
-							log_transition_emission_probability_sum, 
-							f[i*m + k] + 
-							self.out_transition_log_probabilities[l] + 
+						log_transition_emission_probability_sum = pair_lse(
+							log_transition_emission_probability_sum,
+							f[i*m + k] +
+							self.out_transition_log_probabilities[l] +
 							e[i + li*n] + b[(i+1)*m + li] )
 
 					# Now divide by probability of the sequence to make it given
-					# this sequence, and add as this sequence's contribution to 
+					# this sequence, and add as this sequence's contribution to
 					# the expected transitions matrix's k, l entry.
 					expected_transitions[l] += cexp(
-						log_transition_emission_probability_sum - 
+						log_transition_emission_probability_sum -
 						log_sequence_probability)
 
 				for l in range( out_edges[k], out_edges[k+1] ):
@@ -2555,25 +2650,25 @@ cdef class HiddenMarkovModel( Model ):
 					if li < self.silent_start:
 						continue
 					# For each silent state we can go to on the same character
-					# Sum up probabilities that we later normalize by 
+					# Sum up probabilities that we later normalize by
 					# probability of sequence.
 					log_transition_emission_probability_sum = NEGINF
 					for i in range( n+1 ):
 						# For each row in the forward DP table (where we can
-						# have transitions to silent states) of which we have 1 
+						# have transitions to silent states) of which we have 1
 						# more than we have symbols...
 
-						# Add probability that we start and get up to state k, 
-						# and go k->l, and go from l to the end. In this case, 
-						# we use forward and backward entries from the same DP 
+						# Add probability that we start and get up to state k,
+						# and go k->l, and go from l to the end. In this case,
+						# we use forward and backward entries from the same DP
 						# table row, since no character is being emitted.
-						log_transition_emission_probability_sum = pair_lse( 
-							log_transition_emission_probability_sum, 
-							f[i*m + k] + self.out_transition_log_probabilities[l] 
+						log_transition_emission_probability_sum = pair_lse(
+							log_transition_emission_probability_sum,
+							f[i*m + k] + self.out_transition_log_probabilities[l]
 							+ b[i*m + li] )
 
 					# Now divide by probability of the sequence to make it given
-					# this sequence, and add as this sequence's contribution to 
+					# this sequence, and add as this sequence's contribution to
 					# the expected transitions matrix's k, l entry.
 					expected_transitions[l] += cexp(
 						log_transition_emission_probability_sum -
@@ -2598,17 +2693,17 @@ cdef class HiddenMarkovModel( Model ):
 					for i in range( n ):
 						# For each symbol that came out
 						# What's the weight of this symbol for that state?
-						# Probability that we emit index characters and then 
-						# transition to state l, and that from state l we  
-						# continue on to emit len(sequence) - (index + 1) 
-						# characters, divided by the probability of the 
+						# Probability that we emit index characters and then
+						# transition to state l, and that from state l we
+						# continue on to emit len(sequence) - (index + 1)
+						# characters, divided by the probability of the
 						# sequence under the model.
 						# According to http://www1.icsi.berkeley.edu/Speech/
 						# docs/HTKBook/node7_mn.html, we really should divide by
 						# sequence probability.
-						weights[i] = cexp( f[(i+1)*m + k] + b[(i+1)*m + k] - 
+						weights[i] = cexp( f[(i+1)*m + k] + b[(i+1)*m + k] -
 							log_sequence_probability )
-					
+
 						for l in range( tied_states[k], tied_states[k+1] ):
 							li = self.tied[l]
 							weights[i] += cexp( f[(i+1)*m + li] + b[(i+1)*m + li] -
@@ -2630,7 +2725,7 @@ cdef class HiddenMarkovModel( Model ):
 		free(b)
 		return log_sequence_probability
 
-	cpdef double _viterbi_summarize( self, numpy.ndarray sequence_ndarray, 
+	cpdef double _viterbi_summarize( self, numpy.ndarray sequence_ndarray,
 		numpy.ndarray distributions_ndarray ):
 		"""Python wrapper for the summarization step.
 
@@ -2652,9 +2747,9 @@ cdef class HiddenMarkovModel( Model ):
 	cdef double __viterbi_summarize( self, double* sequence, void** distributions,
 		int n, int m ) nogil:
 		"""Perform Viterbi re-estimation on the model parameters.
-		
-		The sequence is tagged using the viterbi algorithm, and both 
-		emissions and transitions are updated based on the probabilities 
+
+		The sequence is tagged using the viterbi algorithm, and both
+		emissions and transitions are updated based on the probabilities
 		in the observations.
 		"""
 
@@ -2710,7 +2805,7 @@ cdef class HiddenMarkovModel( Model ):
 					# Mark that we've visited this state
 					visited[k] = 1
 					memset(weights, 0, n*sizeof(double))
-					
+
 					# Mark that we've visited all other states in this state
 					# group.
 					for l in range( tied_states[k], tied_states[k+1] ):
@@ -2724,7 +2819,7 @@ cdef class HiddenMarkovModel( Model ):
 
 						if path[i] == k:
 							weights[j] = 1
-					
+
 						for l in range( tied_states[k], tied_states[k+1] ):
 							li = self.tied[l]
 
@@ -2742,9 +2837,9 @@ cdef class HiddenMarkovModel( Model ):
 		free(weights)
 		return log_probability
 
-	cdef void _from_summaries(self, double transition_pseudocount, 
+	cdef void _from_summaries(self, double transition_pseudocount,
 		bint use_pseudocount, double edge_inertia, double distribution_inertia ):
-		"""Update the transition matrix and emission distributions."""      
+		"""Update the transition matrix and emission distributions."""
 
 		cdef int k, i, l, li, m = len( self.states ), n, idx
 		cdef int* in_edges = self.in_edge_count
@@ -2771,7 +2866,7 @@ cdef class HiddenMarkovModel( Model ):
 			# We now have expected_transitions taking into account all sequences.
 			# And a list of all emissions, and a weighting of each emission for each
 			# state
-			# Normalize transition expectations per row (so it becomes transition 
+			# Normalize transition expectations per row (so it becomes transition
 			# probabilities)
 			# See http://stackoverflow.com/a/8904762/402891
 			# Only modifies transitions for states a transition was observed from.
@@ -2811,15 +2906,15 @@ cdef class HiddenMarkovModel( Model ):
 					for l in range( out_edges[k], out_edges[k+1] ):
 						li = self.out_transitions[l]
 						probability = ( expected_transitions[k*m + li] +
-							transition_pseudocount + 
+							transition_pseudocount +
 							self.out_transition_pseudocounts[l] * use_pseudocount)\
 							/ norm[k]
 						self.out_transition_log_probabilities[l] = _log(
-							cexp( self.out_transition_log_probabilities[l] ) * 
+							cexp( self.out_transition_log_probabilities[l] ) *
 							edge_inertia + probability * ( 1 - edge_inertia ) )
 
 				# Recalculate each transition in to that node and update the
-				# vector of in transitions appropriately 
+				# vector of in transitions appropriately
 				for l in range( in_edges[k], in_edges[k+1] ):
 					li = self.in_transitions[l]
 					if norm[li] > 0:
@@ -2827,7 +2922,7 @@ cdef class HiddenMarkovModel( Model ):
 							transition_pseudocount +
 							self.in_transition_pseudocounts[l] * use_pseudocount )\
 							/ norm[li]
-						self.in_transition_log_probabilities[l] = _log( 
+						self.in_transition_log_probabilities[l] = _log(
 							cexp( self.in_transition_log_probabilities[l] ) *
 							edge_inertia + probability * ( 1 - edge_inertia ) )
 
@@ -2838,7 +2933,7 @@ cdef class HiddenMarkovModel( Model ):
 				# waste time.
 				if visited[k] == 1:
 					continue
-				
+
 				# Mark that we've visited this state
 				visited[k] = 1
 
@@ -2848,13 +2943,13 @@ cdef class HiddenMarkovModel( Model ):
 					visited[li] = 1
 
 				# Re-estimate the emission distribution for every non-silent state.
-				# Take each emission weighted by the probability that we were in 
-				# this state when it came out, given that the model generated the 
+				# Take each emission weighted by the probability that we were in
+				# this state when it came out, given that the model generated the
 				# sequence that the symbol was part of. Take into account tied
 				# states by only training that distribution one time, since many
 				# states are pointing to the same distribution object.
 				with gil:
-					self.states[k].distribution.from_summaries( 
+					self.states[k].distribution.from_summaries(
 						inertia=distribution_inertia )
 
 		free(norm)
@@ -2866,20 +2961,20 @@ cdef class HiddenMarkovModel( Model ):
 
 		Parameters
 		----------
-		separators : tuple, optional 
+		separators : tuple, optional
 			The two separaters to pass to the json.dumps function for formatting.
 
 		indent : int, optional
 			The indentation to use at each level. Passed to json.dumps for
 			formatting.
-		
+
 		Returns
 		-------
 		json : str
 			A properly formatted JSON object.
 		"""
-		
-		model = { 
+
+		model = {
 					'class' : 'HiddenMarkovModel',
 					'name'  : self.name,
 					'start' : json.loads( self.start.to_json() ),
@@ -2895,7 +2990,7 @@ cdef class HiddenMarkovModel( Model ):
 		# Get the number of groups of edges which are tied
 		groups = []
 		n = self.n_tied_edge_groups-1
-		
+
 		# Go through each group one at a time
 		for i in xrange(n):
 			# Create an empty list for that group
@@ -2935,16 +3030,14 @@ cdef class HiddenMarkovModel( Model ):
 		model['distribution ties'] = ties
 		return json.dumps( model, separators=separators, indent=indent )
 
-			
 	@classmethod
 	def from_json( cls, s, verbose=False ):
 		"""Read in a serialized model and return the appropriate classifier.
-		
+
 		Parameters
 		----------
 		s : str
 			A JSON formatted string containing the file.
-
 		Returns
 		-------
 		model : object
@@ -2979,13 +3072,13 @@ cdef class HiddenMarkovModel( Model ):
 
 		# Add all the edges to the model
 		for start, end, probability, pseudocount, group in d['edges']:
-			model.add_transition( states[start], states[end], probability, 
+			model.add_transition( states[start], states[end], probability,
 				pseudocount, group )
 
 		# Bake the model
 		model.bake( verbose=verbose )
 		return model
-	
+
 	@classmethod
 	def from_matrix( cls, transition_probabilities, distributions, starts, ends=None,
 		state_names=None, name=None, verbose=False, merge='All' ):
@@ -3042,7 +3135,7 @@ cdef class HiddenMarkovModel( Model ):
 		ends = [ .1., .1 ]
 		state_names= [ "A", "B" ]
 
-		model = Model.from_matrix( matrix, distributions, starts, ends, 
+		model = Model.from_matrix( matrix, distributions, starts, ends,
 			state_names, name="test_model" )
 		"""
 
@@ -3072,7 +3165,7 @@ cdef class HiddenMarkovModel( Model ):
 					model.add_transition( states[i], states[j], prob )
 
 		if ends is not None:
-			# Connect states to the end of the model if a non-zero probability 
+			# Connect states to the end of the model if a non-zero probability
 			for i, prob in enumerate( ends ):
 				if prob != 0:
 					model.add_transition( states[j], model.end, prob )

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -7,6 +7,7 @@ from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 import random
+import pickle
 import numpy as np
 
 def setup():
@@ -85,13 +86,18 @@ def test_normal():
 
 	d.thaw()
 	d.fit( [ 5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4 ] )
-	assert_equal( round( d.parameters[0], 4 ), 4.9167 ) 
+	assert_equal( round( d.parameters[0], 4 ), 4.9167 )
 	assert_equal( round( d.parameters[1], 4 ), 0.7592 )
 
 	e = Distribution.from_json( d.to_json() )
 	assert_equal( e.name, "NormalDistribution" )
-	assert_equal( round( e.parameters[0], 4 ), 4.9167 ) 
+	assert_equal( round( e.parameters[0], 4 ), 4.9167 )
 	assert_equal( round( e.parameters[1], 4 ), 0.7592 )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "NormalDistribution" )
+	assert_equal( round( f.parameters[0], 4 ), 4.9167 )
+	assert_equal( round( f.parameters[1], 4 ), 0.7592 )
 
 @with_setup( setup, teardown )
 def test_uniform():
@@ -107,7 +113,7 @@ def test_uniform():
 	for i in xrange( 10 ):
 		data = np.random.randn( 100 ) * 100
 		d.fit( data )
-		assert_equal( d.parameters[0], data.min() ) 
+		assert_equal( d.parameters[0], data.min() )
 		assert_equal( d.parameters[1], data.max() )
 
 	minimum, maximum = data.min(), data.max()
@@ -153,6 +159,10 @@ def test_uniform():
 	assert_equal( e.name, "UniformDistribution" )
 	assert_equal( e.parameters, [ 0, 8 ] )
 
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "UniformDistribution" )
+	assert_equal( f.parameters, [ 0, 8 ] )
+
 @with_setup( setup, teardown )
 def test_discrete():
 	d = DiscreteDistribution( { 'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25 } )
@@ -191,7 +201,7 @@ def test_discrete():
 	d.summarize( list( "BABABABABABABABABA" ) )
 	d.from_summaries( inertia=0.75 )
 	assert_equal( d.parameters[0], { 'A': 0.125, 'B': 0.875 } )
- 
+
 	d = DiscreteDistribution( { 'A': 0.0, 'B': 1.0 } )
 	d.summarize( list( "ABABABAB" ) )
 	d.summarize( list( "ABAB" ) )
@@ -206,6 +216,10 @@ def test_discrete():
 	e = Distribution.from_json( d.to_json() )
 	assert_equal( e.name, "DiscreteDistribution" )
 	assert_equal( e.parameters[0], { 'A': 0.25, 'B': 0.75 } )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "DiscreteDistribution" )
+	assert_equal( f.parameters[0], { 'A': 0.25, 'B': 0.75 } )
 
 @with_setup( setup, teardown )
 def test_lognormal():
@@ -228,6 +242,11 @@ def test_lognormal():
 	assert_equal( e.name, "LogNormalDistribution" )
 	assert_equal( round( e.parameters[0], 4 ), 1.6167 )
 	assert_equal( round( e.parameters[1], 4 ), 0.0237 )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "LogNormalDistribution" )
+	assert_equal( round( f.parameters[0], 4 ), 1.6167 )
+	assert_equal( round( f.parameters[1], 4 ), 0.0237 )
 
 @with_setup( setup, teardown )
 def test_gamma():
@@ -252,7 +271,12 @@ def test_gamma():
 	e = Distribution.from_json( d.to_json() )
 	assert_equal( e.name, "GammaDistribution" )
 	assert_equal( round( e.parameters[0], 4 ), 31.8806 )
-	assert_equal( round( e.parameters[1], 4 ), 10.5916 )	
+	assert_equal( round( e.parameters[1], 4 ), 10.5916 )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "GammaDistribution" )
+	assert_equal( round( f.parameters[0], 4 ), 31.8806 )
+	assert_equal( round( f.parameters[1], 4 ), 10.5916 )
 
 @with_setup( setup, teardown )
 def test_exponential():
@@ -275,6 +299,10 @@ def test_exponential():
 	e = Distribution.from_json( d.to_json() )
 	assert_equal( e.name, "ExponentialDistribution" )
 	assert_equal( round( e.parameters[0], 4 ), 0.4545 )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "ExponentialDistribution" )
+	assert_equal( round( f.parameters[0], 4 ), 0.4545 )
 
 @with_setup( setup, teardown )
 def test_poisson():
@@ -302,7 +330,11 @@ def test_poisson():
 	assert_almost_equal( d.log_probability(5), -1.7403021806115442 )
 	assert_almost_equal( d.log_probability(10), -4.0100334487345126 )
 	assert_almost_equal( d.log_probability(1), -3.3905620875658995 )
-	assert_equal( d.log_probability(-1), float("-inf") )	
+	assert_equal( d.log_probability(-1), float("-inf") )
+
+	e = pickle.loads( pickle.dumps( d ) )
+	assert_equal( e.name, "PoissonDistribution" )
+	assert_equal( e.parameters[0], 5 )
 
 @with_setup( setup, teardown )
 def test_gaussian_kernel():
@@ -337,6 +369,10 @@ def test_gaussian_kernel():
 	assert_equal( round( e.log_probability( 110 ), 4 ), -2.9368 )
 	assert_equal( round( e.log_probability( 0 ), 4 ), -5.1262 )
 
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "GaussianKernelDensity" )
+	assert_equal( round( f.log_probability( 110 ), 4 ), -2.9368 )
+	assert_equal( round( f.log_probability( 0 ), 4 ), -5.1262 )
 
 @with_setup( setup, teardown )
 def test_triangular_kernel():
@@ -360,6 +396,9 @@ def test_triangular_kernel():
 	assert_equal( e.name, "TriangleKernelDensity" )
 	assert_equal( round( e.log_probability( 6.5 ), 4 ), -2.4849 )
 
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( f.name, "TriangleKernelDensity" )
+	assert_equal( round( f.log_probability( 6.5 ), 4 ), -2.4849 )
 
 @with_setup( setup, teardown )
 def test_uniform_kernel():
@@ -382,8 +421,12 @@ def test_uniform_kernel():
 	e = Distribution.from_json( d.to_json() )
 	assert_equal( e.name, "UniformKernelDensity" )
 	assert_equal( round( e.log_probability( 2.2 ), 4 ), -0.4055 )
-	assert_equal( round( e.log_probability( 6.2 ), 4 ), -2.1972 )	
-	
+	assert_equal( round( e.log_probability( 6.2 ), 4 ), -2.1972 )
+
+	f = pickle.loads( pickle.dumps( e ) )
+	assert_equal( e.name, "UniformKernelDensity" )
+	assert_equal( round( f.log_probability( 2.2 ), 4 ), -0.4055 )
+	assert_equal( round( f.log_probability( 6.2 ), 4 ), -2.1972 )
 
 @with_setup( setup, teardown )
 def test_independent():
@@ -410,7 +453,7 @@ def test_independent():
 				     ( 3, 0 ), ( 4, 0 ), ( 5, 0 ), ( 2, 20) ], inertia=0.5 )
 
 	assert_equal( round( d.parameters[0][0].parameters[0], 4 ), 4.3889 )
-	assert_equal( round( d.parameters[0][0].parameters[1], 4 ), 1.9655 ) 
+	assert_equal( round( d.parameters[0][0].parameters[1], 4 ), 1.9655 )
 
 	assert_equal( d.parameters[0][1].parameters[0], -2.5 )
 	assert_equal( d.parameters[0][1].parameters[1], 15 )
@@ -456,6 +499,14 @@ def test_independent():
 	assert_equal( e.parameters[0][1].parameters[0], -2.5 )
 	assert_equal( e.parameters[0][1].parameters[1], 15 )
 
+	f = pickle.loads( pickle.dumps ( e ) )
+	assert_equal( e.name, "IndependentComponentsDistribution" )
+
+	assert_equal( round( f.parameters[0][0].parameters[0], 4 ), 4.3889 )
+	assert_equal( round( f.parameters[0][0].parameters[1], 4 ), 1.9655 )
+
+	assert_equal( f.parameters[0][1].parameters[0], -2.5 )
+	assert_equal( f.parameters[0][1].parameters[1], 15 )
 
 def test_conditional():
 	phditis = DiscreteDistribution({ True : 0.01, False : 0.99 })
@@ -474,7 +525,7 @@ def test_monty():
 	# The actual prize is independent of the other distributions
 	prize = DiscreteDistribution( { 'A': 1./3, 'B': 1./3, 'C': 1./3 } )
 
-	# Monty is dependent on both the guest and the prize. 
+	# Monty is dependent on both the guest and the prize.
 	monty = ConditionalProbabilityTable(
 		[[ 'A', 'A', 'A', 0.0 ],
 		 [ 'A', 'A', 'B', 0.5 ],
@@ -502,7 +553,7 @@ def test_monty():
 		 [ 'C', 'B', 'C', 0.0 ],
 		 [ 'C', 'C', 'A', 0.5 ],
 		 [ 'C', 'C', 'B', 0.5 ],
-		 [ 'C', 'C', 'C', 0.0 ]], [guest, prize] ) 
+		 [ 'C', 'C', 'C', 0.0 ]], [guest, prize] )
 
 	assert_equal( monty.log_probability( ('A', 'B', 'C') ), 0. )
 	assert_equal( monty.log_probability( ('C', 'B', 'A') ), 0. )

--- a/tests/test_gmm.py
+++ b/tests/test_gmm.py
@@ -8,6 +8,7 @@ from nose.tools import assert_greater
 from nose.tools import assert_raises
 from numpy.testing import assert_almost_equal
 import random
+import pickle
 import numpy as np
 
 np.random.seed(0)
@@ -169,12 +170,12 @@ def test_initialization():
 
 	assert_raises( TypeError, GeneralMixtureModel, [ NormalDistribution( 5, 2 ), MultivariateGaussianDistribution([5, 2], [[1, 0], [0, 1]]) ] )
 	assert_raises( TypeError, GeneralMixtureModel, [ NormalDistribution( 5, 2 ), NormalDistribution ] )
-	
+
 	X = numpy.concatenate((numpy.random.randn(100, 5) + 2, numpy.random.randn(100, 5)))
 	gmm1 = GeneralMixtureModel( MultivariateGaussianDistribution, n_components=2 )
 	gmm2 = GeneralMixtureModel( MultivariateGaussianDistribution, n_components=2 )
 	assert_greater( gmm1.fit(X), gmm2.fit(X, max_iterations=1) )
-	
+
 	assert_equal( gmm1.d, 5 )
 	assert_equal( gmm2.d, 5 )
 
@@ -212,4 +213,25 @@ def test_json():
 	assert isinstance( new_multi.distributions[4], MultivariateGaussianDistribution )
 	numpy.testing.assert_array_almost_equal( gmm.weights, new_multi.weights )
 	assert isinstance( new_multi, GeneralMixtureModel )
-	
+
+@with_setup( setup_multivariate_gaussian, teardown )
+def test_pickling():
+	univariate = GeneralMixtureModel([ NormalDistribution( 5, 2 ), UniformDistribution(0, 10) ])
+
+	j_univ = pickle.dumps( univariate )
+	j_multi = pickle.dumps( gmm )
+
+	new_univ = pickle.loads( j_univ )
+	assert isinstance( new_univ.distributions[0], NormalDistribution )
+	assert isinstance( new_univ.distributions[1], UniformDistribution )
+	numpy.testing.assert_array_equal( univariate.weights, new_univ.weights )
+	assert isinstance( new_univ, GeneralMixtureModel )
+
+	new_multi = pickle.loads( j_multi )
+	assert isinstance( new_multi.distributions[0], MultivariateGaussianDistribution )
+	assert isinstance( new_multi.distributions[1], MultivariateGaussianDistribution )
+	assert isinstance( new_multi.distributions[2], MultivariateGaussianDistribution )
+	assert isinstance( new_multi.distributions[3], MultivariateGaussianDistribution )
+	assert isinstance( new_multi.distributions[4], MultivariateGaussianDistribution )
+	numpy.testing.assert_array_almost_equal( gmm.weights, new_multi.weights )
+	assert isinstance( new_multi, GeneralMixtureModel )

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -7,8 +7,11 @@ from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_raises
+import pickle
 import random
 import numpy as np
+
+np.random.seed(0)
 
 def setup():
 	pass
@@ -22,7 +25,7 @@ def test_dimension():
 	s1d1 = State( NormalDistribution( 5, 2 ) )
 	s2d1 = State( NormalDistribution( 0, 1 ) )
 	s3d1 = State( UniformDistribution( 0, 10 ) )
-	
+
 	hmmd1 = HiddenMarkovModel()
 
 	assert_equal( hmmd1.d, 0 )
@@ -44,7 +47,7 @@ def test_dimension():
 	s1d3 = State( MultivariateGaussianDistribution([1, 4, 3], [[3, 0, 1],[0, 3, 0],[1, 0, 3]]) )
 	s2d3 = State( MultivariateGaussianDistribution([7, 7, 7], [[1, 3, 1],[3, 5, 0],[1, 0, 3]]) )
 	s3d3 = State( IndependentComponentsDistribution([ UniformDistribution(0, 10), UniformDistribution(0, 10), UniformDistribution(0, 10) ]) )
-	
+
 	hmmd3 = HiddenMarkovModel()
 
 	assert_equal( hmmd3.d, 0 )
@@ -61,7 +64,7 @@ def test_dimension():
 	hmmd3.bake()
 
 	assert_equal( hmmd3.d, 3 )
-	
+
 	sbd1 = State( UniformDistribution( 0, 10 ) )
 	sbd3 = State( MultivariateGaussianDistribution([1, 4, 3], [[3, 0, 1],[0, 3, 0],[1, 0, 3]]) )
 
@@ -74,3 +77,27 @@ def test_dimension():
 	hmmb.add_transition( sbd3, sbd3, 0.5 )
 
 	assert_raises( ValueError, hmmb.bake )
+
+@with_setup( setup, teardown )
+def test_serialization():
+	s1 = State( MultivariateGaussianDistribution( [1, 4], [[.1, 0], [0, 1]] ) )
+	s2 = State( MultivariateGaussianDistribution( [-1, 1], [[1, 0], [0, 7]] ) )
+	s3 = State( MultivariateGaussianDistribution( [3, 5], [[.5, 0], [0, 6]] ) )
+
+	hmm1 = HiddenMarkovModel()
+
+	hmm1.add_transition( hmm1.start, s1, 1 )
+	hmm1.add_transition( s1, s1, 0.8 )
+	hmm1.add_transition( s1, s2, 0.2 )
+	hmm1.add_transition( s2, s2, 0.9 )
+	hmm1.add_transition( s2, s3, 0.1 )
+	hmm1.add_transition( s3, s3, 0.95 )
+	hmm1.add_transition( s3, hmm1.end, 0.05 )
+
+	hmm1.bake()
+
+	hmm2 = pickle.loads(pickle.dumps(hmm1))
+
+	for i in range(10):
+		sequence = hmm1.sample(10)
+		assert_almost_equal(hmm1.log_probability(sequence), hmm2.log_probability(sequence))

--- a/tests/test_markov_chain.py
+++ b/tests/test_markov_chain.py
@@ -8,6 +8,7 @@ from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_raises
 import random
+import pickle
 import numpy as np
 
 def setup():
@@ -57,7 +58,7 @@ def setup():
 		 [ 'D', 'B', 'A', 0.35 ], [ 'D', 'B', 'B', 0.5 ], [ 'D', 'B', 'C', 0.1 ], [ 'D', 'B', 'D', 0.05 ],
 		 [ 'D', 'C', 'A', 0.1 ], [ 'D', 'C', 'B', 0.45 ], [ 'D', 'C', 'C', 0.0 ], [ 'D', 'C', 'D', 0.45 ],
 		 [ 'D', 'D', 'A', 0.2 ], [ 'D', 'D', 'B', 0.1 ], [ 'D', 'D', 'C', 0.1 ], [ 'D', 'D', 'D', 0.6 ]],
-		 [ zeroth_dist, first_dist ] ) 
+		 [ zeroth_dist, first_dist ] )
 
 def teardown():
 	pass
@@ -90,37 +91,37 @@ def test_second_dist():
 	assert_almost_equal( second_dist.log_probability( ('A', 'A', 'A') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'B', 'A') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'B', 'C') ), -0.162518929498 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('A', 'C', 'C') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'C', 'D') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'D', 'B') ), -0.916290731874 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'D', 'D') ), -2.99573227355 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('B', 'A', 'B') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'A', 'D') ), -0.69314718056 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'B', 'B') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'B', 'D') ), -float('inf') )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('B', 'C', 'A') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'C', 'B') ), -1.0498221245 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'D', 'D') ), -0.916290731874 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'D', 'B') ), -2.30258509299 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('C', 'A', 'A') ), -1.60943791243 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'A', 'B') ), -1.20397280433 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'B', 'C') ), -float('inf') )
 	assert_almost_equal( second_dist.log_probability( ('C', 'B', 'A') ), -1.0498221245 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('C', 'C', 'D') ), -1.89711998489 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'C', 'B') ), -float('inf') )
 	assert_almost_equal( second_dist.log_probability( ('C', 'D', 'A') ), -0.223143551314 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'D', 'C') ), -2.99573227355 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('D', 'A', 'D') ), -float('inf') )
 	assert_almost_equal( second_dist.log_probability( ('D', 'A', 'A') ), -0.69314718056 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'B', 'D') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'B', 'C') ), -2.30258509299 )
-	
+
 	assert_almost_equal( second_dist.log_probability( ('D', 'C', 'A') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'C', 'D') ), -0.798507696218 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'D', 'D') ), -0.510825623766 )
@@ -183,9 +184,9 @@ def test_first_log_probability():
 
 	assert_almost_equal( second_chain.log_probability( list('ABDBCCDC') ), -18.9960448889 )
 	assert_almost_equal( second_chain.log_probability( list('DACCBDCB') ), -float('inf') )
-	
+
 	assert_almost_equal( second_chain.log_probability( list('BCCCACBDBDBABACD') ), -29.1792463442 )
-	
+
 	assert_almost_equal( second_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -float('inf') )
 
 # if summarize and from summaries work, so does fit
@@ -326,19 +327,28 @@ def test_summarize_with_weights_with_inertia():
 	assert_almost_equal( first_chain.log_probability( list('CB') ), -2.70099965753 )
 	assert_almost_equal( first_chain.log_probability( list('DB') ), -2.596587547 )
 	assert_almost_equal( first_chain.log_probability( list('DC') ), -2.43824119019 )
-	
+
 	assert_almost_equal( first_chain.log_probability( list('ABDD') ), -6.77853581842 )
 	assert_almost_equal( first_chain.log_probability( list('CCCB') ), -5.75946483735 )
 	assert_almost_equal( first_chain.log_probability( list('CCBD') ), -6.05149283556 )
 	assert_almost_equal( first_chain.log_probability( list('ACAC') ), -6.10013721195 )
-	
+
 	assert_almost_equal( first_chain.log_probability( list('ABDBCCDC') ), -11.2181867683 )
 	assert_almost_equal( first_chain.log_probability( list('DACCBDCB') ), -11.6681121956 )
-	
+
 	assert_almost_equal( first_chain.log_probability( list('BCCCACBDBDBABACD') ), -25.0365515667 )
-	
+
 	assert_almost_equal( first_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -45.1660985662 )
 
 @with_setup( setup, teardown )
 def test_raise_errors():
 	pass
+
+@with_setup( setup, teardown )
+def test_pickling():
+	chain1 = MarkovChain([ zeroth_dist, first_dist ])
+
+	chain2 = pickle.loads( pickle.dumps( chain1 ) )
+
+	assert_almost_equal( chain1.log_probability( list('BCCCACBDBDBABACD') ),
+	                     chain2.log_probability( list('BCCCACBDBDBABACD') ) )

--- a/tests/test_naive_bayes.py
+++ b/tests/test_naive_bayes.py
@@ -8,6 +8,7 @@ from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_raises
 import random
+import pickle
 import numpy as np
 
 def setup_univariate():
@@ -16,7 +17,7 @@ def setup_univariate():
 	global univariate
 
 	normal = NormalDistribution( 5, 2 )
-	uniform = UniformDistribution( 0, 10 )	
+	uniform = UniformDistribution( 0, 10 )
 	univariate = NaiveBayes([ normal, uniform ])
 
 def setup_multivariate():
@@ -33,10 +34,10 @@ def setup_hmm():
 	global dumb
 	global fair
 	global smart
-	
+
 	rigged = State( DiscreteDistribution({ 'H': 0.8, 'T': 0.2 }) )
 	unrigged = State( DiscreteDistribution({ 'H': 0.5, 'T':0.5 }) )
-	
+
 	dumb = HiddenMarkovModel()
 	dumb.start = rigged
 	dumb.add_transition( rigged, rigged, 1 )
@@ -114,7 +115,7 @@ def test_hmms():
 	assert_almost_equal( dumb.log_probability( list('HHHH') ), -0.8925742052568388 )
 	assert_almost_equal( dumb.log_probability( list('THHH') ), -2.2788685663767296 )
 	assert_almost_equal( dumb.log_probability( list('TTTT') ), -6.437751649736401 )
-	
+
 	assert_almost_equal( fair.log_probability( list('H') ), -0.6931471805599453 )
 	assert_almost_equal( fair.log_probability( list('T') ), -0.6931471805599453 )
 	assert_almost_equal( fair.log_probability( list('HHHH') ), -2.772588722239781 )
@@ -152,29 +153,29 @@ def test_univariate_log_proba():
 
 	assert_almost_equal( logs[0][0], -0.40634848776410526 )
 	assert_almost_equal( logs[0][1], -1.0968478669939319 )
-	
+
 	assert_almost_equal( logs[1][0], -0.60242689998689203 )
 	assert_almost_equal( logs[1][1], -0.79292627921671865 )
-	
+
 	assert_almost_equal( logs[2][0], -1.5484819556996032 )
 	assert_almost_equal( logs[2][1], -0.23898133492942986 )
-	
+
 	assert_almost_equal( logs[3][0], 0.0 )
 	assert_almost_equal( logs[3][1], -float('inf') )
-	
+
 @with_setup( setup_multivariate, teardown )
 def test_multivariate_log_proba():
 	logs = multivariate.predict_log_proba(np.array([[ 5, 5 ], [ 2, 9 ], [ 10, 7 ], [ -1 ,7 ]]))
 
 	assert_almost_equal( logs[0][0], -0.11837282271439786 )
 	assert_almost_equal( logs[0][1], -2.1925187617325435 )
-	
+
 	assert_almost_equal( logs[1][0], -4.1910993250497741 )
 	assert_almost_equal( logs[1][1], -0.015245264067919706 )
-	
+
 	assert_almost_equal( logs[2][0], -5.1814895400206806 )
 	assert_almost_equal( logs[2][1], -0.0056354790388262188 )
-	
+
 	assert_almost_equal( logs[3][0], 0.0 )
 	assert_almost_equal( logs[3][1], -float('inf') )
 
@@ -185,19 +186,19 @@ def test_hmm_log_proba():
 	assert_almost_equal( logs[0][0], -0.89097292388986515 )
 	assert_almost_equal( logs[0][1], -1.3609765531356006 )
 	assert_almost_equal( logs[0][2], -1.0986122886681096 )
-	
+
 	assert_almost_equal( logs[1][0], -0.93570553121744293 )
 	assert_almost_equal( logs[1][1], -1.429425687080494 )
 	assert_almost_equal( logs[1][2], -0.9990078376167526 )
-	
+
 	assert_almost_equal( logs[2][0], -3.9007882563128864 )
 	assert_almost_equal( logs[2][1], -0.23562532881626597 )
 	assert_almost_equal( logs[2][2], -1.6623251045711958 )
-	
+
 	assert_almost_equal( logs[3][0], -3.1703366478831185 )
 	assert_almost_equal( logs[3][1], -0.49261403211260379 )
 	assert_almost_equal( logs[3][2], -1.058478108940049 )
-	
+
 	assert_almost_equal( logs[4][0], -1.3058441172130273 )
 	assert_almost_equal( logs[4][1], -1.4007102236822906 )
 	assert_almost_equal( logs[4][2], -0.7284958836972919 )
@@ -208,29 +209,29 @@ def test_univariate_proba():
 
 	assert_almost_equal( probs[0][0], 0.66607800693933361 )
 	assert_almost_equal( probs[0][1], 0.33392199306066628 )
-	
+
 	assert_almost_equal( probs[1][0], 0.54748134004225524 )
 	assert_almost_equal( probs[1][1], 0.45251865995774476 )
-	
+
 	assert_almost_equal( probs[2][0], 0.21257042033580209 )
 	assert_almost_equal( probs[2][1], 0.78742957966419791 )
-	
+
 	assert_almost_equal( probs[3][0], 1.0 )
 	assert_almost_equal( probs[3][1], 0.0 )
-	
+
 @with_setup( setup_multivariate, teardown )
 def test_multivariate_proba():
 	probs = multivariate.predict_proba(np.array([[ 5, 5 ], [ 2, 9 ], [ 10, 7 ], [ -1, 7 ]]))
 
 	assert_almost_equal( probs[0][0], 0.88836478829527532 )
 	assert_almost_equal( probs[0][1], 0.11163521170472469 )
-	
+
 	assert_almost_equal( probs[1][0], 0.015129643331582699 )
 	assert_almost_equal( probs[1][1], 0.98487035666841727 )
-	
+
 	assert_almost_equal( probs[2][0], 0.0056196295140261846 )
 	assert_almost_equal( probs[2][1], 0.99438037048597383 )
-	
+
 	assert_almost_equal( probs[3][0], 1.0 )
 	assert_almost_equal( probs[3][1], 0.0 )
 
@@ -241,19 +242,19 @@ def test_hmm_proba():
 	assert_almost_equal( probs[0][0], 0.41025641025641024 )
 	assert_almost_equal( probs[0][1], 0.25641025641025639 )
 	assert_almost_equal( probs[0][2], 0.33333333333333331 )
-	
+
 	assert_almost_equal( probs[1][0], 0.39230898163446098 )
 	assert_almost_equal( probs[1][1], 0.23944639992337707 )
 	assert_almost_equal( probs[1][2], 0.36824461844216183 )
-	
+
 	assert_almost_equal( probs[2][0], 0.020225961918306088 )
 	assert_almost_equal( probs[2][1], 0.79007663743383105 )
 	assert_almost_equal( probs[2][2], 0.18969740064786292 )
-	
+
 	assert_almost_equal( probs[3][0], 0.041989459861032523 )
 	assert_almost_equal( probs[3][1], 0.61102706038265642 )
 	assert_almost_equal( probs[3][2], 0.346983479756311 )
-	
+
 	assert_almost_equal( probs[4][0], 0.27094373022369794 )
 	assert_almost_equal( probs[4][1], 0.24642188711704707 )
 	assert_almost_equal( probs[4][2], 0.48263438265925512 )
@@ -266,7 +267,7 @@ def test_univariate_prediction():
 	assert_equal( predicts[1], 0 )
 	assert_equal( predicts[2], 1 )
 	assert_equal( predicts[3], 0 )
-	
+
 @with_setup( setup_multivariate, teardown )
 def test_multivariate_prediction():
 	predicts = multivariate.predict(np.array([[ 5, 5 ], [ 2, 9 ], [ 10, 7 ], [ -1, 7 ]]))
@@ -285,7 +286,7 @@ def test_hmm_prediction():
 	assert_equal( predicts[2], 1 )
 	assert_equal( predicts[3], 1 )
 	assert_equal( predicts[4], 2 )
-	
+
 @with_setup( setup_univariate, teardown )
 def test_univariate_fit():
 	X = np.array([ 5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4, 0, 0, 1, 9, 8, 2, 0, 1, 1, 8, 10, 0 ])
@@ -306,7 +307,7 @@ def test_univariate_fit():
 	assert_almost_equal( logs[2][1], -8.7356310092268075e-06 )
 	assert_almost_equal( logs[3][0], 0.0 )
 	assert_almost_equal( logs[3][1], -float('inf') )
-	
+
 	# test univariate probabilities
 	probs = univariate.predict_proba( data )
 
@@ -469,6 +470,25 @@ def test_raise_errors():
 	assert_raises( ValueError, multivariate.predict, [[ 1, 2, 3 ], [ 4, 5, 6 ]] )
 
 	# special case for hmm's
+
+@with_setup( setup_all, teardown )
+def test_pickling():
+	j_univ = pickle.dumps(univariate)
+	j_multi = pickle.dumps(multivariate)
+
+	new_univ = pickle.loads( j_univ )
+	assert isinstance( new_univ.models[0], NormalDistribution )
+	assert isinstance( new_univ.models[1], UniformDistribution )
+	numpy.testing.assert_array_equal( univariate.weights, new_univ.weights )
+	assert isinstance( new_univ, NaiveBayes )
+
+	new_multi = pickle.loads( j_multi )
+	assert isinstance( new_multi.models[0], MultivariateGaussianDistribution )
+	assert isinstance( new_multi.models[1], IndependentComponentsDistribution )
+	numpy.testing.assert_array_equal( multivariate.weights, new_multi.weights )
+	assert isinstance( new_multi, NaiveBayes )
+
+	# hmms throw an error if the same hmm is recreated in the same space
 
 @with_setup( setup_all, teardown )
 def test_json():


### PR DESCRIPTION
This PR follows up issue https://github.com/jmschrei/pomegranate/issues/153

It adds the methods `__getstate__` and `__getstate__` to GeneralMixtureModel and HiddenMarkovModel to make them 'picklable'.

I had to modify the automatic name generation of State to make sure we always have unique state names (unless overriden by user). Otherwise, deserialization fails on name collision. This fix relies on the uuid library which is part of python standard library.
There are two very simple regression tests to check that pickle doesn't crash. I didn't test if the reloaded value is identical to the original one because json tests should be sufficient. And I have no clue how to properly compare the objects :-) .