### PR TITLE
FIX Bayes Net belief propogation

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -466,6 +466,8 @@ cdef class BayesianNetwork( GraphModel ):
 		for state in self.states:
 			state.distribution.from_summaries(inertia)
 
+		self.bake()
+
 	def fit( self, items, weights=None, inertia=0.0 ):
 		"""Fit the model to data using MLE estimates.
 
@@ -526,22 +528,18 @@ cdef class BayesianNetwork( GraphModel ):
 		if self.d == 0:
 			raise ValueError("must bake model before using impute")
 
-		for i in range( len(items) ):
+		for i in range(len(items)):
 			obs = {}
 
-			for j, state in enumerate( self.states ):
+			for j, state in enumerate(self.states):
 				item = items[i][j]
 
-				if item not in (None, 'nan'):
-					try:
-						if not numpy.isnan(item):
-							obs[ state.name ] = item
-					except:
-						obs[ state.name ] = item
+				if item is not None:
+					obs[state.name] = item
 
-			imputation = self.predict_proba( obs  )
+			imputation = self.predict_proba(obs)
 
-			for j in range( len( self.states) ):
+			for j in range(len(self.states)):
 				items[i][j] = imputation[j].mle()
 
 		return items 

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -41,6 +41,7 @@ DEF NEGINF = float("-inf")
 DEF INF = float("inf")
 DEF SQRT_2_PI = 2.50662827463
 DEF LOG_2_PI = 1.83787706641
+eps = numpy.finfo(numpy.float64).eps
 
 def log(value):
 	"""Return the natural log of the given value, or - nf if the value is 0."""
@@ -1297,18 +1298,24 @@ cdef class DiscreteDistribution( Distribution ):
 
 	def __mul__( self, other ):
 		"""Multiply this by another distribution sharing the same keys."""
-
-		assert set( self.keys() ) == set( other.keys() )
+		assert set(self.keys()) == set(other.keys())
 		distribution, total = {}, 0.0
 
 		for key in self.keys():
-			distribution[key] = self.log_probability( key ) + other.log_probability( key )
-			total += cexp( distribution[key] )
+			x, y = self.probability(key), other.probability(key)
+			distribution[key] = (x + eps) * (y + eps)
+			total += distribution[key]
 
 		for key in self.keys():
-			distribution[key] = cexp( distribution[key] ) / total
+			distribution[key] /= total
 
-		return DiscreteDistribution( distribution )
+			if distribution[key] <= eps / total:
+				distribution[key] = 0.0
+			elif distribution[key] >= 1 - eps / total:
+				distribution[key] = 1.0
+
+		return DiscreteDistribution(distribution)
+
 
 	def equals( self, other ):
 		"""Return if the keys and values are equal"""
@@ -2544,7 +2551,7 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 
 			log_probability[i] = self.values[idx]
 
-	def joint( self, neighbor_values=None ):
+	def joint(self, neighbor_values=None):
 		"""
 		This will turn a conditional probability table into a joint
 		probability table. If the data is already a joint, it will likely
@@ -2553,25 +2560,25 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 		"""
 
 		neighbor_values = neighbor_values or self.parents+[None]
-		if isinstance( neighbor_values, dict ):
-			neighbor_values = [ neighbor_values.get( p, None ) for p in self.parents + [self]]
+		if isinstance(neighbor_values, dict):
+			neighbor_values = [neighbor_values.get(p, None) for p in self.parents + [self]]
 
 		table, total = [], 0
 		for key, idx in self.keymap.items():
 			scaled_val = self.values[idx]
 
-			for j, k in enumerate( key ):
+			for j, k in enumerate(key):
 				if neighbor_values[j] is not None:
-					scaled_val += neighbor_values[j].log_probability( k )
+					scaled_val += neighbor_values[j].log_probability(k)
 
 			scaled_val = cexp(scaled_val)
 			total += scaled_val
 			table.append( key + (scaled_val,) )
 
-		table = [ row[:-1] + (row[-1] / total,) for row in table ]
-		return JointProbabilityTable( table, self.parents )
+		table = [row[:-1] + (row[-1] / total if total > 0 else 1. / self.n,) for row in table]
+		return JointProbabilityTable(table, self.parents)
 
-	def marginal( self, neighbor_values=None ):
+	def marginal(self, neighbor_values=None):
 		"""
 		Calculate the marginal of the CPT. This involves normalizing to turn it
 		into a joint probability table, and then summing over the desired
@@ -2579,11 +2586,11 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 		"""
 
 		# Convert from a dictionary to a list if necessary
-		if isinstance( neighbor_values, dict ):
-			neighbor_values = [ neighbor_values.get( d, None ) for d in self.parents ]
+		if isinstance(neighbor_values, dict):
+			neighbor_values = [neighbor_values.get(d, None) for d in self.parents]
 
 		# Get the index we're marginalizing over
-		i = -1 if neighbor_values == None else neighbor_values.index( None )
+		i = -1 if neighbor_values == None else neighbor_values.index(None)
 		return self.joint(neighbor_values).marginal(i)
 
 	def summarize(self, items, weights=None):
@@ -2642,7 +2649,7 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 	def from_summaries( self, double inertia=0.0, double pseudocount=0.0 ):
 		"""Update the parameters of the distribution using sufficient statistics."""
 
-		cdef int i, k
+		cdef int i, k, idx
 
 		with nogil:
 			for i in range(self.n):
@@ -2659,7 +2666,8 @@ cdef class ConditionalProbabilityTable( MultivariateDistribution ):
 					self.values[i] = -_log(self.k)
 
 		for i in range(self.n):
-			self.parameters[0][i][-1] = cexp(self.values[i])
+			idx = self.keymap[tuple(self.parameters[0][i][:-1])]
+			self.parameters[0][i][-1] = cexp(self.values[idx])
 
 		self.clear_summaries()
 
@@ -2845,33 +2853,34 @@ cdef class JointProbabilityTable( MultivariateDistribution ):
 		"""
 
 		if isinstance(neighbor_values, dict):
-			neighbor_values = [ neighbor_values.get( d, None ) for d in self.parents ]
+			neighbor_values = [neighbor_values.get(d, None) for d in self.parents]
 		
 		if isinstance(neighbor_values, list):
 			wrt = neighbor_values.index(None)
 
 		# Determine the keys for the respective parent distribution
-		d = { k: 0 for k in self.parents[wrt].keys() }
+		d = {k: 0 for k in self.parents[wrt].keys()}
 		total = 0.0
 
 		for key, idx in self.keymap.items():
 			logp = self.values[idx]
 
 			if neighbor_values is not None:
-				for j, k in enumerate( key ):
+				for j, k in enumerate(key):
 					if j == wrt:
 						continue
 
-					logp += neighbor_values[j].log_probability( k )
+					logp += neighbor_values[j].log_probability(k)
 
-			p = cexp( logp )
-			d[ key[wrt] ] += p
+			p = cexp(logp)
+			d[key[wrt]] += p
 			total += p
 
 		for key, value in d.items():
-			d[key] = value / total
+			d[key] = value / total if total > 0 else 1. / len(self.parents[wrt].keys())
 
 		return DiscreteDistribution(d)
+
 
 	def summarize( self, items, weights=None ):
 		"""Summarize the data into sufficient statistics to store."""

--- a/tests/test_bayes_net.py
+++ b/tests/test_bayes_net.py
@@ -8,14 +8,19 @@ These are unit tests for the Bayesian network part of pomegranate.
 
 from __future__ import division
 
-from pomegranate import (DiscreteDistribution,
-                         ConditionalProbabilityTable,
-                         State, BayesianNetwork)
+from pomegranate import DiscreteDistribution
+from pomegranate import ConditionalProbabilityTable
+from pomegranate import State
+from pomegranate import BayesianNetwork
+
 from nose.tools import with_setup
 from nose.tools import assert_equal
 from nose.tools import assert_raises
+from nose.tools import assert_almost_equal
+
 import random
 import numpy as np
+import sys
 
 nan = np.nan
 
@@ -224,20 +229,20 @@ def teardown():
 
 @with_setup(setup_titanic, teardown)
 def test_titanic_network():
-    assert_equal(passenger.log_probability('survive'), np.log(0.6))
-    assert_equal(passenger.log_probability('survive'), np.log(0.6))
+    assert_almost_equal(passenger.log_probability('survive'), np.log(0.6))
+    assert_almost_equal(passenger.log_probability('survive'), np.log(0.6))
 
-    assert_equal(gender.log_probability(('survive', 'male')),   float("-inf"))
-    assert_equal(gender.log_probability(('survive', 'female')), 0.0)
-    assert_equal(gender.log_probability(('perish', 'male')),    0.0)
-    assert_equal(gender.log_probability(('perish', 'female')),  float("-inf"))
+    assert_almost_equal(gender.log_probability(('survive', 'male')),   float("-inf"))
+    assert_almost_equal(gender.log_probability(('survive', 'female')), 0.0)
+    assert_almost_equal(gender.log_probability(('perish', 'male')),    0.0)
+    assert_almost_equal(gender.log_probability(('perish', 'female')),  float("-inf"))
 
-    assert_equal(tclass.log_probability(('survive', 'first')), float("-inf"))
-    assert_equal(tclass.log_probability(('survive', 'second')), 0.0)
-    assert_equal(tclass.log_probability(('survive', 'third')), float("-inf"))
-    assert_equal(tclass.log_probability(('perish', 'first')), 0.0)
-    assert_equal(tclass.log_probability(('perish', 'second')), float("-inf"))
-    assert_equal(tclass.log_probability(('perish', 'third')), float("-inf"))
+    assert_almost_equal(tclass.log_probability(('survive', 'first')), float("-inf"))
+    assert_almost_equal(tclass.log_probability(('survive', 'second')), 0.0)
+    assert_almost_equal(tclass.log_probability(('survive', 'third')), float("-inf"))
+    assert_almost_equal(tclass.log_probability(('perish', 'first')), 0.0)
+    assert_almost_equal(tclass.log_probability(('perish', 'second')), float("-inf"))
+    assert_almost_equal(tclass.log_probability(('perish', 'third')), float("-inf"))
 
 
 @with_setup(setup_titanic, teardown)
@@ -268,8 +273,8 @@ def test_guest_titanic():
 
 @with_setup(setup_huge_monty, teardown)
 def test_huge_monty():
-    assert_equal(huge_monty.log_probability(('A', 'A', 'C')), np.log(0.5))
-    assert_equal(huge_monty.log_probability(('B', 'B', 'C')), np.log(0.5))
+    assert_almost_equal(huge_monty.log_probability(('A', 'A', 'C')), np.log(0.5))
+    assert_almost_equal(huge_monty.log_probability(('B', 'B', 'C')), np.log(0.5))
     assert_equal(huge_monty.log_probability(('C', 'C', 'C')), float("-inf"))
 
     data = [[True,  'A', 'A', 'C', 1, True],
@@ -287,15 +292,15 @@ def test_huge_monty():
 
     huge_monty_network.fit(data)
 
-    assert_equal(huge_monty.log_probability(('A', 'A', 'C')), np.log(0.6))
-    assert_equal(huge_monty.log_probability(('B', 'B', 'C')), np.log(0.5))
-    assert_equal(huge_monty.log_probability(('C', 'C', 'C')), np.log(0.75))
+    assert_almost_equal(huge_monty.log_probability(('A', 'A', 'C')), np.log(0.6))
+    assert_almost_equal(huge_monty.log_probability(('B', 'B', 'C')), np.log(0.5))
+    assert_almost_equal(huge_monty.log_probability(('C', 'C', 'C')), np.log(0.75))
 
 
 @with_setup(setup_huge_monty, teardown)
 def test_huge_monty_friend():
-    assert_equal(huge_monty_friend.log_probability(True), np.log(0.5))
-    assert_equal(huge_monty_friend.log_probability(False), np.log(0.5))
+    assert_almost_equal(huge_monty_friend.log_probability(True), np.log(0.5))
+    assert_almost_equal(huge_monty_friend.log_probability(False), np.log(0.5))
 
     data = [[True,  'A', 'A', 'C', 1, True],
             [True,  'A', 'A', 'C', 0, True],
@@ -312,15 +317,15 @@ def test_huge_monty_friend():
 
     huge_monty_network.fit(data)
 
-    assert_equal(huge_monty_friend.log_probability(True), np.log(7. / 12))
-    assert_equal(huge_monty_friend.log_probability(False), np.log(5. / 12))
+    assert_almost_equal(huge_monty_friend.log_probability(True), np.log(7. / 12))
+    assert_almost_equal(huge_monty_friend.log_probability(False), np.log(5. / 12))
 
 
 @with_setup(setup_huge_monty, teardown)
 def test_huge_monty_remaining():
-    assert_equal(huge_monty_remaining.log_probability(0), np.log(0.1))
-    assert_equal(huge_monty_remaining.log_probability(1), np.log(0.7))
-    assert_equal(huge_monty_remaining.log_probability(2), np.log(0.2))
+    assert_almost_equal(huge_monty_remaining.log_probability(0), np.log(0.1))
+    assert_almost_equal(huge_monty_remaining.log_probability(1), np.log(0.7))
+    assert_almost_equal(huge_monty_remaining.log_probability(2), np.log(0.2))
 
     data = [[True,  'A', 'A', 'C', 1, True],
             [True,  'A', 'A', 'C', 0, True],
@@ -337,20 +342,20 @@ def test_huge_monty_remaining():
 
     huge_monty_network.fit(data)
 
-    assert_equal(huge_monty_remaining.log_probability(0), np.log(3. / 12))
-    assert_equal(huge_monty_remaining.log_probability(1), np.log(5. / 12))
-    assert_equal(huge_monty_remaining.log_probability(2), np.log(4. / 12))
+    assert_almost_equal(huge_monty_remaining.log_probability(0), np.log(3. / 12))
+    assert_almost_equal(huge_monty_remaining.log_probability(1), np.log(5. / 12))
+    assert_almost_equal(huge_monty_remaining.log_probability(2), np.log(4. / 12))
 
 
 @with_setup(setup_huge_monty, teardown)
 def test_huge_monty_prize():
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (True,  True,  'A')), np.log(0.3))
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (True,  False, 'C')), np.log(0.4))
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (False, True,  'B')), np.log(0.9))
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (False, False, 'A')), float("-inf"))
 
     data = [[True,  'A', 'A', 'C', 1, True],
@@ -368,7 +373,7 @@ def test_huge_monty_prize():
 
     huge_monty_network.fit(data)
 
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (True, True, 'C')), np.log(0.5))
     assert_equal(huge_monty_prize.log_probability(
         (True, True, 'B')), float("-inf"))
@@ -377,12 +382,12 @@ def test_huge_monty_prize():
     b = huge_monty_prize.log_probability((True, False, 'B'))
     c = huge_monty_prize.log_probability((True, False, 'C'))
 
-    assert_equal(a, b)
-    assert_equal(b, c)
+    assert_almost_equal(a, b)
+    assert_almost_equal(b, c)
 
     assert_equal(huge_monty_prize.log_probability(
         (False, False, 'C')), float("-inf"))
-    assert_equal(huge_monty_prize.log_probability(
+    assert_almost_equal(huge_monty_prize.log_probability(
         (False, True, 'C')), np.log(2. / 3))
 
 


### PR DESCRIPTION
This PR fixes three different but related issues. The first is in the case when a certain parent set in a conditional probability table has no counts during training, it will assign a uniform distribution to each of the values of that variable instead of crashing. The second is that when a Bayesian network is trained, it did not update the underlying factor graph appropriately. This remakes the factor graph after each update, which is the most efficient way of updating it. The third is that during the message passing scheme with a Bayesian network with many impossible scenarios (0's in the discrete distributions or CPTs) the messages may be inconsistent, such that one message is certain one value is happening, but another message says the opposite. In these cases the messages would cancel out and yield a NaN value. Using an epsilon-smoothing technique I was able to fix this, while retaining the exactness of 0 and 1 probability events.