### PR TITLE
Specify networkx version <2.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.8.0
 joblib >= 0.9.0b4
-networkx >= 1.8.1
+networkx >= 1.8.1, < 2.0
 scipy >= 0.17.0


### PR DESCRIPTION
Networkx 2.0 changed the behavior of graph.nodes() to produce a NodeView
(which cannot be numerically indexed) instead of a list. See, e.g.
https://networkx.github.io/documentation/networkx-1.10/_modules/networkx/classes/graph.html
https://networkx.github.io/documentation/networkx-2.0/_modules/networkx/classes/graph.html

It's a bummer.

The simplest fix is to require a pre-2.0 version of networkx, which is
all this patch does.

The specific place where this crashes is in hmm.pyx line 734 and 735:
```python
            prestates = self.graph.nodes()
            indices = { prestates[i]: i for i in range(len(prestates)) }
```
doesn't work because prestates[i] doesn't work, because prestates isn't a list under networkx 2.0.

I have not researched how much work it would be to rewrite this such that it's networkx 2.0 compatible. Sorry. 