### PR TITLE
docs: Fix the docstring of the HMM's `predict`

### DIFF
--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -2271,12 +2271,8 @@ cdef class HiddenMarkovModel(GraphModel):
 
         Returns
         -------
-        logp : double
-            The log probability of the sequence under the Viterbi path
-
-        path : list of tuples
-            Tuples of (state index, state object) of the states along the
-            Viterbi path.
+        path : list of integers
+            A list of the ids of states along the MAP or the Viterbi path.
         """
 
         if self.d == 0:


### PR DESCRIPTION
* Previously, calling `predict` was the same as calling `viterbi` on a
  HMM object. This behaviour has since changed, but the docs stayed the
  same.

* This commit updates the inline docstring of the `predict` function of
  `HMM` in order to reflect the new situation.

* Fixes #245.

Signed-off-by: mr.Shu <mr@shu.io>