### PR TITLE
[MRG] Semi-supervised HMM training

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -29,6 +29,33 @@ k-means
 	be added in.
 
 
+Hidden Markov Models
+....................
+
+	- Allowed labels for labeled training to take in string names of the states
+	instead of the state objects themselves.
+
+	- Added in `state_names` and `names` parameters to the `from_samples` method
+	to allow for more control over the creation of the model.
+
+	- Added in semi-supervised learning to the `fit` step that can be activated
+	by passing in a list of labels where sequences that have no labels have a None
+	value. This allows for training to occur where some sequences are fully labeled
+	and others have no labels, not for training to occur on partially labeled
+	sequences.
+
+	- Supervised initialization followed by semi-supervised learning added in to the
+	`from_samples` method similarly to other methods. One should do this by passing
+	in string labels for state names, always starting with <model_name>-start, where
+	model_name is the `name` parameter passed into the `from_samples` method. Sequences
+	that do not have labels should have a None instead of a list of corresponding labels.
+	While semi-supervised learning using the `fit` method can support arbitrary
+	transitions amongst silent states, the `from_samples` method does not produce
+	silent states, and so other than the start and end states, all states should be
+	symbol emitting states. If using semi-supervised learning, one must also pass in a
+	list of the state names using the `state_names` parameter that has been added in.
+
+
 Tutorials
 .........
 


### PR DESCRIPTION
Adds support for semi-supervised HMM training. This means in particular that HMMs can be fit to a mixture of fully labeled and completely unlabeled sequences, not that the sequences can be partially labeled. Unlabeled sequences can be specified using `None` instead of a list of labels. Labels can now also be strings in addition to passing in the state object as before. The `from_samples` method now allows you to do semi-supervised learning if you also pass in the corresponding `state_names` list. It will first do a supervised initialization of the emission distributions, followed by semi-supervised updates. You can choose to do semi-supervised updates with either Baum-Welch or the Viterbi algorithm for the unsupervised part by specifying the algorithm.