### PR TITLE
Fix sampling from Conditional Probability Tables

### DIFF
--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -329,7 +329,7 @@ cdef class Distribution(Model):
 		elif 'Table' in d['name']:
 			parents = [Distribution.from_json(json.dumps(j)) for j in d['parents']]
 			table = []
-			
+
 			for row in d['table']:
 				table.append([])
 				for item in row:
@@ -536,7 +536,7 @@ cdef class BernoulliDistribution(Distribution):
 	def from_summaries(self, inertia=0.0):
 		"""Update the parameters of the distribution from the summaries."""
 
-		p = self.summaries[1] / self.summaries[0] 
+		p = self.summaries[1] / self.summaries[0]
 		self.p = self.p * inertia + p * (1-inertia)
 		self.logp[0] = _log(1-p)
 		self.logp[1] = _log(p)
@@ -703,7 +703,7 @@ cdef class LogNormalDistribution(Distribution):
 		cdef int i
 		for i in range(n):
 			log_probability[i] = -_log(X[i] * self.sigma * SQRT_2_PI) \
-				- 0.5 * ((_log(X[i]) - self.mu) / self.sigma) ** 2			
+				- 0.5 * ((_log(X[i]) - self.mu) / self.sigma) ** 2
 
 	def sample(self, n=None):
 		"""Return a sample from this distribution."""
@@ -1042,7 +1042,7 @@ cdef class GammaDistribution(Distribution):
 		cdef int i
 
 		for i in range(n):
-			log_probability[i] = (_log(beta) * alpha - lgamma(alpha) + 
+			log_probability[i] = (_log(beta) * alpha - lgamma(alpha) +
 				_log(X[i]) * (alpha - 1) - beta * X[i])
 
 	def sample(self, n=None):
@@ -1366,11 +1366,11 @@ cdef class DiscreteDistribution(Distribution):
 			for key, value in self.items():
 				if value >= rand:
 					return key
-				rand -= value		
+				rand -= value
 		else:
 			samples = [self.sample() for i in range(n)]
 			return numpy.array(samples)
-			
+
 
 	def fit(self, items, weights=None, inertia=0.0, pseudocount=0.0):
 		"""
@@ -1861,7 +1861,7 @@ cdef class MultivariateDistribution(Distribution):
 
 		with nogil:
 			self._log_probability(X_ptr, logp_ptr, n)
-		
+
 		if n == 1:
 			return logp_array[0]
 		else:
@@ -2054,7 +2054,7 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 						   }, separators=separators, indent=indent)
 
 	@classmethod
-	def from_samples(self, X, weights=None, distribution_weights=None, 
+	def from_samples(self, X, weights=None, distribution_weights=None,
 		pseudocount=0.0, distributions=None):
 		"""Create a new independent components distribution from data."""
 
@@ -2105,7 +2105,7 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		self._inv_dot_mu = <double*> calloc(d, sizeof(double))
 
 		chol = scipy.linalg.cholesky(self.cov, lower=True)
-		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d), 
+		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d),
 			lower=True).T
 		self._inv_cov = <double*> self.inv_cov.data
 		mdot(self._mu, self._inv_cov, self._inv_dot_mu, 1, d, d)
@@ -2245,7 +2245,7 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 
 		for j in range(d):
 			for k in range(d):
-				cov = (pair_sum[j*d + k] - column_sum[j]*u[k]- column_sum[k]*u[j] + 
+				cov = (pair_sum[j*d + k] - column_sum[j]*u[k]- column_sum[k]*u[j] +
 					self.w_sum*u[j]*u[k]) / self.w_sum
 				self._cov[j*d + k] = self._cov[j*d + k] * inertia + cov * (1-inertia)
 
@@ -2263,7 +2263,7 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 
 		_, self._log_det = numpy.linalg.slogdet(self.cov)
 
-		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d), 
+		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d),
 			lower=True).T
 		self._inv_cov = <double*> self.inv_cov.data
 		mdot(self._mu, self._inv_cov, self._inv_dot_mu, 1, d, d)
@@ -2305,7 +2305,7 @@ cdef class DirichletDistribution(MultivariateDistribution):
 		self.name = "DirichletDistribution"
 		self.frozen = frozen
 		self.d = len(alphas)
-		
+
 		self.alphas = numpy.array(alphas, dtype='float64')
 		self.alphas_ptr = <double*> self.alphas.data
 		self.beta_norm = lgamma(sum(alphas)) - sum([lgamma(alpha) for alpha in alphas])
@@ -2361,8 +2361,8 @@ cdef class DirichletDistribution(MultivariateDistribution):
 			return
 
 		self.summaries_ndarray += pseudocount
-		alphas = self.summaries_ndarray * (1-inertia) + self.alphas * inertia 
-		
+		alphas = self.summaries_ndarray * (1-inertia) + self.alphas * inertia
+
 		self.alphas = alphas
 		self.alphas_ptr = <double*> self.alphas.data
 		self.beta_norm = lgamma(sum(alphas)) - sum([lgamma(alpha) for alpha in alphas])
@@ -2415,7 +2415,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		memset(self.counts, 0, self.n*sizeof(double))
 		memset(self.marginal_counts, 0, self.n*sizeof(double)/self.k)
-		
+
 		self.idxs[0] = 1
 		self.idxs[1] = self.k
 		for i in range(self.m-1):
@@ -2434,7 +2434,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		marginal_keys = []
 		for i, row in enumerate(table[::self.k]):
-			marginal_keys.append((tuple(row[:-2]), i)) 
+			marginal_keys.append((tuple(row[:-2]), i))
 
 		self.marginal_keymap = OrderedDict(marginal_keys)
 		self.parents = parents
@@ -2478,7 +2478,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		marginal_keys = []
 		for i, row in enumerate(keys[::self.k]):
-			marginal_keys.append((tuple(row[:-1]), i)) 
+			marginal_keys.append((tuple(row[:-1]), i))
 
 		self.marginal_keymap = OrderedDict(marginal_keys)
 
@@ -2487,31 +2487,28 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		self.keymap = OrderedDict(keymap)
 
-	def sample(self, parent_values={}):
+	def sample(self, parent_values=None):
 		"""Return a random sample from the conditional probability table."""
+		if parent_values is None:
+			parent_values = {}
 
-		keys = self.keymap.keys()
 		for parent in self.parents:
 			if parent not in parent_values:
 				parent_values[parent] = parent.sample()
 
-		n = len(keys)
-		idxs = []
-		values_ = []
-
-		for i in range(n):
+		sample_cands = []
+		sample_vals = []
+		for key, ind in self.keymap.items():
 			for j, parent in enumerate(self.parents):
-				if parent_values[parent] != keys[i][j]:
+				if parent_values[parent] != key[j]:
 					break
 			else:
-				idxs.append(i)
-				values_.append(cexp(self.values[i]))
+				sample_cands.append(key[-1])
+				sample_vals.append(cexp(self.values[ind]))
 
-		values_ = numpy.cumsum(values_)
-		a = numpy.random.uniform(0, 1)
-		for i in range(len(values_)):
-			if values_[i] > a:
-				return keys[idxs[i]][-1]
+		sample_vals /= numpy.sum(sample_vals)
+		sample_ind = numpy.where(numpy.random.multinomial(1, sample_vals))[0][0]
+		return sample_cands[sample_ind]
 
 	def log_probability(self, X):
 		"""
@@ -2591,12 +2588,12 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 	cdef void __summarize(self, items, double [:] weights):
 		cdef int i, n = len(items)
-		cdef tuple item 
+		cdef tuple item
 
 		for i in range(n):
 			key = self.keymap[tuple(items[i])]
 			self.counts[key] += weights[i]
-			
+
 			key = self.marginal_keymap[tuple(items[i][:-1])]
 			self.marginal_counts[key] += weights[i]
 
@@ -2637,10 +2634,10 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 				k = i / self.k
 
 				if self.marginal_counts[k] > 0:
-					probability = ((self.counts[i] + pseudocount) / 
+					probability = ((self.counts[i] + pseudocount) /
 						(self.marginal_counts[k] + pseudocount * self.k))
 
-					self.values[i] = _log(cexp(self.values[i])*inertia + 
+					self.values[i] = _log(cexp(self.values[i])*inertia +
 						probability*(1-inertia))
 
 				else:
@@ -2739,7 +2736,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		self.count = 0
 
 		memset(self.counts, 0, self.n*sizeof(double))
-		
+
 		self.idxs[0] = 1
 		self.idxs[1] = self.k
 		for i in range(self.m-1):
@@ -2827,7 +2824,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 		if isinstance(neighbor_values, dict):
 			neighbor_values = [neighbor_values.get(d, None) for d in self.parents]
-		
+
 		if isinstance(neighbor_values, list):
 			wrt = neighbor_values.index(None)
 
@@ -2872,7 +2869,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 	cdef void __summarize(self, items, double [:] weights):
 		cdef int i, n = len(items)
-		cdef tuple item 
+		cdef tuple item
 
 		for i in range(n):
 			key = self.keymap[tuple(items[i])]
@@ -2907,7 +2904,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		with nogil:
 			for i in range(self.n):
 				probability = ((self.counts[i] + p) / (self.count + p * self.k))
-				self.values[i] = _log(cexp(self.values[i])*inertia + 
+				self.values[i] = _log(cexp(self.values[i])*inertia +
 					probability*(1-inertia))
 
 		for i in range(self.n):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -22,6 +22,7 @@ from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_true
+from sklearn.utils.testing import assert_array_almost_equal
 import pickle
 import numpy
 
@@ -470,7 +471,7 @@ def test_uniform_kernel():
 @with_setup(setup, teardown)
 def test_bernoulli():
 	d = BernoulliDistribution(0.6)
-	assert_equal(d.probability(0), 0.4) 
+	assert_equal(d.probability(0), 0.4)
 	assert_equal(d.probability(1), 0.6)
 	assert_equal(d.parameters[0], 1-d.probability(0))
 	assert_equal(d.parameters[0], d.probability(1))
@@ -606,7 +607,7 @@ def test_independent():
 		          [0.3, 0.2, 0.6],
 		          [0.5, 0.2, 0.8]])
 
-	d = IndependentComponentsDistribution.from_samples(X, 
+	d = IndependentComponentsDistribution.from_samples(X,
 		distributions=NormalDistribution)
 	assert_almost_equal(d.parameters[0][0].parameters[0], 0.38333, 4)
 	assert_almost_equal(d.parameters[0][0].parameters[1], 0.08975, 4)
@@ -615,13 +616,13 @@ def test_independent():
 	assert_almost_equal(d.parameters[0][2].parameters[0], 0.78333, 4)
 	assert_almost_equal(d.parameters[0][2].parameters[1], 0.10672, 4)
 
-	d = IndependentComponentsDistribution.from_samples(X, 
+	d = IndependentComponentsDistribution.from_samples(X,
 		distributions=ExponentialDistribution)
 	assert_almost_equal(d.parameters[0][0].parameters[0], 2.6087, 4)
 	assert_almost_equal(d.parameters[0][1].parameters[0], 4.6154, 4)
 	assert_almost_equal(d.parameters[0][2].parameters[0], 1.2766, 4)
 
-	d = IndependentComponentsDistribution.from_samples(X, 
+	d = IndependentComponentsDistribution.from_samples(X,
 		distributions=[NormalDistribution, NormalDistribution, NormalDistribution])
 	assert_almost_equal(d.parameters[0][0].parameters[0], 0.38333, 4)
 	assert_almost_equal(d.parameters[0][0].parameters[1], 0.08975, 4)
@@ -630,7 +631,7 @@ def test_independent():
 	assert_almost_equal(d.parameters[0][2].parameters[0], 0.78333, 4)
 	assert_almost_equal(d.parameters[0][2].parameters[1], 0.10672, 4)
 
-	d = IndependentComponentsDistribution.from_samples(X, 
+	d = IndependentComponentsDistribution.from_samples(X,
 		distributions=[NormalDistribution, LogNormalDistribution, ExponentialDistribution])
 	assert_almost_equal(d.parameters[0][0].parameters[0], 0.38333, 4)
 	assert_almost_equal(d.parameters[0][0].parameters[1], 0.08975, 4)
@@ -731,7 +732,7 @@ def test_univariate_log_probability():
 
 def test_multivariate_log_probability():
 	X = numpy.random.randn(100, 5)
-	
+
 	d = MultivariateGaussianDistribution.from_samples(X)
 	logp = d.log_probability(X)
 	for i in range(100):
@@ -742,3 +743,31 @@ def test_multivariate_log_probability():
 	for i in range(100):
 		assert_almost_equal(d.log_probability(X[i]), logp[i])
 
+def test_cpd_sampling():
+	d1 = DiscreteDistribution({"A": 0.1, "B": 0.9})
+	d2 = ConditionalProbabilityTable(
+		[["A", "A", 0.1], ["A", "B", 0.9], ["B", "A", 0.7], ["B", "B", 0.3]],
+		[d1])
+
+	# P(A) = 0.1*0.1 + 0.9*0.7 = 0.64
+	# P(B) = 0.1*0.9 + 0.9*0.3 = 0.36
+	true = [0.64, 0.36]
+	est = numpy.bincount([0 if d2.sample() == "A" else 1 for i in range(1000)]) / 1000.0
+	assert_array_almost_equal(est, true, 1)
+
+	# when A is observed, it reduces to [0.1, 0.9]
+	true1 = [0.1, 0.9]
+	par_val = {}
+	par_val[d1] = "A"
+	est = numpy.bincount(
+		[0 if d2.sample(parent_values=par_val) == "A" else 1 for i in range(1000)]
+		) / 1000.0
+	assert_array_almost_equal(est, true1, 1)
+
+	true2= [0.7, 0.3]
+	par_val = {}
+	par_val[d1] = "B"
+	est = numpy.bincount(
+		[0 if d2.sample(parent_values=par_val) == "A" else 1 for i in range(1000)]
+		) / 1000.0
+	assert_array_almost_equal(est, true2, 1)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -22,7 +22,6 @@ from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 from nose.tools import assert_less_equal
 from nose.tools import assert_true
-from sklearn.utils.testing import assert_array_almost_equal
 import pickle
 import numpy
 
@@ -753,7 +752,8 @@ def test_cpd_sampling():
 	# P(B) = 0.1*0.9 + 0.9*0.3 = 0.36
 	true = [0.64, 0.36]
 	est = numpy.bincount([0 if d2.sample() == "A" else 1 for i in range(1000)]) / 1000.0
-	assert_array_almost_equal(est, true, 1)
+	assert_almost_equal(est[0], true[0], 1)
+	assert_almost_equal(est[1], true[1], 1)
 
 	# when A is observed, it reduces to [0.1, 0.9]
 	true1 = [0.1, 0.9]
@@ -762,7 +762,8 @@ def test_cpd_sampling():
 	est = numpy.bincount(
 		[0 if d2.sample(parent_values=par_val) == "A" else 1 for i in range(1000)]
 		) / 1000.0
-	assert_array_almost_equal(est, true1, 1)
+	assert_almost_equal(est[0], true1[0], 1)
+	assert_almost_equal(est[1], true1[1], 1)
 
 	true2= [0.7, 0.3]
 	par_val = {}
@@ -770,4 +771,5 @@ def test_cpd_sampling():
 	est = numpy.bincount(
 		[0 if d2.sample(parent_values=par_val) == "A" else 1 for i in range(1000)]
 		) / 1000.0
-	assert_array_almost_equal(est, true2, 1)
+	assert_almost_equal(est[0], true2[0], 1)
+	assert_almost_equal(est[1], true2[1], 1)


### PR DESCRIPTION
The Conditional Probability Tables method for sampling seems broken to me.

1. I get this error, TypeError: 'odict_keys' object does not support indexing
2. There is a  dict as a default value (which is mutated). This means the 2nd time I call `sample()`, the value of `parent_values` used is the one modified internally after calling `sample()` for the first time.

I also added a test.