### PR TITLE
don't include leftover .so files in sdist packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.txt
-include pomegranate/*
+include pomegranate/*.c
+include pomegranate/*.pxd


### PR DESCRIPTION
Attempt to fix https://github.com/jmschrei/pomegranate/issues/282.

Remaining .so file are not included in the source distributions.