### PR TITLE
[MRG] Clean up log probability calculation internals

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -325,7 +325,7 @@ cdef class BayesianNetwork( GraphModel ):
 
 		return logp
 
-	cdef void _v_log_probability( self, double* symbol, double* log_probability, int n ) nogil:
+	cdef void _log_probability( self, double* symbol, double* log_probability, int n ) nogil:
 		cdef int i, j, l, li, k
 		cdef double logp
 		cdef double* sym = <double*> calloc(self.d, sizeof(double))
@@ -341,7 +341,7 @@ cdef class BayesianNetwork( GraphModel ):
 					k = l - self.parent_count[j]
 					sym[k] = symbol[i*self.d + li]
 
-				(<Model> self.distributions_ptr[j])._v_log_probability(sym, &logp, 1)
+				(<Model> self.distributions_ptr[j])._log_probability(sym, &logp, 1)
 				log_probability[i] += logp
 
 

--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -325,11 +325,6 @@ cdef class BayesianNetwork( GraphModel ):
 
 		return logp
 
-	cdef double _mv_log_probability(self, double* symbol) nogil:
-		cdef double logp
-		self._v_log_probability(symbol, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability( self, double* symbol, double* log_probability, int n ) nogil:
 		cdef int i, j, l, li, k
 		cdef double logp

--- a/pomegranate/base.pxd
+++ b/pomegranate/base.pxd
@@ -8,9 +8,9 @@ cdef class Model(object):
 	cdef public int d
 	cdef public bint frozen
 	cdef public str model
-	
+
+	cdef void _log_probability(self, double* symbol, double* log_probability, int n) nogil
 	cdef double _vl_log_probability(self, double* symbol, int n) nogil
-	cdef void _v_log_probability(self, double* symbol, double* log_probability, int n) nogil
 	cdef double _summarize(self, double* items, double* weights, int n) nogil
 
 

--- a/pomegranate/base.pxd
+++ b/pomegranate/base.pxd
@@ -3,22 +3,15 @@
 
 cimport numpy
 
-ctypedef numpy.npy_intp SIZE_t
-
-
 cdef class Model(object):
 	cdef public str name
 	cdef public int d
 	cdef public bint frozen
 	cdef public str model
-
-	cdef double _log_probability( self, double symbol ) nogil
-	cdef double _mv_log_probability( self, double* symbol ) nogil
-	cdef double _vl_log_probability( self, double* symbol, int n ) nogil
-	cdef void _v_log_probability( self, double* symbol,
-	                              double* log_probability, int n ) nogil
-	cdef double _summarize( self, double* items, double* weights,
-	                        SIZE_t n ) nogil
+	
+	cdef double _vl_log_probability(self, double* symbol, int n) nogil
+	cdef void _v_log_probability(self, double* symbol, double* log_probability, int n) nogil
+	cdef double _summarize(self, double* items, double* weights, int n) nogil
 
 
 cdef class GraphModel(Model):

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -258,7 +258,7 @@ cdef class Model(object):
 		"""Clear the summary statistics stored in the object."""
 		return NotImplementedError
 
-	cdef void _v_log_probability( self, double* symbol,
+	cdef void _log_probability( self, double* symbol,
 								  double* log_probability, int n ) nogil:
 		pass
 

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -258,21 +258,15 @@ cdef class Model(object):
 		"""Clear the summary statistics stored in the object."""
 		return NotImplementedError
 
-	cdef double _log_probability( self, double symbol ) nogil:
-		return NEGINF
-
-	cdef double _mv_log_probability( self, double* symbol ) nogil:
-		return NEGINF
+	cdef void _v_log_probability( self, double* symbol,
+								  double* log_probability, int n ) nogil:
+		pass
 
 	cdef double _vl_log_probability( self, double* symbol, int n ) nogil:
 		return NEGINF
 
 	cdef double _summarize( self, double* items,
 		                    double* weights, int n ) nogil:
-		pass
-
-	cdef void _v_log_probability( self, double* symbol,
-								  double* log_probability, int n ) nogil:
 		pass
 
 

--- a/pomegranate/bayes.pxd
+++ b/pomegranate/bayes.pxd
@@ -19,12 +19,5 @@ cdef class BayesModel(Model):
 	cdef public int n
 	cdef public bint is_vl_
 
-	cdef double _log_probability(self, double X) nogil
-	cdef double _mv_log_probability(self, double* X) nogil
-	cdef double _vl_log_probability(self, double* X, int n) nogil
 	cdef void _predict_log_proba(self, double* X, double* y, int n, int d) nogil
 	cdef void _predict( self, double* X, int* y, int n, int d) nogil
-	cdef double _summarize(self, double* X, double* weights, int n) nogil
-
-cdef class BayesClassifier(BayesModel):
-	pass

--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -203,20 +203,20 @@ cdef class BayesModel(Model):
 						X_ptr = <double*> X_ndarray.data
 					logp[i] = self._vl_log_probability(X_ptr, n)
 			else:
-				self._v_log_probability(X_ptr, logp, n)
+				self._log_probability(X_ptr, logp, n)
 
 		return logp_ndarray
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, d = self.d
 		cdef double* logp = <double*> calloc(n, sizeof(double))
 
-		(<Model> self.distributions_ptr[0])._v_log_probability(X, log_probability, n)
+		(<Model> self.distributions_ptr[0])._log_probability(X, log_probability, n)
 		for i in range(n):
 			log_probability[i] += self.weights_ptr[0]
 
 		for j in range(1, self.n):
-			(<Model> self.distributions_ptr[j])._v_log_probability(X, logp, n)
+			(<Model> self.distributions_ptr[j])._log_probability(X, logp, n)
 			for i in range(n):
 				log_probability[i] = pair_lse(log_probability[i], logp[i] + self.weights_ptr[j])
 
@@ -328,7 +328,7 @@ cdef class BayesModel(Model):
 			if self.is_vl_:
 				y[j] = (<Model> self.distributions_ptr[j])._vl_log_probability(X, d)
 			else:
-				(<Model> self.distributions_ptr[j])._v_log_probability(X, y+j*n, n)
+				(<Model> self.distributions_ptr[j])._log_probability(X, y+j*n, n)
 
 		for i in range(n):
 			y_sum = NEGINF
@@ -406,7 +406,7 @@ cdef class BayesModel(Model):
 			if self.is_vl_:
 				r[j] = (<Model> self.distributions_ptr[j])._vl_log_probability(X, d)
 			else:
-				(<Model> self.distributions_ptr[j])._v_log_probability(X, r+j*n, n)
+				(<Model> self.distributions_ptr[j])._log_probability(X, r+j*n, n)
 
 		for i in range(n):
 			max_logp = NEGINF

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -170,7 +170,7 @@ cdef class Distribution(Model):
 		X_ndarray = numpy.array(X, dtype='float64')
 		X_ptr = <double*> X_ndarray.data
 
-		self._v_log_probability(X_ptr, logp_ptr, n)
+		self._log_probability(X_ptr, logp_ptr, n)
 
 		if n == 1:
 			return logp_array[0]
@@ -384,7 +384,7 @@ cdef class UniformDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.start, self.end, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			if X[i] >= self.start and X[i] <= self.end:
@@ -500,7 +500,7 @@ cdef class BernoulliDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.p, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			log_probability[i] = self.logp[<int> X[i]]
@@ -582,7 +582,7 @@ cdef class NormalDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.mu, self.sigma, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			log_probability[i] = self.log_sigma_sqrt_2_pi - ((X[i] - self.mu) ** 2) /\
@@ -699,7 +699,7 @@ cdef class LogNormalDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.mu, self.sigma, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			log_probability[i] = -_log(X[i] * self.sigma * SQRT_2_PI) \
@@ -816,7 +816,7 @@ cdef class ExponentialDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.rate, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			log_probability[i] = self.log_rate - self.rate * X[i]
@@ -923,7 +923,7 @@ cdef class BetaDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.alpha, self.beta, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double alpha = self.alpha
 		cdef double beta = self.beta
 		cdef double beta_norm = self.beta_norm
@@ -1036,7 +1036,7 @@ cdef class GammaDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.alpha, self.beta, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double alpha = self.alpha
 		cdef double beta = self.beta
 		cdef int i
@@ -1352,7 +1352,7 @@ cdef class DiscreteDistribution(Distribution):
 	cdef double __log_probability(self, X):
 		return self.log_dist.get(X, NEGINF)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
 			if X[i] < 0 or X[i] > self.n:
@@ -1534,7 +1534,7 @@ cdef class PoissonDistribution(Distribution):
 		"""Serialize the distribution for pickle."""
 		return self.__class__, (self.l, self.frozen)
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double f
 		cdef int i, j
 
@@ -1714,7 +1714,7 @@ cdef class GaussianKernelDensity(KernelDensity):
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "GaussianKernelDensity"
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob, b = self.bandwidth
 		cdef int i, j
 
@@ -1749,7 +1749,7 @@ cdef class UniformKernelDensity(KernelDensity):
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "UniformKernelDensity"
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob, b = self.bandwidth
 		cdef int i, j
 
@@ -1786,7 +1786,7 @@ cdef class TriangleKernelDensity(KernelDensity):
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "TriangleKernelDensity"
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob
 		cdef double hinge, b = self.bandwidth
 		cdef int i, j
@@ -1860,7 +1860,7 @@ cdef class MultivariateDistribution(Distribution):
 		X_ptr = <double*> X_ndarray.data
 
 		with nogil:
-			self._v_log_probability(X_ptr, logp_ptr, n)
+			self._log_probability(X_ptr, logp_ptr, n)
 		
 		if n == 1:
 			return logp_array[0]
@@ -1961,14 +1961,14 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 			logp_ptr = <double*> logp_array.data
 
 			with nogil:
-				self._v_log_probability(X_ptr, logp_ptr, n)
+				self._log_probability(X_ptr, logp_ptr, n)
 
 			if n == 1:
 				return logp_array[0]
 			else:
 				return logp_array
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j
 		cdef double logp
 
@@ -1976,7 +1976,7 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 
 		for i in range(n):
 			for j in range(self.d):
-				(<Model> self.distributions_ptr[j])._v_log_probability(X+i*self.d+j, &logp, 1)
+				(<Model> self.distributions_ptr[j])._log_probability(X+i*self.d+j, &logp, 1)
 				log_probability[i] += logp * self.weights_ptr[j]
 
 	def sample(self, n=None):
@@ -2126,7 +2126,7 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		free(self.column_sum)
 		free(self.pair_sum)
 
-	cdef void _v_log_probability(self, double* X, double* logp, int n) nogil:
+	cdef void _log_probability(self, double* X, double* logp, int n) nogil:
 		cdef int i, j, d = self.d
 
 		cdef double* dot = <double*> calloc(n*d, sizeof(double))
@@ -2312,7 +2312,7 @@ cdef class DirichletDistribution(MultivariateDistribution):
 		self.summaries_ndarray = numpy.zeros(self.d, dtype='float64')
 		self.summaries_ptr = <double*> self.summaries_ndarray.data
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, d = self.d
 		cdef double logp
 
@@ -2522,7 +2522,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		idx = self.keymap[tuple(X)]
 		return self.values[idx]
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, idx
 
 		for i in range(n):
@@ -2801,7 +2801,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		key = self.keymap[tuple(X)]
 		return self.values[key]
 
-	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, idx
 
 		for i in range(n):

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -162,19 +162,19 @@ cdef class Distribution(Model):
 		cdef double* X_ptr
 		cdef double* logp_ptr
 
+		n = 1 if isinstance(X, (int, float)) else len(X)
 
-		if isinstance(X, (int, float)):
-			logp = self._log_probability(X)
-			return logp
+		logp_array = numpy.empty(n, dtype='float64')
+		logp_ptr = <double*> logp_array.data
+
+		X_ndarray = numpy.array(X, dtype='float64')
+		X_ptr = <double*> X_ndarray.data
+
+		self._v_log_probability(X_ptr, logp_ptr, n)
+
+		if n == 1:
+			return logp_array[0]
 		else:
-			n = len(X)
-			logp_array = numpy.empty(n, dtype='float64')
-			logp_ptr = <double*> logp_array.data
-
-			X_ndarray = numpy.array(X, dtype='float64')
-			X_ptr = <double*> X_ndarray.data
-
-			self._v_log_probability(X_ptr, logp_ptr, n)
 			return logp_array
 
 	def summarize(self, items, weights=None):
@@ -210,8 +210,7 @@ cdef class Distribution(Model):
 
 			self.summaries = [items, weights]
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
-
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		pass
 
 	def from_summaries(self, inertia=0.0):
@@ -385,11 +384,6 @@ cdef class UniformDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.start, self.end, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -428,12 +422,12 @@ cdef class UniformDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		cdef double minimum = INF, maximum = NEGINF
 		cdef double weight = 0.0
 		cdef int i
@@ -506,11 +500,6 @@ cdef class BernoulliDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.p, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -526,13 +515,13 @@ cdef class BernoulliDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
-		cdef SIZE_t i
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
+		cdef int i
 		cdef double w_sum = 0, x_sum = 0
 
 		for i in range(n):
@@ -593,11 +582,6 @@ cdef class NormalDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.mu, self.sigma, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -620,8 +604,8 @@ cdef class NormalDistribution(Distribution):
 		self.summarize(items, weights)
 		self.from_summaries(inertia, min_std)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
-		cdef SIZE_t i
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
+		cdef int i
 		cdef double x_sum = 0.0, x2_sum = 0.0, w_sum = 0.0
 
 		for i in range(n):
@@ -646,7 +630,7 @@ cdef class NormalDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
@@ -715,11 +699,6 @@ cdef class LogNormalDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.mu, self.sigma, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -743,10 +722,10 @@ cdef class LogNormalDistribution(Distribution):
 		self.summarize(items, weights)
 		self.from_summaries(inertia, min_std)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		"""Cython function to get the MLE estimate for a Gaussian."""
 
-		cdef SIZE_t i
+		cdef int i
 		cdef double x_sum = 0.0, x2_sum = 0.0, w_sum = 0.0
 		cdef double log_item
 
@@ -773,7 +752,7 @@ cdef class LogNormalDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
@@ -837,11 +816,6 @@ cdef class ExponentialDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.rate, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -873,16 +847,16 @@ cdef class ExponentialDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		"""Cython function to get the MLE estimate for an exponential."""
 
 		cdef double xw_sum = 0, w = 0
-		cdef SIZE_t i
+		cdef int i
 
 		# Calculate the average, which is the MLE mu estimate
 		for i in range(n):
@@ -949,11 +923,6 @@ cdef class BetaDistribution(Distribution):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.alpha, self.beta, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double alpha = self.alpha
 		cdef double beta = self.beta
@@ -991,16 +960,16 @@ cdef class BetaDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		"""Cython optimized function for summarizing some data."""
 
 		cdef double alpha = 0, beta = 0
-		cdef SIZE_t i
+		cdef int i
 
 		for i in range(n):
 			if items[i] == 1:
@@ -1066,11 +1035,6 @@ cdef class GammaDistribution(Distribution):
 	def __reduce__(self):
 		"""Serialize distribution for pickling."""
 		return self.__class__, (self.alpha, self.beta, self.frozen)
-
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
 
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double alpha = self.alpha
@@ -1388,11 +1352,6 @@ cdef class DiscreteDistribution(Distribution):
 	cdef double __log_probability(self, X):
 		return self.log_dist.get(X, NEGINF)
 
-	cdef public double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
@@ -1439,7 +1398,7 @@ cdef class DiscreteDistribution(Distribution):
 		for i in xrange(len(items)):
 			characters[items[i]] += weights[i]
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		cdef int i
 		self.encoded_summary = 1
 
@@ -1447,7 +1406,7 @@ cdef class DiscreteDistribution(Distribution):
 		memset(encoded_counts, 0, self.n*sizeof(double))
 
 		for i in range(n):
-			encoded_counts[<SIZE_t> items[i]] += weights[i]
+			encoded_counts[<int> items[i]] += weights[i]
 
 		with gil:
 			for i in range(self.n):
@@ -1575,11 +1534,6 @@ cdef class PoissonDistribution(Distribution):
 		"""Serialize the distribution for pickle."""
 		return self.__class__, (self.l, self.frozen)
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double f
 		cdef int i, j
@@ -1622,12 +1576,12 @@ cdef class PoissonDistribution(Distribution):
 
 		cdef double* items_p = <double*> (<numpy.ndarray> items).data
 		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = items.shape[0]
 
 		with nogil:
 			self._summarize(items_p, weights_p, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* items, double* weights, int n) nogil:
 		"""Cython optimized function to calculate the summary statistics."""
 
 		cdef double x_sum = 0.0, w_sum = 0.0
@@ -1760,11 +1714,6 @@ cdef class GaussianKernelDensity(KernelDensity):
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "GaussianKernelDensity"
 
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob, b = self.bandwidth
 		cdef int i, j
@@ -1799,11 +1748,6 @@ cdef class UniformKernelDensity(KernelDensity):
 
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "UniformKernelDensity"
-
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
 
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob, b = self.bandwidth
@@ -1841,11 +1785,6 @@ cdef class TriangleKernelDensity(KernelDensity):
 
 	def __cinit__(self, points=[], bandwidth=1, weights=None, frozen=False):
 		self.name = "TriangleKernelDensity"
-
-	cdef double _log_probability(self, double X) nogil:
-		cdef double logp
-		self._v_log_probability(&X, &logp, 1)
-		return logp
 
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef double mu, w, scalar = 1.0 / SQRT_2_PI, prob
@@ -1901,27 +1840,31 @@ cdef class MultivariateDistribution(Distribution):
 		"""
 
 		cdef int i, n
-		cdef double logp
 		cdef numpy.ndarray logp_array
 		cdef numpy.ndarray X_ndarray
 		cdef double* X_ptr
 		cdef double* logp_ptr
 
-
 		if isinstance(X[0], (int, float)) or len(X) == 1:
-			X_ndarray = numpy.array(X, dtype='float64')
-			X_ptr = <double*> X_ndarray.data
-			logp = self._mv_log_probability(X_ptr)
-			return logp
+			n = 1
 		else:
 			n = len(X)
-			logp_array = numpy.empty(n, dtype='float64')
-			logp_ptr = <double*> logp_array.data
 
-			X_ndarray = numpy.array(X, dtype='float64')
-			X_ptr = <double*> X_ndarray.data
+		X_ndarray = numpy.array(X, dtype='float64')
+		X_ptr = <double*> X_ndarray.data
 
+		logp_array = numpy.empty(n, dtype='float64')
+		logp_ptr = <double*> logp_array.data
+
+		X_ndarray = numpy.array(X, dtype='float64')
+		X_ptr = <double*> X_ndarray.data
+
+		with nogil:
 			self._v_log_probability(X_ptr, logp_ptr, n)
+		
+		if n == 1:
+			return logp_array[0]
+		else:
 			return logp_array
 
 cdef class IndependentComponentsDistribution(MultivariateDistribution):
@@ -1958,11 +1901,10 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 		self.discrete = isinstance(distributions[0], DiscreteDistribution)
 
 		if weights is not None:
-			weights = numpy.array(weights, dtype=numpy.float64)
+			self.weights = numpy.array(weights, dtype=numpy.float64)
 		else:
-			weights = numpy.ones(self.d, dtype=numpy.float64)
+			self.weights = numpy.ones(self.d, dtype=numpy.float64)
 
-		self.weights = numpy.log(weights)
 		self.weights_ptr = <double*> self.weights.data
 		self.name = "IndependentComponentsDistribution"
 		self.frozen = frozen
@@ -1991,56 +1933,51 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 		cdef double* logp_ptr
 
 		if self.discrete:
-			if not isinstance(X[0], (list, numpy.ndarray)) or len(X) == 1:
-				logp = 0
-				for i in range(self.d):
-					logp += self.distributions[i].log_probability(X[i]) + self.weights[i]
-				return logp
-
+			if not isinstance(X[0], (list, tuple, numpy.ndarray)) or len(X) == 1:
+				n = 1
 			else:
 				n = len(X)
-				logp_array = numpy.zeros(n)
-				for i in range(n):
-					for j in range(self.d):
-						logp_array[i] += self.distributions[j].log_probability(X[i][j]) + self.weights[j]
+
+			logp_array = numpy.zeros(n)
+			for i in range(n):
+				for j in range(self.d):
+					logp_array[i] += self.distributions[j].log_probability(X[i][j]) * self.weights[j]
+
+			if n == 1:
+				return logp_array[0]
+			else:
 				return logp_array
 
 		else:
+			if isinstance(X[0], (int, float)) or len(X) == 1:
+				n = 1
+			else:
+				n = len(X)
+
 			X_ndarray = numpy.array(X, dtype='float64')
 			X_ptr = <double*> X_ndarray.data
 
-			if isinstance(X[0], (int, float)) or len(X[0]) == 1:
-				with nogil:
-					logp = self._mv_log_probability(X_ptr)
-				return logp
+			logp_array = numpy.empty(n, dtype='float64')
+			logp_ptr = <double*> logp_array.data
+
+			with nogil:
+				self._v_log_probability(X_ptr, logp_ptr, n)
+
+			if n == 1:
+				return logp_array[0]
 			else:
-				n = len(X)
-				logp_array = numpy.empty(n, dtype='float64')
-				logp_ptr = <double*> logp_array.data
-
-				with nogil:
-					self._v_log_probability(X_ptr, logp_ptr, n)
-
 				return logp_array
 
-
-	cdef double _mv_log_probability(self, double* X) nogil:
-		cdef double logp
-		self._v_log_probability(X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
-		cdef int i, j, d = self.d
+		cdef int i, j
 		cdef double logp
+
+		memset(log_probability, 0, n*sizeof(double))
 
 		for i in range(n):
-			logp = 0.0
-
-			for j in range(d):
-				logp += (<Model> self.distributions_ptr[j])._log_probability(X[i*d+j])
-				logp += self.weights_ptr[j]	
-
-			log_probability[i] = logp
+			for j in range(self.d):
+				(<Model> self.distributions_ptr[j])._v_log_probability(X+i*self.d+j, &logp, 1)
+				log_probability[i] += logp * self.weights_ptr[j]
 
 	def sample(self, n=None):
 		if n is None:
@@ -2048,7 +1985,7 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 		else:
 			return numpy.array([self.sample() for i in range(n)])
 
-	def fit(self, items, weights=None, inertia=0, pseudocount=0.0):
+	def fit(self, X, weights=None, inertia=0, pseudocount=0.0):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of
 		the given sample. Items holds some sort of sequence. If weights is
@@ -2058,34 +1995,30 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 		if self.frozen:
 			return
 
-		self.summarize(items, weights)
+		self.summarize(X, weights)
 		self.from_summaries(inertia, pseudocount)
 
-	def summarize(self, items, weights=None):
+	def summarize(self, X, weights=None):
 		"""
 		Take in an array of items and reduce it down to summary statistics. For
 		a multivariate distribution, this involves just passing the appropriate
 		data down to the appropriate distributions.
 		"""
 
-		items, weights = weight_set(items, weights)
-		cdef double* items_ptr = <double*> (<numpy.ndarray> items).data
+		X, weights = weight_set(X, weights)
+		cdef double* X_ptr = <double*> (<numpy.ndarray> X).data
 		cdef double* weights_ptr = <double*> (<numpy.ndarray> weights).data
-		#cdef int n = items.shape[0]
-
-		#with nogil:
-		#	self._summarize(items_ptr, weights_ptr, n)
 
 		for j, distribution in enumerate(self.distributions):
-			distribution.summarize(items[:,j], weights)
+			distribution.summarize(X[:,j], weights)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
-		cdef SIZE_t i, j, d = self.d
+	cdef double _summarize(self, double* X, double* weights, int n) nogil:
+		cdef int i, j, d = self.d
 		cdef double logp = 0.0
 
 		for i in range(n):
 			for j in range(d):
-				(<Model> self.distributions_ptr[j])._summarize(items+i*d+j, weights+i, 1)
+				(<Model> self.distributions_ptr[j])._summarize(X+i*d+j, weights+i, 1)
 
 	def from_summaries(self, inertia=0.0, pseudocount=0.0):
 		"""
@@ -2121,20 +2054,20 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 						   }, separators=separators, indent=indent)
 
 	@classmethod
-	def from_samples(self, items, weights=None, distribution_weights=None, 
+	def from_samples(self, X, weights=None, distribution_weights=None, 
 		pseudocount=0.0, distributions=None):
 		"""Create a new independent components distribution from data."""
 
 		if distributions is None:
 			raise ValueError("must pass in a list of distribution callables")
 
-		items, weights = weight_set(items, weights)
-		n, d = items.shape
+		X, weights = weight_set(X, weights)
+		n, d = X.shape
 
 		if callable(distributions):
-			distributions = [distributions.from_samples(items[:,i], weights) for i in range(d)]
+			distributions = [distributions.from_samples(X[:,i], weights) for i in range(d)]
 		else:
-			distributions = [distributions[i].from_samples(items[:,i], weights) for i in range(d)]
+			distributions = [distributions[i].from_samples(X[:,i], weights) for i in range(d)]
 
 		return IndependentComponentsDistribution(distributions, distribution_weights)
 
@@ -2193,15 +2126,6 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		free(self.column_sum)
 		free(self.pair_sum)
 
-
-	cdef double _mv_log_probability(self, double* X) nogil:
-		"""Cython optimized function for log probability calculation."""
-
-		cdef SIZE_t i, j, d = self.d
-		cdef double logp
-		self._v_log_probability(X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* logp, int n) nogil:
 		cdef int i, j, d = self.d
 
@@ -2218,15 +2142,10 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		free(dot)
 
 	def sample(self, n=None):
-		"""
-		Sample from the mixture. First, choose a distribution to sample from
-		according to the weights, then sample from that distribution.
-		"""
-
 		return numpy.random.multivariate_normal(self.parameters[0],
 			self.parameters[1], n)
 
-	def fit(self, items, weights=None, inertia=0):
+	def fit(self, X, weights=None, inertia=0):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of
 		the given sample. Items holds some sort of sequence. If weights is
@@ -2236,39 +2155,38 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		if self.frozen:
 			return
 
-		self.summarize(items, weights)
+		self.summarize(X, weights)
 		self.from_summaries(inertia)
 
-	def summarize(self, items, weights=None):
+	def summarize(self, X, weights=None):
 		"""
 		Take in a series of items and their weights and reduce it down to a
 		summary statistic to be used in training later.
 		"""
 
-		items, weights = weight_set(items, weights)
+		X, weights = weight_set(X, weights)
 
-		cdef double* items_p = <double*> (<numpy.ndarray> items).data
-		cdef double* weights_p = <double*> (<numpy.ndarray> weights).data
+		cdef double* X_ptr = <double*> (<numpy.ndarray> X).data
+		cdef double* weights_ptr = <double*> (<numpy.ndarray> weights).data
 
-		cdef SIZE_t n = items.shape[0]
-		d = items.shape[1]
+		cdef int n = X.shape[0], d = X.shape[1]
 
 		if self.d != d:
 			raise ValueError("trying to fit data with {} dimensions to distribution \
 				with {} distributions".format(d, self.d))
 
 		with nogil:
-			self._summarize(items_p, weights_p, n)
+			self._summarize(X_ptr, weights_ptr, n)
 
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* X, double* weights, int n) nogil:
 		"""Calculate sufficient statistics for a minibatch.
 
 		The sufficient statistics for a multivariate gaussian update is the sum of
 		each column, and the sum of the outer products of the vectors.
 		"""
 
-		cdef SIZE_t i, j, k, d = self.d
+		cdef int i, j, k, d = self.d
 		cdef double w_sum = 0.0
 		cdef double* column_sum = <double*> calloc(d, sizeof(double))
 		cdef double* pair_sum = <double*> calloc(d*d, sizeof(double))
@@ -2285,10 +2203,10 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 			w_sum += weights[i]
 
 			for j in range(d):
-				y[i*d + j] = items[i*d + j] * weights[i]
+				y[i*d + j] = X[i*d + j] * weights[i]
 				column_sum[j] += y[i*d + j]
 
-		dgemm('N', 'T', &d, &d, &n, &alpha, y, &d, items, &d, &beta, pair_sum, &d)
+		dgemm('N', 'T', &d, &d, &n, &alpha, y, &d, X, &d, &beta, pair_sum, &d)
 
 		with gil:
 			self.w_sum += w_sum
@@ -2314,7 +2232,7 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		if self.frozen == True or self.w_sum < 1e-7:
 			return
 
-		cdef SIZE_t d = self.d, i, j, k
+		cdef int d = self.d, i, j, k
 		cdef double* column_sum = self.column_sum
 		cdef double* pair_sum = self.pair_sum
 		cdef double* u = self._mu_new
@@ -2358,11 +2276,11 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		self.w_sum = 0.0
 
 	@classmethod
-	def from_samples(cls, items, weights=None, **kwargs):
+	def from_samples(cls, X, weights=None, **kwargs):
 		"""Fit a distribution to some data without pre-specifying it."""
 
-		distribution = cls.blank(items.shape[1])
-		distribution.fit(items, weights, **kwargs)
+		distribution = cls.blank(X.shape[1])
+		distribution.fit(X, weights, **kwargs)
 		return distribution
 
 	@classmethod
@@ -2394,11 +2312,6 @@ cdef class DirichletDistribution(MultivariateDistribution):
 		self.summaries_ndarray = numpy.zeros(self.d, dtype='float64')
 		self.summaries_ptr = <double*> self.summaries_ndarray.data
 
-	cdef double _mv_log_probability(self, double* X) nogil:
-		cdef double logp
-		self._v_log_probability(X, &logp, 1)
-		return logp
-
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, d = self.d
 		cdef double logp
@@ -2412,23 +2325,23 @@ cdef class DirichletDistribution(MultivariateDistribution):
 	def sample(self, n=None):
 		return numpy.random.dirichlet(self.alphas, n)
 
-	def summarize(self, items, weights=None):
+	def summarize(self, X, weights=None):
 		"""
 		Take in a series of items and their weights and reduce it down to a
 		summary statistic to be used in training later.
 		"""
 
-		items, weights = weight_set(items, weights)
+		X, weights = weight_set(X, weights)
 
-		cdef double* items_ptr = <double*> (<numpy.ndarray> items).data
+		cdef double* X_ptr = <double*> (<numpy.ndarray> X).data
 		cdef double* weights_ptr = <double*> (<numpy.ndarray> weights).data
 
-		cdef SIZE_t n = items.shape[0]
+		cdef int n = X.shape[0]
 
 		with nogil:
-			self._summarize(items_ptr, weights_ptr, n)
+			self._summarize(X_ptr, weights_ptr, n)
 
-	cdef double _summarize(self, double* items, double* weights, SIZE_t n) nogil:
+	cdef double _summarize(self, double* X, double* weights, int n) nogil:
 		"""Calculate sufficient statistics for a minibatch.
 
 		The sufficient statistics for a dirichlet distribution is just the
@@ -2439,7 +2352,7 @@ cdef class DirichletDistribution(MultivariateDistribution):
 
 		for i in range(n):
 			for j in range(d):
-				self.summaries_ptr[j] += items[i*d + j] * weights[i]
+				self.summaries_ptr[j] += X[i*d + j] * weights[i]
 
 	def from_summaries(self, inertia=0.0, pseudocount=0.0):
 		"""Update the internal parameters of the distribution."""
@@ -2458,16 +2371,16 @@ cdef class DirichletDistribution(MultivariateDistribution):
 	def clear_summaries(self):
 		self.summaries_ndarray *= 0
 
-	def fit(self, items, weights=None, inertia=0.0, pseudocount=0.0):
-		self.summarize(items, weights)
+	def fit(self, X, weights=None, inertia=0.0, pseudocount=0.0):
+		self.summarize(X, weights)
 		self.from_summaries(inertia, pseudocount)
 
 	@classmethod
-	def from_samples(cls, items, weights=None, **kwargs):
+	def from_samples(cls, X, weights=None, **kwargs):
 		"""Fit a distribution to some data without pre-specifying it."""
 
-		distribution = cls.blank(items.shape[1])
-		distribution.fit(items, weights, **kwargs)
+		distribution = cls.blank(X.shape[1])
+		distribution.fit(X, weights, **kwargs)
 		return distribution
 
 	@classmethod
@@ -2607,14 +2520,6 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		"""
 
 		idx = self.keymap[tuple(X)]
-		return self.values[idx]
-
-	cdef double _mv_log_probability(self, double* X) nogil:
-		cdef int i, idx = 0
-
-		for i in range(self.m+1):
-			idx += self.idxs[i] * <int> X[self.m-i]
-
 		return self.values[idx]
 
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
@@ -2895,14 +2800,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 		key = self.keymap[tuple(X)]
 		return self.values[key]
-
-	cdef double _mv_log_probability(self, double* X) nogil:
-		cdef int i, idx = 0
-
-		for i in range(self.m+1):
-			idx += self.idxs[i] * <int> X[self.m-i]
-
-		return self.values[idx]
 
 	cdef void _v_log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i, j, idx

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -262,11 +262,9 @@ cdef class GeneralMixtureModel(BayesModel):
 
 		for j in range(self.n):
 			if self.is_vl_:
-				r[j*n] = (<Model> self.distributions_ptr[j]) \
-					._vl_log_probability(X, n)
+				r[j*n] = (<Model> self.distributions_ptr[j])._vl_log_probability(X, n)
 			else:
-				(<Model> self.distributions_ptr[j]) \
-					._v_log_probability(X, r+j*n, n)
+				(<Model> self.distributions_ptr[j])._log_probability(X, r+j*n, n)
 
 		for i in range(n):
 			total = NEGINF

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -1388,12 +1388,8 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    if self.multivariate:
-                        e[l*n + i] = ((<Model> distributions[l])._mv_log_probability(sequence+i*dim) +
-                            self.state_weights[l])
-                    else:
-                        e[l*n + i] = ((<Model> distributions[l])._log_probability(sequence[i]) +
-                            self.state_weights[l])
+                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
 
@@ -1558,12 +1554,8 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    if self.multivariate:
-                        e[l*n + i] = ((<Model>distributions[l])._mv_log_probability(sequence+i*dim) +
-                            self.state_weights[l])
-                    else:
-                        e[l*n + i] = ((<Model>distributions[l])._log_probability(sequence[i]) +
-                            self.state_weights[l])
+                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
 
@@ -1800,12 +1792,8 @@ cdef class HiddenMarkovModel(GraphModel):
         # Calculate the emissions table
         for l in range(self.silent_start):
             for i in range(n):
-                if self.multivariate:
-                    e[l*n + i] = ((<Model>distributions[l])._mv_log_probability(sequence+i*dim) +
-                        self.state_weights[l])
-                else:
-                    e[l*n + i] = ((<Model>distributions[l])._log_probability(sequence[i]) +
-                        self.state_weights[l])
+                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                e[l*n + i] += self.state_weights[l]
 
         f = self._forward(sequence, n, e)
         b = self._backward(sequence, n, e)
@@ -1990,12 +1978,8 @@ cdef class HiddenMarkovModel(GraphModel):
         # Fill in the emission table
         for l in range(self.silent_start):
             for i in range(n):
-                if self.multivariate:
-                    e[l*n + i] = ((<Model>distributions[l])._mv_log_probability(sequence+i*dim) +
-                        self.state_weights[l])
-                else:
-                    e[l*n + i] = ((<Model>distributions[l])._log_probability(sequence[i]) +
-                        self.state_weights[l])
+                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                e[l*n + i] += self.state_weights[l]
 
         for i in range(m):
             v[i] = NEGINF
@@ -2225,12 +2209,8 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    if self.multivariate:
-                        e[l*n + i] = ((<Model>distributions[l])._mv_log_probability(sequence+i*dim) +
-                            self.state_weights[l])
-                    else:
-                        e[l*n + i] = ((<Model>distributions[l])._log_probability(sequence[i]) +
-                            self.state_weights[l])
+                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
 
@@ -2658,12 +2638,8 @@ cdef class HiddenMarkovModel(GraphModel):
         e = <double*> calloc(n*self.silent_start, sizeof(double))
         for l in range(self.silent_start):
             for i in range(n):
-                if self.multivariate:
-                    e[l*n + i] = ((<Model>distributions[l])._mv_log_probability(sequence+i*dim) +
-                        self.state_weights[l])
-                else:
-                    e[l*n + i] = ((<Model>distributions[l])._log_probability(sequence[i]) +
-                        self.state_weights[l])
+                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                e[l*n + i] += self.state_weights[l]
 
         f = self._forward(sequence, n, e)
         b = self._backward(sequence, n, e)

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -1388,7 +1388,7 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                     e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
@@ -1554,7 +1554,7 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                     e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
@@ -1792,7 +1792,7 @@ cdef class HiddenMarkovModel(GraphModel):
         # Calculate the emissions table
         for l in range(self.silent_start):
             for i in range(n):
-                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                 e[l*n + i] += self.state_weights[l]
 
         f = self._forward(sequence, n, e)
@@ -1978,7 +1978,7 @@ cdef class HiddenMarkovModel(GraphModel):
         # Fill in the emission table
         for l in range(self.silent_start):
             for i in range(n):
-                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                 e[l*n + i] += self.state_weights[l]
 
         for i in range(m):
@@ -2209,7 +2209,7 @@ cdef class HiddenMarkovModel(GraphModel):
             e = <double*> calloc(n*self.silent_start, sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
-                    (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                    (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                     e[l*n + i] += self.state_weights[l]
         else:
             e = emissions
@@ -2638,7 +2638,7 @@ cdef class HiddenMarkovModel(GraphModel):
         e = <double*> calloc(n*self.silent_start, sizeof(double))
         for l in range(self.silent_start):
             for i in range(n):
-                (<Model> distributions[l])._v_log_probability(sequence+i*dim, e+l*n+i, 1)
+                (<Model> distributions[l])._log_probability(sequence+i*dim, e+l*n+i, 1)
                 e[l*n + i] += self.state_weights[l]
 
         f = self._forward(sequence, n, e)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -21,6 +21,7 @@ from nose.tools import assert_almost_equal
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
+from nose.tools import assert_true
 import pickle
 import numpy
 
@@ -55,6 +56,10 @@ def discrete_equality(x, y, z=8):
 def test_normal():
 	d = NormalDistribution(5, 2)
 	e = NormalDistribution(5., 2.)
+
+	assert_true(isinstance(d.log_probability(5), float))
+	assert_true(isinstance(d.log_probability([5]), float))
+	assert_true(isinstance(d.log_probability([5, 6]), numpy.ndarray))
 
 	assert_almost_equal(d.log_probability(5), -1.61208571, 8)
 	assert_equal(d.log_probability(5), e.log_probability(5))
@@ -524,8 +529,8 @@ def test_independent():
 										   ExponentialDistribution(2)],
 										  weights=[18., 1.])
 
-	assert_equal(round(d.log_probability((4, 1)), 4), -0.1536)
-	assert_equal(round(d.log_probability((100, 0.001)), 4), -1126.1556)
+	assert_equal(round(d.log_probability((4, 1)), 4), -32.5744)
+	assert_equal(round(d.log_probability((100, 0.001)), 4), -20334.5764)
 
 	d.fit([(5, 1), (5.2, 1.7), (4.7, 1.9), (4.9, 2.4), (4.5, 1.2)])
 

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -9,6 +9,7 @@ from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_raises
 from nose.tools import assert_greater
+from numpy.testing import assert_array_almost_equal
 import pickle
 import random
 import numpy as np
@@ -17,21 +18,10 @@ import time
 np.random.seed(0)
 random.seed(0)
 
-def setup():
-	'''
-	Build a model that we want to use to test sequences. This model will
-	be somewhat complicated, in order to extensively test YAHMM. This will be
-	a three state global sequence alignment HMM. The HMM models a reference of
-	'ACT', with pseudocounts to allow for slight deviations from this
-	reference.
-	'''
+NEGINF = float("-inf")
 
-	global model
-	global m1, m2, m3
+def sparse_model(d1, d2, d3, i_d):
 	model = HiddenMarkovModel("Global Alignment")
-
-	# Define the distribution for insertions
-	i_d = DiscreteDistribution({ 'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25 })
 
 	# Create the insert states
 	i0 = State(i_d, name="I0")
@@ -40,9 +30,9 @@ def setup():
 	i3 = State(i_d, name="I3")
 
 	# Create the match states
-	m1 = State(DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 }) , name="M1")
-	m2 = State(DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 }) , name="M2")
-	m3 = State(DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 }) , name="M3")
+	m1 = State(d1, name="M1")
+	m2 = State(d2, name="M2")
+	m3 = State(d3, name="M3")
 
 	# Create the delete states
 	d1 = State(None, name="D1")
@@ -50,7 +40,7 @@ def setup():
 	d3 = State(None, name="D3")
 
 	# Add all the states to the model
-	model.add_states([i0, i1, i2, i3, m1, m2, m3, d1, d2, d3])
+	model.add_states(i0, i1, i2, i3, m1, m2, m3, d1, d2, d3)
 
 	# Create transitions from match states
 	model.add_transition(model.start, m1, 0.9)
@@ -94,95 +84,42 @@ def setup():
 
 	# Call bake to finalize the structure of the model.
 	model.bake()
+	return model
+
+
+def setup():
+	global model
+	model = HiddenMarkovModel("Global Alignment")
+
+	i_d = DiscreteDistribution({ 'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25 })
+
+	d1 = DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 })
+	d2 = DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 })
+	d3 = DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 })
+
+	model = sparse_model(d1, d2, d3, i_d)
 
 def setup_multivariate_discrete():
-	'''
-	Build a model that we want to use to test sequences. This model will
-	be somewhat complicated, in order to extensively test YAHMM. This will be
-	a three state global sequence alignment HMM. The HMM models a reference of
-	'ACT', with pseudocounts to allow for slight deviations from this
-	reference.
-	'''
-
 	global model
-	global m1, m2, m3
-	model = HiddenMarkovModel("Global Alignment")
 
 	i1 = DiscreteDistribution({'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25})
 	i2 = DiscreteDistribution({'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25})
-	# Define the distribution for insertions
 	i_d = IndependentComponentsDistribution([i1, i2])
 
-	# Create the insert states
-	i0 = State(i_d, name="I0")
-	i1 = State(i_d, name="I1")
-	i2 = State(i_d, name="I2")
-	i3 = State(i_d, name="I3")
+	d11 = DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 })
+	d12 = DiscreteDistribution({ "A": 0.92, 'C': 0.02, 'G': 0.02, 'T': 0.03 })
 
-	# Create the match states
-	m11 = DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 })
-	m12 = DiscreteDistribution({ "A": 0.92, 'C': 0.02, 'G': 0.02, 'T': 0.03 })
+	d21 = DiscreteDistribution({ "A": 0.005, 'C': 0.96, 'G': 0.005, 'T': 0.003 })
+	d22 = DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 })
 
-	m21 = DiscreteDistribution({ "A": 0.005, 'C': 0.96, 'G': 0.005, 'T': 0.003 })
-	m22 = DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 })
+	d31 = DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 })
+	d32 = DiscreteDistribution({ "A": 0.05, 'C': 0.03, 'G': 0.02, 'T': 0.90 })
 
-	m31 = DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 })
-	m32 = DiscreteDistribution({ "A": 0.05, 'C': 0.03, 'G': 0.02, 'T': 0.90 })
+	d1 = IndependentComponentsDistribution([d11, d12])
+	d2 = IndependentComponentsDistribution([d21, d22])
+	d3 = IndependentComponentsDistribution([d31, d32])
 
-	m1 = State(IndependentComponentsDistribution([m11, m12]), name="M1")
-	m2 = State(IndependentComponentsDistribution([m21, m22]), name="M2")
-	m3 = State(IndependentComponentsDistribution([m31, m32]), name="M3")
-
-	# Create the delete states
-	d1 = State(None, name="D1")
-	d2 = State(None, name="D2")
-	d3 = State(None, name="D3")
-
-	# Add all the states to the model
-	model.add_states([i0, i1, i2, i3, m1, m2, m3, d1, d2, d3])
-
-	# Create transitions from match states
-	model.add_transition(model.start, m1, 0.9)
-	model.add_transition(model.start, i0, 0.1)
-	model.add_transition(m1, m2, 0.9)
-	model.add_transition(m1, i1, 0.05)
-	model.add_transition(m1, d2, 0.05)
-	model.add_transition(m2, m3, 0.9)
-	model.add_transition(m2, i2, 0.05)
-	model.add_transition(m2, d3, 0.05)
-	model.add_transition(m3, model.end, 0.9)
-	model.add_transition(m3, i3, 0.1)
-
-	# Create transitions from insert states
-	model.add_transition(i0, i0, 0.70)
-	model.add_transition(i0, d1, 0.15)
-	model.add_transition(i0, m1, 0.15)
-
-	model.add_transition(i1, i1, 0.70)
-	model.add_transition(i1, d2, 0.15)
-	model.add_transition(i1, m2, 0.15)
-
-	model.add_transition(i2, i2, 0.70)
-	model.add_transition(i2, d3, 0.15)
-	model.add_transition(i2, m3, 0.15)
-
-	model.add_transition(i3, i3, 0.85)
-	model.add_transition(i3, model.end, 0.15)
-
-	# Create transitions from delete states
-	model.add_transition(d1, d2, 0.15)
-	model.add_transition(d1, i1, 0.15)
-	model.add_transition(d1, m2, 0.70) 
-
-	model.add_transition(d2, d3, 0.15)
-	model.add_transition(d2, i2, 0.15)
-	model.add_transition(d2, m3, 0.70)
-
-	model.add_transition(d3, i3, 0.30)
-	model.add_transition(d3, model.end, 0.70)
-
-	# Call bake to finalize the structure of the model.
-	model.bake()
+	model = sparse_model(d1, d2, d3, i_d)
 
 def setup_multivariate_gaussian():
 	'''
@@ -194,84 +131,25 @@ def setup_multivariate_gaussian():
 	'''
 
 	global model
-	global m1, m2, m3
-	model = HiddenMarkovModel("Global Alignment")
 
 	i1 = UniformDistribution(-20, 20)
 	i2 = UniformDistribution(-20, 20)
-	# Define the distribution for insertions
 	i_d = IndependentComponentsDistribution([i1, i2])
 
-	# Create the insert states
-	i0 = State(i_d, name="I0")
-	i1 = State(i_d, name="I1")
-	i2 = State(i_d, name="I2")
-	i3 = State(i_d, name="I3")
+	d11 = NormalDistribution(5, 1)
+	d12 = NormalDistribution(7, 1)
 
-	# Create the match states
-	m11 = NormalDistribution(5, 1)
-	m12 = NormalDistribution(7, 1)
+	d21 = NormalDistribution(13, 1)
+	d22 = NormalDistribution(17, 1)
 
-	m21 = NormalDistribution(13, 1)
-	m22 = NormalDistribution(17, 1)
+	d31 = NormalDistribution(-2, 1)
+	d32 = NormalDistribution(-5, 1)
 
-	m31 = NormalDistribution(-2, 1)
-	m32 = NormalDistribution(-5, 1)
+	d1 = IndependentComponentsDistribution([d11, d12])
+	d2 = IndependentComponentsDistribution([d21, d22])
+	d3 = IndependentComponentsDistribution([d31, d32])
 
-	m1 = State(IndependentComponentsDistribution([m11, m12]), name="M1")
-	m2 = State(IndependentComponentsDistribution([m21, m22]), name="M2")
-	m3 = State(IndependentComponentsDistribution([m31, m32]), name="M3")
-
-	# Create the delete states
-	d1 = State(None, name="D1")
-	d2 = State(None, name="D2")
-	d3 = State(None, name="D3")
-
-	# Add all the states to the model
-	model.add_states([i0, i1, i2, i3, m1, m2, m3, d1, d2, d3])
-
-	# Create transitions from match states
-	model.add_transition(model.start, m1, 0.9)
-	model.add_transition(model.start, i0, 0.1)
-	model.add_transition(m1, m2, 0.9)
-	model.add_transition(m1, i1, 0.05)
-	model.add_transition(m1, d2, 0.05)
-	model.add_transition(m2, m3, 0.9)
-	model.add_transition(m2, i2, 0.05)
-	model.add_transition(m2, d3, 0.05)
-	model.add_transition(m3, model.end, 0.9)
-	model.add_transition(m3, i3, 0.1)
-
-	# Create transitions from insert states
-	model.add_transition(i0, i0, 0.70)
-	model.add_transition(i0, d1, 0.15)
-	model.add_transition(i0, m1, 0.15)
-
-	model.add_transition(i1, i1, 0.70)
-	model.add_transition(i1, d2, 0.15)
-	model.add_transition(i1, m2, 0.15)
-
-	model.add_transition(i2, i2, 0.70)
-	model.add_transition(i2, d3, 0.15)
-	model.add_transition(i2, m3, 0.15)
-
-	model.add_transition(i3, i3, 0.85)
-	model.add_transition(i3, model.end, 0.15)
-
-	# Create transitions from delete states
-	model.add_transition(d1, d2, 0.15)
-	model.add_transition(d1, i1, 0.15)
-	model.add_transition(d1, m2, 0.70) 
-
-	model.add_transition(d2, d3, 0.15)
-	model.add_transition(d2, i2, 0.15)
-	model.add_transition(d2, m3, 0.70)
-
-	model.add_transition(d3, i3, 0.30)
-	model.add_transition(d3, model.end, 0.70)
-
-	# Call bake to finalize the structure of the model.
-	model.bake()
+	model = sparse_model(d1, d2, d3, i_d)
 
 def dense_model(d1, d2, d3, d4):
 	s1 = State(d1, "s1")
@@ -353,6 +231,97 @@ def teardown():
 
 	pass
 
+@with_setup(setup_discrete_dense)
+def test_discrete_forward():
+	f = model.forward(['A', 'B', 'D', 'D', 'C'])
+	logp = numpy.array([[NEGINF, NEGINF, NEGINF, NEGINF, 0., NEGINF],
+				[-2.40794561, -5.11599581, -5.11599581, -3.91202301, NEGINF, -4.40631933],
+				[-6.89188193, -4.35987383, -8.09848286, -7.43200392, NEGINF, -6.52303724],
+				[-8.73634472, -9.47926612, -8.22377759, -5.87605232, NEGINF, -8.01305991],
+				[-10.28388158, -10.39501067, -10.80077009, -6.76858029, NEGINF, -8.99969597],
+				[-11.780373, -11.84820305, -9.00308599, -11.14654124, NEGINF, -11.09251037]])
+	assert_array_almost_equal(f, logp)
+
+@with_setup(setup_gaussian_dense)
+def test_gaussian_forward():
+	f = model.forward([3, 5, 8, 19, 13])
+	logp = numpy.array([[NEGINF, NEGINF, NEGINF, NEGINF, 0.0, NEGINF], 
+		[-5.221523626198319, -4.122911337530209, -15.72152362619832, -339.14208208451845, NEGINF, -6.137807473983832], 
+		[-6.045149476287824, -15.056746007188107, -14.571238720950003, -247.67044476202696, NEGINF, -8.347414404915495], 
+		[-12.157146753448874, -33.766352938119766, -13.083738234853534, -135.8798604314077, NEGINF, -14.126191869688759], 
+		[-111.69303081629936, -177.04513040289305, -19.78896563212587, -31.409154369913637, NEGINF, -22.091541742268795],
+		[-55.01047129270264, -95.01047129270263, -22.605021155923353, -38.93103873379323, NEGINF, -24.90760616769035]])
+	assert_array_almost_equal(f, logp)
+
+
+@with_setup(setup_multivariate_gaussian_dense)
+def test_multivariate_gaussian_forward():
+	f = model.forward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
+	logp = numpy.array([[NEGINF, NEGINF, NEGINF, NEGINF, 0.0, NEGINF], 
+		[-17.388625105797296, -25.109952452723487, -20.33305760532214, -28.085443290422877, NEGINF, -19.639474084287432], 
+		[-41.518178585896166, -62.62215498003203, -56.463304390840634, -63.21955480161304, NEGINF, -43.820763354673296], 
+		[-86.42085732368164, -67.62244823776697, -71.30752972353059, -70.64290643117542, NEGINF, -69.85376066028503]])
+	assert_array_almost_equal(f, logp)
+
+
+@with_setup(setup_poisson_dense)
+def test_poisson_forward():
+	f = model.forward([5, 8, 2, 4, 7, 8, 2])
+	logp = numpy.array([[NEGINF, NEGINF, NEGINF, NEGINF, 0.0, NEGINF], 
+		[-6.724049572762615, -3.874849418805291, -7.396929655216146, -2.6565929124856993, NEGINF, -4.680333421931903], 
+		[-6.730147189571273, -6.114939268804046, -15.76343567997591, -6.1491172641470415, NEGINF, -7.498440536740427], 
+		[-14.331825716875938, -12.23889386200279, -8.404629462451046, -8.953498331843619, NEGINF, -10.236032891838605], 
+		[-15.218653579546471, -13.152885951823485, -13.58596603773139, -10.59764914181018, NEGINF, -12.771059542322048], 
+		[-15.25983657200538, -14.222315575321783, -22.039008189195016, -13.683075848076015, NEGINF, -15.403406295745581], 
+		[-17.30957501126636, -16.957613004675117, -26.32610484066788, -16.995462506806398, NEGINF, -18.279525087145316], 
+		[-25.05974969431663, -23.03771236899512, -19.218787612604835, -19.75231189091333, NEGINF, -21.044274521213687]])
+	assert_array_almost_equal(f, logp)
+
+@with_setup(setup_discrete_dense)
+def test_discrete_backward():
+	f = model.backward(['A', 'B', 'D', 'D', 'C'])
+	logp = numpy.array([[-9.86805902419294, -10.666561769922483, -11.09973677168472, -10.617074536069564, -11.092510372852566, NEGINF], 
+		[-9.120551817416588, -9.07513780778706, -9.061129343592423, -8.517934491110973, -8.143527673240188, NEGINF], 
+		[-6.950743680969357, -6.918207210615943, -6.3171849919534315, -6.328223424806821, -6.314201940019015, NEGINF], 
+		[-5.926238762190273, -5.832923518979429, -5.343210135438772, -5.352351255040521, -5.296020007499352, NEGINF], 
+		[-4.474141923581687, -3.2834143460057716, -3.547379891840237, -4.474141923581686, -3.8922203781319653, NEGINF], 
+		[-2.3025850929940455, -2.3025850929940455, -2.3025850929940455, -2.3025850929940455, NEGINF, 0.0]])
+	assert_array_almost_equal(f, logp)
+
+@with_setup(setup_gaussian_dense)
+def test_gaussian_backward():
+	f = model.backward([3, 5, 8, 19, 13])
+	logp = numpy.array([[-24.010022764471987, -24.820878919065986, -25.359784144328874, -24.666641886986977, -24.907606167690343, NEGINF], 
+		[-20.47495458748052, -21.390489786220005, -22.08295469697486, -21.390527588974052, -22.081667004696868, NEGINF], 
+		[-18.86308443640411, -18.00715991329825, -18.32109321121691, -19.183852463904262, -18.700307092256082, NEGINF], 
+		[-13.533310680731095, -12.147019061523556, -12.434699610689767, -13.533307024859651, -12.840163500171148, NEGINF], 
+		[-6.217255777912353, -4.830961508172448, -5.1186435298576365, -6.217255656072613, -5.524108597352521, NEGINF], 
+		[-2.3025850929940455, -2.3025850929940455, -2.3025850929940455, -2.3025850929940455, NEGINF, 0.0]])
+	assert_array_almost_equal(f, logp)
+
+
+@with_setup(setup_multivariate_gaussian_dense)
+def test_multivariate_gaussian_backward():
+	f = model.backward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
+	logp = numpy.array([[-68.2539137567533, -69.16076639610863, -69.84868309756291, -69.16857768159394, -69.85376066028503, NEGINF], 
+		[-52.47579136451719, -53.392079325925124, -54.08522496164164, -53.392081629466915, -54.08522649261687, NEGINF], 
+		[-28.335582428803374, -28.267824434424867, -28.247424322493245, -27.65418843714621, -27.260167817399534, NEGINF], 
+		[-2.3025850929940455, -2.3025850929940455, -2.3025850929940455, -2.3025850929940455, NEGINF, 0.0]])
+	assert_array_almost_equal(f, logp)
+
+
+@with_setup(setup_poisson_dense)
+def test_poisson_backward():
+	f = model.backward([5, 8, 2, 4, 7, 8, 2])
+	logp = numpy.array([[-21.691907586187032, -21.73799328948721, -21.138366991878907, -21.083291604178275, -21.044274521213687, NEGINF], 
+		[-18.8959690490499, -19.147279755417475, -18.96895836891973, -18.554384880883024, -18.344028493972242, NEGINF], 
+		[-16.436767297608355, -15.50289984292892, -15.520463678389667, -16.044844087024796, -15.741349651348344, NEGINF], 
+		[-13.746179478239421, -13.67833968609671, -13.103892290217432, -13.104515632505755, -13.064497897488891, NEGINF], 
+		[-10.900016194765097, -11.134592598694933, -10.70914236553333, -10.534402907712945, -10.472655441966987, NEGINF], 
+		[-8.08666946806842, -8.338743855593863, -8.159657556177146, -7.746210358522981, -7.536781914211483, NEGINF], 
+		[-5.624801928499422, -4.698024820874441, -4.71562372030326, -5.232043004902404, -4.927999971986549, NEGINF], 
+		[-2.3025850929940455, -2.3025850929940455, -2.3025850929940455, -2.3025850929940455, NEGINF, 0.0]])
+	assert_array_almost_equal(f, logp)
 
 @with_setup(setup, teardown)
 def test_viterbi_train():


### PR DESCRIPTION
Explicitly remove the `_log_probability` and `_mv_log_probability` methods, using exclusively `_v_log_probability` to calculate a vector of log probabilities. Renames `_v_log_probability` to `_log_probability`. Follows the scipy format of returning either a single number or an array of log probabilities given the input. This speeds up log probability calculations across almost all models.