### PR TITLE
[MRG] Added option for explicit end states to hmm.from_samples()

### DIFF
--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -3244,7 +3244,7 @@ cdef class HiddenMarkovModel(GraphModel):
             # Connect states to the end of the model if a non-zero probability
             for i, prob in enumerate(ends):
                 if prob != 0:
-                    model.add_transition(states[j], model.end, prob)
+                    model.add_transition(states[i], model.end, prob)
 
         model.bake(verbose=verbose, merge=merge)
         return model
@@ -3394,16 +3394,15 @@ cdef class HiddenMarkovModel(GraphModel):
             y = clf.predict(X_concat)
 
             distributions = [distribution.from_samples(X_concat[y == i]) for i in range(n_components)]
-        
+
         transition_matrix = numpy.ones((n_components, n_components)) / n_components
         start_probabilities = numpy.ones(n_components) / n_components
         end_probabilities = None
         if end_state:
             end_probabilities = numpy.ones(n_components) / n_components
         model = HiddenMarkovModel.from_matrix(transition_matrix, distributions, start_probabilities, ends=end_probabilities)
-
         model.fit(X, weights, labels, stop_threshold, min_iterations,
-            max_iterations, algorithm, verbose, pseudocount, 
+            max_iterations, algorithm, verbose, pseudocount,
             transition_pseudocount, emission_pseudocount, use_pseudocount,
             inertia, edge_inertia, distribution_inertia, n_jobs)
 

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -3256,7 +3256,7 @@ cdef class HiddenMarkovModel(GraphModel):
         init='kmeans++', max_kmeans_iterations=1, pseudocount=None, 
         transition_pseudocount=0, emission_pseudocount=0.0, 
         use_pseudocount=False, inertia=None, edge_inertia=0.0, 
-        distribution_inertia=0.0, n_jobs=1):
+        distribution_inertia=0.0, n_jobs=1, end_state=False):
         """Learn the transitions and emissions of a model directly from data.
 
         This method will learn both the transition matrix, emission distributions,
@@ -3363,6 +3363,10 @@ cdef class HiddenMarkovModel(GraphModel):
             The number of threads to use when performing training. This
             leads to exact updates. Default is 1.
 
+        end_state : bool, optional
+            Whether to calculate the probability of ending in each state or not.
+            Default is False. 
+
         Returns
         -------
         model : HiddenMarkovModel
@@ -3393,7 +3397,10 @@ cdef class HiddenMarkovModel(GraphModel):
         
         transition_matrix = numpy.ones((n_components, n_components)) / n_components
         start_probabilities = numpy.ones(n_components) / n_components
-        model = HiddenMarkovModel.from_matrix(transition_matrix, distributions, start_probabilities)
+        end_probabilities = None
+        if end_state:
+            end_probabilities = numpy.ones(n_components) / n_components
+        model = HiddenMarkovModel.from_matrix(transition_matrix, distributions, start_probabilities, ends=end_probabilities)
 
         model.fit(X, weights, labels, stop_threshold, min_iterations,
             max_iterations, algorithm, verbose, pseudocount, 

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -924,3 +924,25 @@ def test_multivariate_gaussian_from_samples():
 	logp2 = sum(map(model2.log_probability, X))
 
 	assert_greater(logp2, logp1)
+
+@with_setup(setup_discrete_dense, teardown)
+def test_discrete_from_samples_end_state():
+    X = [model.sample() for i in range(25)]
+    model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, end_state=True)
+
+    #We get non-zero end probabilities for each state
+    assert_greater(model2.dense_transition_matrix()[0][model2.end_index],0)
+    assert_greater(model2.dense_transition_matrix()[1][model2.end_index],0)
+    assert_greater(model2.dense_transition_matrix()[2][model2.end_index],0)
+    assert_greater(model2.dense_transition_matrix()[3][model2.end_index],0)
+
+@with_setup(setup_discrete_dense, teardown)
+def test_discrete_from_samples_no_end_state():
+    X = [model.sample() for i in range(25)]
+    model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, end_state=False)
+
+    #We don't have end probabilities for each state
+    assert_equal(model2.dense_transition_matrix()[0][model2.end_index],0)
+    assert_equal(model2.dense_transition_matrix()[1][model2.end_index],0)
+    assert_equal(model2.dense_transition_matrix()[2][model2.end_index],0)
+    assert_equal(model2.dense_transition_matrix()[3][model2.end_index],0)


### PR DESCRIPTION
Added the option end_state=False to hmm.from_samples. If true, the HMM will also train to determine which states are likely to be the end of the sequence. 