### PR TITLE
Correcting code documentation for NaiveBayes.

### DIFF
--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -276,10 +276,6 @@ cdef class NaiveBayes(BayesModel):
 			distributions of the components. If callable, must also pass in the
 			number of components and kmeans++ will be used to initialize them.
 
-		n_components : int
-			If a callable is passed into distributions then this is the number
-			of components to initialize using the kmeans++ algorithm.
-
 		X : array-like, shape (n_samples, n_dimensions)
 			This is the data to train on. Each row is a sample, and each column
 			is a dimension to train on.
@@ -290,10 +286,10 @@ cdef class NaiveBayes(BayesModel):
 			Default is None.
 
 		pseudocount : double, optional, positive
-            A pseudocount to add to the emission of each distribution. This
-            effectively smoothes the states to prevent 0. probability symbols
-            if they don't happen to occur in the data. Only effects mixture
-            models defined over discrete distributions. Default is 0.
+			A pseudocount to add to the emission of each distribution. This
+			effectively smoothes the states to prevent 0. probability symbols
+			if they don't happen to occur in the data. Only effects mixture
+			models defined over discrete distributions. Default is 0.
 
 		stop_threshold : double, optional, positive
 			The threshold at which EM will terminate for the improvement of
@@ -311,6 +307,10 @@ cdef class NaiveBayes(BayesModel):
 			Whether or not to print out improvement information over
 			iterations. Only required if doing semisupervised learning.
 			Default is False.
+
+		n_jobs : int
+			The number of jobs to use to parallelize, either the number of threads
+			or the number of processes to use. Default is 1.
 
 		Returns
 		-------


### PR DESCRIPTION
When I was looking through the API documentation for NaiveBayes on ReadTheDocs, I noticed that:

  1. The pseudocount parameter documentation for from_samples was tabbed incorrectly (spaces
      rather than tabs), inconsistent with the rest of the docs, which broke the HTML version.
  2. There was an n_components parameter, which seems to have been removed and is now
      inferred automatically.
  3. The n_jobs parameter wasn't documented (but was in e.g., fit).

So I thought I'd fix the above issues (tabbed, removed + added) when I encountered them.