### PR TITLE
Automatically building Python Wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 build
 *.so
 .idea/
+dist/
+.eggs/
+*.egg-info/
+*.pyd

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,5 @@ script:
 - python setup.py test
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel fi
-deploy:
-  provider: releases
-  api_key:
-    secure: MwOvWR12meTyIxkNuaSPw2TFDPAsCYgUix/5wkRhumYDxHoy/+tAF608SEu14Y6Xj5mEef91jBH7/kEoAnQy65rofu7DJINEt11Ce/FngZWz8+xpbD/vB/quE6HOASi40M1GwqwbmvwYsV8xrqKrGk7AkapuNwQMEQV2G6OvBmg4TaxOehp0yLYinna083LyYya2PIXvX72siEou2ocSc40YIVrhJSR4sFF2+jwEYthT7ECOWNRNoruS4fHcmNJqgYIdZM7tpDKiBeeMb2cO6MwvBy4SQFtkJ97RkjQH8wwTB0aR9uV6SI26cuA5WycDZClED+X4xk9yyZVTvKndZi+hAldUjgPqydehqbc2BYxQp4/pcpVRFY4DJjXqtFn934PnAbDeBLwLSQ6QESICjNM2Lx+23proiFS8BoeokyguzG2LqL8eyfDpK8hF33T2INj0YlvN49nki5CPLLJs5YeJIkFTi40fpQdk92kPdwuOMIHSm83xBqUt84ffUV1Ln7tarGLTYDoUcEUPMeiF6MY5SKSD5AfK+Age0SH1oNMNsPU32na2wSbIce1sGjAv7Y48PjFPBg7SF5eaESsPfmRdMEG2BtvySdUPP+gXijO+SfGrKvZWSsuHQfWrl3tVkOpyERHGPzRhwCvEwpcxORjIf+2gIFFo0j///nrqx98=
-  file: dist/*.whl
-  file_glob: true
-  skip_cleanup: true
-  on:
-    tags: true
+# deploy:
+# This is where you can deploy to PyPI

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,57 @@
-# Travis file provided by conda
-
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-
+matrix:
+  include:
+  - os: osx
+    language: generic
+    env: PYTHON=2.7
+  - os: osx
+    language: generic
+    env: PYTHON=3.4
+  - os: osx
+    language: generic
+    env: PYTHON=3.5
+  - os: osx
+    language: generic
+    env: PYTHON=3.6
+  - os: linux
+    language: generic
+    env: PYTHON=2.7
+  - os: linux
+    language: generic
+    env: PYTHON=3.4
+  - os: linux
+    language: generic
+    env: PYTHON=3.5
+  - os: linux
+    language: generic
+    env: PYTHON=3.6
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$PYTHON" == "2.7" ]]; then wget
+  http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;
+  else wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+  -O miniconda.sh; fi else if [[ "$PYTHON" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  -O miniconda.sh; fi fi
+- bash miniconda.sh -b -p $HOME/miniconda
+- export PATH="$HOME/miniconda/bin:$PATH"
+- conda config --set always_yes yes --set changeps1 no
+- conda update -q conda
+- conda info -a
+- conda create -q -n test-environment python=$PYTHON numpy scipy
+- source activate test-environment
+- pip install -r dev-requirements.txt
 install:
-  - sudo apt-get update
-
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cython numpy scipy nose networkx
-  - source activate test-environment
-  - pip install joblib
-  - python setup.py install
-
-script: nosetests -s -v
+- python setup.py install
+script:
+- python setup.py test
+after_success:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel fi
+deploy:
+  provider: releases
+  api_key:
+    secure: MwOvWR12meTyIxkNuaSPw2TFDPAsCYgUix/5wkRhumYDxHoy/+tAF608SEu14Y6Xj5mEef91jBH7/kEoAnQy65rofu7DJINEt11Ce/FngZWz8+xpbD/vB/quE6HOASi40M1GwqwbmvwYsV8xrqKrGk7AkapuNwQMEQV2G6OvBmg4TaxOehp0yLYinna083LyYya2PIXvX72siEou2ocSc40YIVrhJSR4sFF2+jwEYthT7ECOWNRNoruS4fHcmNJqgYIdZM7tpDKiBeeMb2cO6MwvBy4SQFtkJ97RkjQH8wwTB0aR9uV6SI26cuA5WycDZClED+X4xk9yyZVTvKndZi+hAldUjgPqydehqbc2BYxQp4/pcpVRFY4DJjXqtFn934PnAbDeBLwLSQ6QESICjNM2Lx+23proiFS8BoeokyguzG2LqL8eyfDpK8hF33T2INj0YlvN49nki5CPLLJs5YeJIkFTi40fpQdk92kPdwuOMIHSm83xBqUt84ffUV1Ln7tarGLTYDoUcEUPMeiF6MY5SKSD5AfK+Age0SH1oNMNsPU32na2wSbIce1sGjAv7Y48PjFPBg7SF5eaESsPfmRdMEG2BtvySdUPP+gXijO+SfGrKvZWSsuHQfWrl3tVkOpyERHGPzRhwCvEwpcxORjIf+2gIFFo0j///nrqx98=
+  file: dist/*.whl
+  file_glob: true
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No good project is done alone, and so I'd like to thank all the previous contrib
 pomegranate requires:
 
 ```
-- Cython
+- Cython (only if building from source)
 - NumPy
 - SciPy
 - NetworkX
@@ -44,7 +44,7 @@ python setup.py install
 
 Lastly, you can also download the zip and manually move the files into your site-packages folder (or your PYTHON_PATH, if you've changed it).
 
-On Windows machines you may need to download a C++ compiler. For Python 2 this minimal version of Visual Studio 2008 works well: https://www.microsoft.com/en-us/download/details.aspx?id=44266. For Python 3 this version of the Visual Studio Build Tools has been reported to work: http://go.microsoft.com/fwlink/?LinkId=691126. 
+To build from source on Windows machines, you may need to download a C++ compiler. For Python 2 this minimal version of Visual Studio 2008 works well: https://www.microsoft.com/en-us/download/details.aspx?id=44266. For Python 3 this version of the Visual Studio Build Tools has been reported to work: http://go.microsoft.com/fwlink/?LinkId=691126. 
 
 If those do no work, it has been suggested that https://wiki.python.org/moin/WindowsCompilers may provide more information. Note that your compiler version must fit your python version. Run python --version to tell which python version you use. Don't forget to select the appropriate Windows version API you'd like to use. If you get an error message "ValueError: Unknown MS Compiler version 1900" remove your Python's Lib/distutils/distutil.cfg and retry. See http://stackoverflow.com/questions/34135280/valueerror-unknown-ms-compiler-version-1900 for details.
 
@@ -52,9 +52,9 @@ If those do no work, it has been suggested that https://wiki.python.org/moin/Win
 
 If you would like to contribute a feature then fork the master branch (fork the release if you are fixing a bug). Be sure to run the tests before changing any code. You'll need to have [nosetests](https://github.com/nose-devs/nose) installed. The following command will run all the tests:
 ```
-nosetests -s -v tests/
+python setup.py test
 ```
-Let us know what you want to do just in case we're already working on an implementation of something similar. This way we can avoid any needless duplication of effort. Also, please don't forget to add tests for any new functions. 
+Let us know what you want to do just in case we're already working on an implementation of something similar. This way we can avoid any needless duplication of effort. Also, please don't forget to add tests for any new functions.
 
 ## Tutorial
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,118 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+    # See: http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7" # currently 2.7.9
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7" # currently 2.7.9
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda-x64
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4" # currently 3.4.3
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4" # currently 3.4.3
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+
+    # Python versions not pre-installed
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # We need to install numpy, scipy and matplotlib through conda
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy"
+  - activate test-environment
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+
+build_script:
+  # Build the compiled extension
+  - "%CMD_IN_ENV% python setup.py build"
+
+test_script:
+  # Run the project tests
+  - "%CMD_IN_ENV% python setup.py test"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
+  # - "%CMD_IN_ENV% python setup.py bdist_wininst"
+  # - "%CMD_IN_ENV% python setup.py bdist_msi"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse
+#

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,229 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel, Jonathan Helmus, Kyle Kastner, and Alex Willmer
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$BASE_URL = "https://www.python.org/ftp/python/"
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+
+$PYTHON_PRERELEASE_REGEX = @"
+(?x)
+(?<major>\d+)
+\.
+(?<minor>\d+)
+\.
+(?<micro>\d+)
+(?<prerelease>[a-z]{1,2}\d+)
+"@
+
+
+function Download ($filename, $url) {
+    $webclient = New-Object System.Net.WebClient
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for ($i = 0; $i -lt $retry_attempts; $i++) {
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+    }
+    if (Test-Path $filepath) {
+        Write-Host "File saved at" $filepath
+    } else {
+        # Retry once to get the error message if any at the last try
+        $webclient.DownloadFile($url, $filepath)
+    }
+    return $filepath
+}
+
+
+function ParsePythonVersion ($python_version) {
+    if ($python_version -match $PYTHON_PRERELEASE_REGEX) {
+        return ([int]$matches.major, [int]$matches.minor, [int]$matches.micro,
+                $matches.prerelease)
+    }
+    $version_obj = [version]$python_version
+    return ($version_obj.major, $version_obj.minor, $version_obj.build, "")
+}
+
+
+function DownloadPython ($python_version, $platform_suffix) {
+    $major, $minor, $micro, $prerelease = ParsePythonVersion $python_version
+
+    if (($major -le 2 -and $micro -eq 0) `
+        -or ($major -eq 3 -and $minor -le 2 -and $micro -eq 0) `
+        ) {
+        $dir = "$major.$minor"
+        $python_version = "$major.$minor$prerelease"
+    } else {
+        $dir = "$major.$minor.$micro"
+    }
+
+    if ($prerelease) {
+        if (($major -le 2) `
+            -or ($major -eq 3 -and $minor -eq 1) `
+            -or ($major -eq 3 -and $minor -eq 2) `
+            -or ($major -eq 3 -and $minor -eq 3) `
+            ) {
+            $dir = "$dir/prev"
+        }
+    }
+
+    if (($major -le 2) -or ($major -le 3 -and $minor -le 4)) {
+        $ext = "msi"
+        if ($platform_suffix) {
+            $platform_suffix = ".$platform_suffix"
+        }
+    } else {
+        $ext = "exe"
+        if ($platform_suffix) {
+            $platform_suffix = "-$platform_suffix"
+        }
+    }
+
+    $filename = "python-$python_version$platform_suffix.$ext"
+    $url = "$BASE_URL$dir/$filename"
+    $filepath = Download $filename $url
+    return $filepath
+}
+
+
+function InstallPython ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = ""
+    } else {
+        $platform_suffix = "amd64"
+    }
+    $installer_path = DownloadPython $python_version $platform_suffix
+    $installer_ext = [System.IO.Path]::GetExtension($installer_path)
+    Write-Host "Installing $installer_path to $python_home"
+    $install_log = $python_home + ".log"
+    if ($installer_ext -eq '.msi') {
+        InstallPythonMSI $installer_path $python_home $install_log
+    } else {
+        InstallPythonEXE $installer_path $python_home $install_log
+    }
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallPythonEXE ($exepath, $python_home, $install_log) {
+    $install_args = "/quiet InstallAllUsers=1 TargetDir=$python_home"
+    RunCommand $exepath $install_args
+}
+
+
+function InstallPythonMSI ($msipath, $python_home, $install_log) {
+    $install_args = "/qn /log $install_log /i $msipath TARGETDIR=$python_home"
+    $uninstall_args = "/qn /x $msipath"
+    RunCommand "msiexec.exe" $install_args
+    if (-not(Test-Path $python_home)) {
+        Write-Host "Python seems to be installed else-where, reinstalling."
+        RunCommand "msiexec.exe" $uninstall_args
+        RunCommand "msiexec.exe" $install_args
+    }
+}
+
+function RunCommand ($command, $command_args) {
+    Write-Host $command $command_args
+    Start-Process -FilePath $command -ArgumentList $command_args -Wait -Passthru
+}
+
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $python_path = $python_home + "\python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        & $python_path $GET_PIP_PATH
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    if ($python_version -eq "3.4") {
+        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
+    }
+    $url = $MINICONDA_URL + $filename
+    $filepath = Download $filename $url
+    return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallMinicondaPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $args = "install --yes pip"
+        Write-Host $conda_path $args
+        Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function main () {
+    InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallPip $env:PYTHON
+}
+
+main

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -1,0 +1,88 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+wheel
+cython >= 0.22.1
+nose
+numpy >= 1.8.0
+scipy >= 0.17.0

--- a/pomegranate/__init__.py
+++ b/pomegranate/__init__.py
@@ -6,35 +6,6 @@
 For detailed documentation and examples, see the README.
 """
 
-import numpy as np
-import os
-import pyximport
-
-# Adapted from Cython docs https://github.com/cython/cython/wiki/
-# InstallingOnWindows#mingw--numpy--pyximport-at-runtime
-if os.name == 'nt':
-    if 'CPATH' in os.environ:
-        os.environ['CPATH'] = os.environ['CPATH'] + np.get_include()
-    else:
-        os.environ['CPATH'] = np.get_include()
-
-    # XXX: we're assuming that MinGW is installed in C:\MinGW (default)
-    if 'PATH' in os.environ:
-        os.environ['PATH'] = os.environ['PATH'] + ';C:\MinGW\bin'
-    else:
-        os.environ['PATH'] = 'C:\MinGW\bin'
-
-    mingw_setup_args = { 'options': { 'build_ext': { 'compiler': 'mingw32' } }, 'include_dirs': np.get_include() }
-    pyximport.install(setup_args=mingw_setup_args)
-
-elif os.name == 'posix':
-    if 'CFLAGS' in os.environ:
-        os.environ['CFLAGS'] = os.environ['CFLAGS'] + ' -I' + np.get_include()
-    else:
-        os.environ['CFLAGS'] = ' -I' + np.get_include()
-
-    pyximport.install()
-
 from .base import *
 from .parallel import *
 
@@ -48,7 +19,5 @@ from .hmm import HiddenMarkovModel
 from .BayesianNetwork import BayesianNetwork
 from .FactorGraph import FactorGraph
 from .fsm import FiniteStateMachine
-
-
 
 __version__ = '0.7.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cython >= 0.22.1
 numpy >= 1.8.0
 joblib >= 0.9.0b4
 networkx >= 1.8.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from distutils.core import setup
-from distutils.extension import Extension
-import numpy as np
+from setuptools import setup
+from setuptools import Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 
 try:
     from Cython.Build import cythonize
@@ -24,18 +24,24 @@ filenames = [ "base",
 
 if not use_cython:
     extensions = [
-        Extension( "pomegranate.{}".format( name ), 
-                   [ "pomegranate/{}.{}".format( name, ext ) ], 
-                   include_dirs=[np.get_include()] ) for name in filenames
+        Extension( "pomegranate.{}".format( name ),
+                   [ "pomegranate/{}.{}".format( name, ext ) ]) for name in filenames
     ]
 else:
     extensions = [
             Extension( "pomegranate.*", 
-                       [ "pomegranate/*.pyx" ], 
-                       include_dirs=[np.get_include()] )
+                       [ "pomegranate/*.pyx" ] )
     ]
 
     extensions = cythonize( extensions )
+
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 setup(
     name='pomegranate',
@@ -47,11 +53,17 @@ setup(
     license='LICENSE.txt',
     description='Pomegranate is a graphical models library for Python, implemented in Cython for speed.',
     ext_modules=extensions,
-    install_requires=[
+    cmdclass={'build_ext':build_ext},
+    setup_requires=[
         "cython >= 0.22.1",
+        "numpy >= 1.8.0",
+        "scipy >= 0.17.0"
+    ],
+    install_requires=[
         "numpy >= 1.8.0",
         "joblib >= 0.9.0b4",
         "networkx >= 1.8.1",
         "scipy >= 0.17.0"
     ],
+    test_suite = 'nose.collector'
 )


### PR DESCRIPTION
Installation can be tedious on Windows and OS X due to the need for a C compiler. This pull request sets up AppVeyor and Travis CI to build precompiled wheels. These wheels can be uploaded directly to PyPI. Wheels are built for Python 2.7, 3.4, 3.5, and 3.6 on Windows x86, x64, and OS X (Linux should still build from source).

Changes:
- Set up AppVeyor to install, test, and build wheels on Windows
- Changed Travis CI script to include OS X and to build wheels
- Removed requirement for Numpy to be installed prior to installation (`np.get_includes()`)
- Removed Cython runtime requirement (required only during setup)

Action required for maintainers if accepted:
- Set up AppVeyor to build this repo
- Update the API key in the GitHub releases deployment (or remove the deployment altogether)
- (optional) set up Travis/AppVeyor to autodeploy to PyPI on tagged releases


Though tests pass on all platforms, I have not done extensive testing on installing from wheels. I  welcome feedback on this PR, particularly on the removal of pyximport.