### PR TITLE
bayesian network structure learning

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -2,10 +2,7 @@
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
 import itertools as it
-<<<<<<< HEAD
 import json
-=======
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 
 import numpy
 cimport numpy
@@ -540,7 +537,6 @@ cdef class BayesianNetwork( GraphModel ):
 	def impute( self, *args, **kwargs ):
 		raise Warning("method 'impute' has been depricated, please use 'predict' instead") 
 
-<<<<<<< HEAD
 	def to_json( self, separators=(',', ' : '), indent=4 ):
 		"""Serialize the model to a JSON.
 
@@ -620,8 +616,6 @@ cdef class BayesianNetwork( GraphModel ):
 		print model.structure
 		return model
 
-=======
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 	@classmethod
 	def from_structure( cls, X, structure, weights=None, name=None ):
 		"""Return a Bayesian network from a predefined structure.
@@ -678,40 +672,26 @@ cdef class BayesianNetwork( GraphModel ):
 						nodes[i] = ConditionalProbabilityTable.from_samples(X[:,parents+(i,)], 
 							parents=[nodes[parent] for parent in parents], 
 							weights=weights_ndarray)
-<<<<<<< HEAD
 						break
 			else:
 				break
-=======
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 
 		states = [State(node, name=str(i)) for i, node in enumerate(nodes)]
 
 		model = BayesianNetwork(name=name)
-<<<<<<< HEAD
 		model.add_nodes(*states)
 
 		for i, parents in enumerate(structure):
 			d = states[i].distribution
 
 			for parent in parents:
-=======
-		model.add_nodes(*nodes)
-
-		for i, node in enumerate(parents):
-			for parent in node:
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 				model.add_edge(states[parent], states[i])
 
 		model.bake()
 		return model
 
 	@classmethod
-<<<<<<< HEAD
 	def from_samples( cls, X, weights=None, algorithm='chow-liu', root=0, pseudocount=0.0 ):
-=======
-	def from_samples( cls, X, weights=None, algorithm='chow-liu', root=1, pseudocount=0.0 ):
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 		"""Learn the structure of the network from data.
 
 		Find the structure of the network from data using a Bayesian structure
@@ -746,7 +726,6 @@ cdef class BayesianNetwork( GraphModel ):
 			The learned BayesianNetwork.
 		"""
 
-<<<<<<< HEAD
 		X = numpy.array(X)
 		n, d = X.shape
 
@@ -781,36 +760,6 @@ cdef tuple discrete_chow_liu_tree(numpy.ndarray X_ndarray, numpy.ndarray weights
 	cdef double* weights = <double*> weights_ndarray.data
 	cdef int* key_count = <int*> key_count_ndarray.data
 
-=======
-		cdef numpy.ndarray X_ndarray = numpy.array(X, dtype='int32')
-		cdef numpy.ndarray weights_ndarray
-		cdef numpy.ndarray key_count
-
-		cdef int n = X_ndarray.shape[0], d = X_ndarray.shape[1], max_keys
-
-		key_count = numpy.array([numpy.unique(X_ndarray[:,i]).shape[0] for i in range(d) ], dtype='int32')
-		max_keys = key_count.max()
-
-		cdef int* X_ptr = <int*> X_ndarray.data
-		cdef double* weights_ptr
-		cdef int* key_count_ptr = <int*> key_count.data
-
-		if weights is None:
-			weights_ndarray = numpy.ones(X.shape[0], dtype='float64')
-		else:
-			weights_ndarray = numpy.array(weights, dtype='float64')
-
-		weights_ptr = <double*> weights_ndarray.data
-
-		if algorithm == 'chow-liu':
-			structure = discrete_chow_liu_tree(X_ptr, weights_ptr, n, d, key_count_ptr, max_keys, pseudocount)
-		
-		return BayesianNetwork.from_structure(X, structure, weights=weights)
-
-
-cdef double discrete_chow_liu_tree(int* X, double* weights, int n, int d, int* key_count, int max_keys, double pseudocount):
-	cdef int i, j, k, l, lj, lk, Xj, Xk, xj, xk
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 	cdef numpy.ndarray mutual_info_ndarray = numpy.zeros((d, d), dtype='float64')
 	cdef double* mutual_info = <double*> mutual_info_ndarray.data
 
@@ -820,12 +769,9 @@ cdef double discrete_chow_liu_tree(int* X, double* weights, int n, int d, int* k
 
 	for j in range(d):
 		for k in range(j):
-<<<<<<< HEAD
 			if j == k:
 				continue
 
-=======
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 			lj = key_count[j]
 			lk = key_count[k]
 
@@ -846,7 +792,6 @@ cdef double discrete_chow_liu_tree(int* X, double* weights, int n, int d, int* k
 
 			for xj in range(lj):
 				for xk in range(lk):
-<<<<<<< HEAD
 					mutual_info[j*d + k] -= joint_count[xj*lk+xk] * _log( 
 						joint_count[xj*lk+xk] / (marg_j[xj] * marg_k[xk]))
 					mutual_info[k*d + j] = mutual_info[j*d + k]
@@ -874,28 +819,6 @@ cdef double discrete_chow_liu_tree(int* X, double* weights, int n, int d, int* k
 	free(marg_k)
 	free(joint_count)
 	return tuple(structure)
-=======
-					mutual_info[j*d + k] += joint_count[xj*lk+xk] * _log( joint_count[xj*lk+xk] / (marg_j[xj] * marg_k[xk]))
-
-	cdef int* parents = <int*> calloc(d, sizeof(int))
-	memset(parents, -1, d*sizeof(int))
-	cdef int argmax, m = 0
-
-	while True:
-		argmax = mutual_info_ndarray.argmax()
-		mutual_info[argmax] = 0
-		i, j = argmax / d, argmax % d
-
-		if parents[j] != -1:
-			parents[j] == i
-
-
-
-
-
-
-	
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 
 
 

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -342,7 +342,8 @@ cdef class GraphModel( Model ):
 		Another name for a node.
 		"""
 
-		self.add_nodes( states )
+		for state in states:
+			self.add_state(state)
 
 	def add_edge( self, a, b ):
 		"""
@@ -468,7 +469,7 @@ cdef class State( object ):
 		Return a hard copy of this state.
 		"""
 
-		return State( **self.__dict__ )
+		return State( distribution=self.distribution.copy(), name=self.name )
 
 	def to_json( self, separators=(',', ' : '), indent=4 ):
 		"""

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -99,21 +99,23 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	cdef double* values
 	cdef double* counts
 	cdef double* marginal_counts
-	cdef int m, n, k
+	cdef int n, k
 	cdef int* idxs
 	cdef int* marginal_idxs
 	cdef public list parents, parameters
 	cdef public object keymap
 	cdef public object marginal_keymap
+	cdef public int m
 	cdef void __summarize( self, items, double [:] weights )
 
 cdef class JointProbabilityTable( MultivariateDistribution ):
 	cdef double* values
 	cdef double* counts
 	cdef double count
-	cdef int m, n, k
+	cdef int n, k
 	cdef int* idxs
 	cdef public list parents, parameters
 	cdef public object keymap
 	cdef public object marginal_keymap
+	cdef public int m
 	cdef void __summarize( self, items, double [:] weights )

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -2711,11 +2711,7 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 		keys = [numpy.unique(X[:,i]) for i in range(d)]
 
 		table = []
-<<<<<<< HEAD
 		for key in it.product(*keys):
-=======
-		for key in it.product(keys, repeat=d):
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 			table.append( list(key) + [1./len(keys[-1]),] )
 
 		d = ConditionalProbabilityTable(table, parents)
@@ -2985,11 +2981,7 @@ cdef class JointProbabilityTable( MultivariateDistribution ):
 		m = numpy.prod([k.shape[0] for k in keys])
 
 		table = []
-<<<<<<< HEAD
 		for key in it.product(*keys):
-=======
-		for key in it.product(keys, repeat=d):
->>>>>>> 32a242cf35fb355397bb2e6058436af8ef93d60b
 			table.append( list(key) + [1./m,] )
 
 		d = ConditionalProbabilityTable(table, parents)

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -1047,7 +1047,7 @@ cdef class HiddenMarkovModel( GraphModel ):
 				keys.extend( state.distribution.keys() )
 			self.keymap = { key: i for i, key in enumerate(set(keys)) }
 			for state in states:
-				state.distribution.encode( tuple(set(keys)) )
+				state.distribution.bake( tuple(set(keys)) )
 
 		self.d = dist.d
 		self.multivariate = self.d > 1


### PR DESCRIPTION
Implements the backend to support structure learning algorithms efficiently by converting all observations into a set of integer keys and operating at the C level. Currently only supports chow-liu tree learning. 