### PR TITLE
Fix TypeError in HiddenMarkovModel.from_samples()

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,7 +17,8 @@ Changelog
 HiddenMarkovModel
 -----------------
 
-	- The documentation has been fixed so that states are defined as `State(NormalDistribution(0, 1))` instead of incorrectly as `State(Distribution(NormalDistribution(0, 1)))
+	- The documentation has been fixed so that states are defined as `State(NormalDistribution(0, 1))` instead of incorrectly as `State(Distribution(NormalDistribution(0, 1)))`
+	- Fixed a bug in `from_samples` that was causing a TypeError if `name` was not specified when using `DiscreteDistribution` with custom labels.
 
 
 Distributions

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -3540,7 +3540,7 @@ cdef class HiddenMarkovModel(GraphModel):
 
             labels_ = [[label for label in l] for l in labels if l is not None]
             labels_ = numpy.concatenate(labels_)
-            labels_ = numpy.array([l for l in labels_ if l != name+"-start" and l != name+"-end"])
+            labels_ = numpy.array([l for l in labels_ if l != str(name)+"-start" and l != str(name)+"-end"])
             label_set = numpy.unique(labels_)
 
             if distribution is DiscreteDistribution:

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -904,6 +904,18 @@ def test_discrete_from_samples():
 	assert_greater(logp2, logp1)
 
 
+@with_setup(setup_discrete_dense, teardown)
+def test_discrete_from_samples_with_labels():
+	X = [model.sample() for i in range(25)]
+	Y = X.copy()
+	model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, labels=Y)
+
+	logp1 = sum(map(model.log_probability, X))
+	logp2 = sum(map(model2.log_probability, X))
+
+	assert_greater(logp2, logp1)
+
+
 @with_setup(setup_gaussian_dense, teardown)
 def test_gaussian_from_samples():
 	X = [model.sample() for i in range(25)]

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -907,7 +907,7 @@ def test_discrete_from_samples():
 @with_setup(setup_discrete_dense, teardown)
 def test_discrete_from_samples_with_labels():
 	X = [model.sample() for i in range(25)]
-	Y = X.copy()
+	Y = X[:]
 	model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, labels=Y)
 
 	logp1 = sum(map(model.log_probability, X))


### PR DESCRIPTION
When using `HiddenMarkovModel.from_samples()` with `DiscreteDistribution` and passing custom labels, if name attribute is left to None a TypeError will be raised from the concatenation with string.

- Cast `name` to str to prevent "NoneType + str" TypeError when name is None
- Add test case to prevent regression