### PR TITLE
[MRG] Bayesian Network Structure Learning speedup

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -55,6 +55,23 @@ Hidden Markov Models
 	symbol emitting states. If using semi-supervised learning, one must also pass in a
 	list of the state names using the `state_names` parameter that has been added in.
 
+Bayesian Networks
+.................
+
+	- Added in a reduce_dataset parameter to the `from_samples` method that will take
+	in a dataset and create a new dataset that is the unique set of samples, weighted
+	by their weighted occurance in the dataset. Essentially, it takes a dataset that
+	may have repeating members, and produces a new dataset that is entirely unique
+	members. This produces an identically scoring Bayesian network as before, but all
+	structure learning algorithms can be significantly sped up. This speed up is
+	proportional to the redundancy of the dataset, so large datasets on a smallish
+	(< 12) number of variables will see massive speed gains (sometimes even 2-3 orders
+	of magnitude!) whereas past that it may not be beneficial. The redundancy of the
+	dataset (and thus the speedup) can be estimated as n_samples / n_possibilities,
+	where n_samples is the number of samples in the dataset and n_possibilities is
+	the product of the number of unique keys per variable, or 2**d for binary data
+	with d variables. It can be calculated exactly as n_samples / n_unique_samples,
+	as many datasets are biased towards repeating elements. 
 
 Tutorials
 .........

--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -947,8 +947,8 @@ cdef class BayesianNetwork( GraphModel ):
 				else:
 					X_count[x] = weight
 
-			weights = numpy.array(X_count.values(), dtype='float64')
-			X = numpy.array(X_count.keys())
+			weights = numpy.array(list(X_count.values()), dtype='float64')
+			X = numpy.array(list(X_count.keys()))
 			n, d = X.shape
 
 		X_int = numpy.zeros((n, d), dtype='int32')


### PR DESCRIPTION
This speedup comes by reducing the dataset from redundant samples to a set of non-redundant samples weights according to the number of times they occur in the original dataset. Frequently the actually observed items in a dataset are highly redundant even if the space of possibilities is large. This automatically generates a new non-redundant dataset, resulting in potentially massive speedups when doing structure learning (examples to follow.)