### PR TITLE
change deprecated encode to bake in naive bayes

### DIFF
--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -160,7 +160,7 @@ cdef class NaiveBayes( Model ):
 				keys.extend( d.keys() )
 			self.keymap = { key: i for i, key in enumerate(set(keys)) }
 			for d in self.distributions:
-				d.encode( tuple(set(keys)) )
+				d.bake( tuple(set(keys)) )
 
 	def __reduce__( self ):
 		return self.__class__, (self.distributions, self.weights)


### PR DESCRIPTION
found another place encode was erroneously used, so i fixed it.