### PR TITLE
[MRG] Add n_jobs parameter to predict methods

### DIFF
--- a/pomegranate/BayesClassifier.pyx
+++ b/pomegranate/BayesClassifier.pyx
@@ -131,7 +131,8 @@ cdef class BayesClassifier(BayesModel):
 
 		n_jobs : int
 			The number of jobs to use to parallelize, either the number of threads
-			or the number of processes to use. Default is 1.
+			or the number of processes to use. -1 means use all available resources.
+			Default is 1.
 
 		Returns
 		-------
@@ -222,7 +223,7 @@ cdef class BayesClassifier(BayesModel):
 
 		return self
 
-	def summarize( self, X, y, weights=None, n_jobs=1 ):
+	def summarize(self, X, y, weights=None, n_jobs=1):
 		"""Summarize data into stored sufficient statistics for out-of-core training.
 
 		Parameters
@@ -239,7 +240,8 @@ cdef class BayesClassifier(BayesModel):
 
 		n_jobs : int
 			The number of jobs to use to parallelize, either the number of threads
-			or the number of processes to use. Default is 1.
+			or the number of processes to use. -1 means use all available resources.
+			Default is 1.
 
 		Returns
 		-------
@@ -371,7 +373,8 @@ cdef class BayesClassifier(BayesModel):
 
 		n_jobs : int
 			The number of jobs to use to parallelize, either the number of threads
-			or the number of processes to use. Default is 1.
+			or the number of processes to use. -1 means use all available resources.
+			Default is 1.
 
 		Returns
 		-------

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -330,3 +330,9 @@ def _check_input(X, keymap):
 
 
 	return X_ndarray
+
+def parallelize_function(X, cls, func, filename):
+	"""Parallelize a function using joblib multiprocessing."""
+
+	model = cls.from_json(filename)
+	return getattr(model, func)(X)


### PR DESCRIPTION
This adds the n_jobs parameter to the vectorized prediction functions, speeding them up linearly with the number of threads in cases where large amounts of data are being crunched. For an example, a 10 node Bayesian network calculating the log probability of ~100,000 points:

```
Bayesian Network Log Probability (n_jobs=1)
-8317751.26947 25.122713089
Bayesian Network Log Probability (n_jobs=2)
-8317751.26947 18.0607879162
Bayesian Network Log Probability (n_jobs=4)
-8317751.26947 5.8684720993
```