### PR TITLE
[MRG] Add missing value support for models

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -24,13 +24,37 @@ HiddenMarkovModel
 Distributions
 -------------
 	
-	- Multivariate Gaussian Distributions have had their parameter updates simplifies. This doesn't lead to a significant change in speed, just less code.
+	- Multivariate Gaussian distributions have had their parameter updates simplified. This doesn't lead to a significant change in speed, just less code.
 
 	- Fixed an issue where Poisson Distributions had an overflow issue caused when calculating large factorials by moving the log inside the product.
 
 	- Fixed an issue where Poisson Distributions were not correctly calculating the probability of 0 counts.
 
 	- Fixed an issue where Exponential Distribution would fail when fed integer 0-mode data.
+
+	- Fixed an issue where IndependentComponentDistribution would have incorrect per-dimension weights after serialization.
+
+	- Added in missing value support for fitting and log probability calculations for all univariate distributions, ICD, and MGD through calculating sufficient statistics only on data that exists
+
+	- Fixed an issue with multivariate Gaussian distributions where the covariance matrix is no longer invertible with enough missing data by subtracting the smallest eigenvalue from the diagonal
+
+K-Means
+-------
+
+	- Added in missing value support for k-means clustering by ignoring dimensions that are missing in the data. Can now fit and predict on missing data.
+
+	- Added in missing value support for all initialization strategies
+
+	- Added in a suite of unit tests
+
+	- Added in the `distance` method that returns the distance between each point and each centroid
+
+GeneralMixtureModel
+-------------------
+
+	- Added in missing value support for mixture models through updates to the distributions
+
+	- Expanded the unit test suite and added tests for missing value support
 
 
 Version 0.8.1

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -54,6 +54,7 @@ cdef class Model(object):
 		json : str
 			A properly formatted JSON object.
 		"""
+
 		raise NotImplementedError
 
 	@classmethod
@@ -76,6 +77,7 @@ cdef class Model(object):
 		distribution : Distribution
 			A copy of the distribution with the same parameters.
 		"""
+
 		return self.__class__.from_json( self.to_json() )
 
 	def freeze(self):
@@ -85,23 +87,6 @@ cdef class Model(object):
 	def thaw(self):
 		"""Thaw the distribution, re-allowing updates to occur."""
 		self.frozen = False
-
-	def log_probability(self, double symbol):
-		"""Return the log probability of the given symbol under this
-		distribution.
-
-		Parameters
-		----------
-		symbol : double
-			The symbol to calculate the log probability of (overridden for
-			DiscreteDistributions)
-
-		Returns
-		-------
-		logp : double
-			The log probability of that point under the distribution.
-		"""
-		return NotImplementedError
 
 	def copy(self):
 		"""Return a deep copy of this distribution object.
@@ -118,6 +103,7 @@ cdef class Model(object):
 		distribution : Distribution
 			A copy of the distribution with the same parameters.
 		"""
+
 		return self.__class__(*self.parameters)
 
 	def sample(self, n=None):
@@ -135,6 +121,7 @@ cdef class Model(object):
 			Returns a sample from the distribution of a type in the support
 			of the distribution.
 		"""
+
 		raise NotImplementedError
 
 	def probability(self, symbol):
@@ -150,6 +137,7 @@ cdef class Model(object):
 		probability : double
 			The probability of that point under the distribution.
 		"""
+
 		return numpy.exp(self.log_probability(symbol))
 
 	def log_probability(self, symbol):
@@ -167,7 +155,23 @@ cdef class Model(object):
 		logp : double
 			The log probability of that point under the distribution.
 		"""
+
 		raise NotImplementedError
+
+	def score(self, X, y):
+		"""Return the accuracy of the model on a data set.
+
+		Parameters
+		----------
+		X : numpy.ndarray, shape=(n, d)
+			The values of the data set
+
+		y : numpy.ndarray, shape=(n,)
+			The labels of each value
+		"""
+
+		return (self.predict(X) == y).mean() 
+
 
 	def sample(self, n=None):
 		"""Return a random item sampled from this distribution.
@@ -184,6 +188,7 @@ cdef class Model(object):
 			Returns a sample from the distribution of a type in the support
 			of the distribution.
 		"""
+
 		raise NotImplementedError
 
 	def fit(self, items, weights=None, inertia=0.0):
@@ -212,6 +217,7 @@ cdef class Model(object):
 		-------
 		None
 		"""
+
 		raise NotImplementedError
 
 	def summarize(self, items, weights=None):
@@ -234,6 +240,7 @@ cdef class Model(object):
 		-------
 		None
 		"""
+
 		return NotImplementedError
 
 	def from_summaries(self, inertia=0.0):
@@ -252,6 +259,7 @@ cdef class Model(object):
 		-------
 		None
 		"""
+		
 		return NotImplementedError
 
 	def clear_summaries(self):

--- a/pomegranate/distributions.pxd
+++ b/pomegranate/distributions.pxd
@@ -85,12 +85,14 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 	cdef double* _mu_new
 	cdef double* _cov
 	cdef double _log_det
-	cdef double w_sum
 	cdef double* column_sum
+	cdef double* column_w_sum
 	cdef double* pair_sum
+	cdef double* pair_w_sum
 	cdef double* chol_dot_mu
 	cdef double* _inv_cov
 	cdef double* _inv_dot_mu
+	cdef double _log_probability_missing(self, double* X) nogil
 
 cdef class DirichletDistribution(MultivariateDistribution):
 	cdef public numpy.ndarray alphas

--- a/pomegranate/distributions.pyx
+++ b/pomegranate/distributions.pyx
@@ -29,6 +29,7 @@ from .utils cimport lgamma
 from .utils cimport mdot
 from .utils cimport ndarray_wrap_cpointer
 from .utils cimport _is_gpu_enabled
+from .utils cimport isnan
 
 from collections import OrderedDict
 
@@ -43,6 +44,10 @@ try:
 	import cupy
 except:
 	cupy = object
+
+#cdef extern from "numpy/npy_math.h":
+#	bint npy_isnan(double x)
+
 
 # Define some useful constants
 DEF NEGINF = float("-inf")
@@ -400,7 +405,9 @@ cdef class UniformDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			if X[i] >= self.start and X[i] <= self.end:
+			if isnan(X[i]):
+				log_probability[i] = 1.
+			elif X[i] >= self.start and X[i] <= self.end:
 				log_probability[i] = self.logp
 			else:
 				log_probability[i] = NEGINF
@@ -412,17 +419,21 @@ cdef class UniformDistribution(Distribution):
 
 	cdef double _summarize(self, double* items, double* weights, int n, 
 		int column_idx, int d) nogil:
-		cdef double minimum = INF, maximum = NEGINF
-		cdef double weight = 0.0
 		cdef int i
+		cdef double minimum = INF, maximum = NEGINF
+		cdef double item, weight = 0.0
 
 		for i in range(n):
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
 			weight += weights[i]
 			if weights[i] > 0:
-				if items[i*d + column_idx] < minimum:
-					minimum = items[i*d + column_idx]
-				if items[i*d + column_idx] > maximum:
-					maximum = items[i*d + column_idx]
+				if item < minimum:
+					minimum = item
+				if item > maximum:
+					maximum = item
 
 		with gil:
 			self.summaries[2] += weight
@@ -487,7 +498,10 @@ cdef class BernoulliDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			log_probability[i] = self.logp[<int> X[i]]
+			if isnan(X[i]):
+				log_probability[i] = 1
+			else:
+				log_probability[i] = self.logp[<int> X[i]]
 
 	def sample(self, n=None):
 		return numpy.random.choice(2, p=[1-self.p, self.p], size=n)
@@ -496,10 +510,15 @@ cdef class BernoulliDistribution(Distribution):
 		int column_idx, int d) nogil:
 		cdef int i
 		cdef double w_sum = 0, x_sum = 0
+		cdef double item
 
 		for i in range(n):
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
 			w_sum += weights[i]
-			if items[i*d + column_idx] == 1:
+			if item == 1:
 				x_sum += weights[i]
 
 		with gil:
@@ -542,7 +561,7 @@ cdef class NormalDistribution(Distribution):
 		self.frozen = frozen
 		self.summaries = [0, 0, 0]
 		self.log_sigma_sqrt_2_pi = -_log(std * SQRT_2_PI)
-		self.two_sigma_squared = 2 * std ** 2
+		self.two_sigma_squared = 1. / (2 * std ** 2)
 		self.min_std = min_std
 
 	def __reduce__(self):
@@ -552,8 +571,11 @@ cdef class NormalDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			log_probability[i] = self.log_sigma_sqrt_2_pi - ((X[i] - self.mu) ** 2) /\
-				self.two_sigma_squared
+			if isnan(X[i]):
+				log_probability[i] = 1.
+			else:
+				log_probability[i] = self.log_sigma_sqrt_2_pi - ((X[i] - self.mu) ** 2) *\
+					self.two_sigma_squared
 
 	def sample(self, n=None):
 		return numpy.random.normal(self.mu, self.sigma, n)
@@ -562,12 +584,16 @@ cdef class NormalDistribution(Distribution):
 		int column_idx, int d) nogil:
 		cdef int i, j
 		cdef double x_sum = 0.0, x2_sum = 0.0, w_sum = 0.0
+		cdef double item
 
 		for i in range(n):
-			j = i*d + column_idx
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
 			w_sum += weights[i]
-			x_sum += weights[i] * items[j]
-			x2_sum += weights[i] * items[j] * items[j]
+			x_sum += weights[i] * item
+			x2_sum += weights[i] * item * item
 
 		with gil:
 			self.summaries[0] += w_sum
@@ -597,7 +623,7 @@ cdef class NormalDistribution(Distribution):
 		self.sigma = self.sigma*inertia + sigma*(1-inertia)
 		self.summaries = [0, 0, 0]
 		self.log_sigma_sqrt_2_pi = -_log(sigma * SQRT_2_PI)
-		self.two_sigma_squared = 2 * sigma ** 2
+		self.two_sigma_squared = 1. / (2 * sigma ** 2)
 
 	def clear_summaries(self):
 		"""Clear the summary statistics stored in the object."""
@@ -640,8 +666,11 @@ cdef class LogNormalDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			log_probability[i] = -_log(X[i] * self.sigma * SQRT_2_PI) \
-				- 0.5 * ((_log(X[i]) - self.mu) / self.sigma) ** 2
+			if isnan(X[i]):
+				log_probability[i] = 1.
+			else:
+				log_probability[i] = -_log(X[i] * self.sigma * SQRT_2_PI) - 0.5\
+					* ((_log(X[i]) - self.mu) / self.sigma) ** 2
 
 	def sample(self, n=None):
 		"""Return a sample from this distribution."""
@@ -653,10 +682,14 @@ cdef class LogNormalDistribution(Distribution):
 
 		cdef int i
 		cdef double x_sum = 0.0, x2_sum = 0.0, w_sum = 0.0
-		cdef double log_item
+		cdef double item, log_item
 
 		for i in range(n):
-			log_item = _log(items[i*d + column_idx])
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
+			log_item = _log(item)
 			w_sum += weights[i]
 			x_sum += weights[i] * log_item
 			x2_sum += weights[i] * log_item * log_item
@@ -728,7 +761,10 @@ cdef class ExponentialDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			log_probability[i] = self.log_rate - self.rate * X[i]
+			if isnan(X[i]):
+				log_probability[i] = 1
+			else:
+				log_probability[i] = self.log_rate - self.rate * X[i]
 
 	def sample(self, n=None):
 		return numpy.random.exponential(1. / self.parameters[0], n)
@@ -737,12 +773,17 @@ cdef class ExponentialDistribution(Distribution):
 		int column_idx, int d) nogil:
 		"""Cython function to get the MLE estimate for an exponential."""
 
-		cdef double xw_sum = 0, w = 0
 		cdef int i
+		cdef double xw_sum = 0, w = 0
+		cdef double item
 
 		# Calculate the average, which is the MLE mu estimate
 		for i in range(n):
-			xw_sum += items[i*d + column_idx] * weights[i]
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
+			xw_sum += item * weights[i]
 			w += weights[i]
 
 		with gil:
@@ -806,14 +847,17 @@ cdef class BetaDistribution(Distribution):
 		return self.__class__, (self.alpha, self.beta, self.frozen)
 
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
+		cdef int i
 		cdef double alpha = self.alpha
 		cdef double beta = self.beta
 		cdef double beta_norm = self.beta_norm
-		cdef int i
 
 		for i in range(n):
-			log_probability[i] = beta_norm + (alpha-1)*_log(X[i]) + \
-				(beta-1)*_log(1-X[i])
+			if isnan(X[i]):
+				log_probability[i] = 1
+			else:
+				log_probability[i] = beta_norm + (alpha-1)*_log(X[i]) + \
+					(beta-1)*_log(1-X[i])
 
 	def sample(self, n=None):
 		"""Return a random sample from the beta distribution."""
@@ -823,11 +867,16 @@ cdef class BetaDistribution(Distribution):
 		int column_idx, int d) nogil:
 		"""Cython optimized function for summarizing some data."""
 
-		cdef double alpha = 0, beta = 0
 		cdef int i
+		cdef double alpha = 0, beta = 0
+		cdef double item
 
 		for i in range(n):
-			if items[i*d + column_idx] == 1:
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
+			if item == 1:
 				alpha += weights[i]
 			else:
 				beta += weights[i]
@@ -892,13 +941,16 @@ cdef class GammaDistribution(Distribution):
 		return self.__class__, (self.alpha, self.beta, self.frozen)
 
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
+		cdef int i
 		cdef double alpha = self.alpha
 		cdef double beta = self.beta
-		cdef int i
 
 		for i in range(n):
-			log_probability[i] = (_log(beta) * alpha - lgamma(alpha) +
-				_log(X[i]) * (alpha - 1) - beta * X[i])
+			if isnan(X[i]):
+				log_probability[i] = 1.
+			else:
+				log_probability[i] = (_log(beta) * alpha - lgamma(alpha) +
+					_log(X[i]) * (alpha - 1) - beta * X[i])
 
 	def sample(self, n=None):
 		return numpy.random.gamma(self.parameters[0], 1.0 / self.parameters[1])
@@ -960,11 +1012,16 @@ cdef class GammaDistribution(Distribution):
 		int column_idx, int d) nogil:
 		cdef int i
 		cdef double xw = 0, logxw = 0, w = 0
+		cdef double item
 
 		for i in range(n):
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
 			w += weights[i]
-			xw = items[i*d + column_idx] * weights[i]
-			logxw = _log(items[i*d + column_idx]) * weights[i]
+			xw = item * weights[i]
+			logxw = _log(item) * weights[i]
 
 		with gil:
 			self.summaries[0] += xw
@@ -1211,7 +1268,9 @@ cdef class DiscreteDistribution(Distribution):
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
 		for i in range(n):
-			if X[i] < 0 or X[i] > self.n:
+			if isnan(X[i]):
+				log_probability[i] = 1
+			elif X[i] < 0 or X[i] > self.n:
 				log_probability[i] = NEGINF
 			else:
 				log_probability[i] = self.encoded_log_probability[<int> X[i]]
@@ -1258,13 +1317,18 @@ cdef class DiscreteDistribution(Distribution):
 	cdef double _summarize(self, double* items, double* weights, int n,
 		int column_idx, int d) nogil:
 		cdef int i
+		cdef double item
 		self.encoded_summary = 1
 
 		encoded_counts = <double*> calloc(self.n, sizeof(double))
 		memset(encoded_counts, 0, self.n*sizeof(double))
 
 		for i in range(n):
-			encoded_counts[<int> items[i*d + column_idx]] += weights[i]
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
+			encoded_counts[<int> item] += weights[i]
 
 		with gil:
 			for i in range(self.n):
@@ -1396,7 +1460,9 @@ cdef class PoissonDistribution(Distribution):
 		cdef int i
 
 		for i in range(n):
-			if X[i] < 0 or self.l == 0:
+			if isnan(X[i]):
+				continue
+			elif X[i] < 0 or self.l == 0:
 				log_probability[i] = NEGINF
 			else:
 				log_probability[i] = X[i] * self.logl - self.l - lgamma(X[i]+1)
@@ -1408,11 +1474,16 @@ cdef class PoissonDistribution(Distribution):
 		int column_idx, int d) nogil:
 		"""Cython optimized function to calculate the summary statistics."""
 
-		cdef double x_sum = 0.0, w_sum = 0.0
 		cdef int i
+		cdef double x_sum = 0.0, w_sum = 0.0
+		cdef double item
 
 		for i in range(n):
-			x_sum += items[i*d + column_idx] * weights[i]
+			item = items[i*d + column_idx]
+			if isnan(item):
+				continue
+
+			x_sum += item * weights[i]
 			w_sum += weights[i]
 
 		with gil:
@@ -1742,10 +1813,10 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 
 	property parameters:
 		def __get__(self):
-			return [self.distributions.tolist(), numpy.exp(self.weights).tolist()]
+			return [self.distributions.tolist(), list(self.weights)]
 		def __set__(self, parameters):
 			self.distributions = numpy.asarray(parameters[0], dtype=numpy.object_)
-			self.weights = numpy.log(parameters[1])
+			self.weights = parameters[1]
 
 	def __cinit__(self, distributions=[], weights=None, frozen=False):
 		"""
@@ -1771,7 +1842,7 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 
 	def __reduce__(self):
 		"""Serialize the distribution for pickle."""
-		return self.__class__, (self.distributions, numpy.exp(self.weights), self.frozen)
+		return self.__class__, (self.distributions, self.weights, self.frozen)
 
 	def bake(self, keys):
 		for i, distribution in enumerate(self.distributions):
@@ -1964,18 +2035,18 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		d = self.mu.shape[0]
 		self.d = d
 		self._inv_dot_mu = <double*> calloc(d, sizeof(double))
+		self._mu_new = <double*> calloc(d, sizeof(double))
 
 		chol = scipy.linalg.cholesky(self.cov, lower=True)
 		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d), lower=True).T
 		self._inv_cov = <double*> self.inv_cov.data
 		mdot(self._mu, self._inv_cov, self._inv_dot_mu, 1, d, d)
 
-		self.w_sum = 0.0
-		self.column_sum = <double*> calloc(d, sizeof(double))
+		self.column_sum = <double*> calloc(d*d, sizeof(double))
+		self.column_w_sum = <double*> calloc(d, sizeof(double))
 		self.pair_sum = <double*> calloc(d*d, sizeof(double))
-		memset(self.column_sum, 0, d*sizeof(double))
-		memset(self.pair_sum, 0, d*d*sizeof(double))
-		self._mu_new = <double*> calloc(d, sizeof(double))
+		self.pair_w_sum = <double*> calloc(d*d, sizeof(double))
+		self.clear_summaries()
 
 	def __reduce__(self):
 		"""Serialize the distribution for pickle."""
@@ -1984,7 +2055,9 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 	def __dealloc__(self):
 		free(self._mu_new)
 		free(self.column_sum)
+		free(self.column_w_sum)
 		free(self.pair_sum)
+		free(self.pair_w_sum)
 
 	cdef void _log_probability(self, double* X, double* logp, int n) nogil:
 		cdef int i, j, d = self.d
@@ -2004,12 +2077,33 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		for i in range(n):
 			logp[i] = 0
 			for j in range(d):
-				logp[i] += (dot[i*d + j] - self._inv_dot_mu[j])**2
-
-			logp[i] = -0.5 * (d * LOG_2_PI + logp[i]) - 0.5 * self._log_det
+				if isnan(X[i*d + j]):
+					logp[i] = self._log_probability_missing(X+i*d)
+					break
+				else:
+					logp[i] += (dot[i*d + j] - self._inv_dot_mu[j])**2
+			else:
+				logp[i] = -0.5 * (d * LOG_2_PI + logp[i]) - 0.5 * self._log_det
 
 		if not _is_gpu_enabled():
 			free(dot)
+
+	cdef double _log_probability_missing(self, double* X) nogil:
+		cdef double logp
+
+		with gil:
+			X_ndarray = ndarray_wrap_cpointer(X, self.d)
+			avail = ~numpy.isnan(X_ndarray)
+			if avail.sum() == 0:
+				return 0
+
+			a = numpy.ix_(avail, avail)
+
+
+			d1 = MultivariateGaussianDistribution(self.mu[avail], self.cov[a])
+			logp = d1.log_probability(X_ndarray[avail])
+
+		return logp
 
 	def sample(self, n=None):
 		return numpy.random.multivariate_normal(self.parameters[0],
@@ -2024,58 +2118,75 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		"""
 
 		cdef int i, j, k
-		cdef double w_sum = 0.0
-		cdef double* column_sum = <double*> calloc(d, sizeof(double))
+		cdef double x, w, sqrt_weight, w_sum = 0.0
+		cdef double* column_sum = <double*> calloc(d*d, sizeof(double))
+		cdef double* column_w_sum = <double*> calloc(d, sizeof(double))
 		cdef double* pair_sum
-		memset(column_sum, 0, d*sizeof(double))
+		cdef double* pair_w_sum = <double*> calloc(d*d, sizeof(double))
+
+		memset(column_sum, 0, d*d*sizeof(double))
+		memset(column_w_sum, 0, d*sizeof(double))
+		memset(pair_w_sum, 0, d*d*sizeof(double))
 
 		cdef double* y = <double*> calloc(n*d, sizeof(double))
-
 		cdef double alpha = 1
 		cdef double beta = 0
 
 		for i in range(n):
-			w_sum += weights[i]
+			w = weights[i]
+			w_sum += w
+			sqrt_weight = csqrt(w)
 
 			for j in range(d):
-				y[i*d + j] = X[i*d + j] * weights[i]
-				column_sum[j] += y[i*d + j]
+				x = X[i*d + j]
+				if isnan(x):
+					y[i*d + j] = 0.
+
+					for k in range(d):
+						pair_w_sum[j*d + k] -= w
+						if not isnan(X[i*d + k]):
+							pair_w_sum[k*d + j] -= w
+							column_sum[k*d + j] -= X[i*d + k] * w
+
+				else:
+					y[i*d + j] = x * sqrt_weight
+					column_sum[j*d + j] += x * w
+					column_w_sum[j] += w
 
 		if _is_gpu_enabled():
 			with gil:
-				x_ndarray = ndarray_wrap_cpointer(X, n*d).reshape(n, d)
-				y_ndarray = ndarray_wrap_cpointer(y, n*d).reshape(n, d)
-
+				x_ndarray = ndarray_wrap_cpointer(y, n*d).reshape(n, d)
 				x_gpu = cupy.array(x_ndarray, copy=False)
-				y_gpu = cupy.array(y_ndarray, copy=False)
+				pair_sum_ndarray = cupy.dot(x_gpu.T, x_gpu).get()
 
-				pair_sum_ndarray = cupy.dot(x_gpu.T, y_gpu).get()
-
-				self.w_sum += w_sum
 				for j in range(d):
-					self.column_sum[j] += column_sum[j]
+					self.column_w_sum[j] += column_w_sum[j]
 
 					for k in range(d):
 						self.pair_sum[j*d + k] += pair_sum_ndarray[j, k]
+						self.pair_w_sum[j*d + k] += pair_w_sum[j*d + k] + w_sum
+						self.column_sum[j*d + k] += column_sum[j*d + k]
 
 		else:
 			pair_sum = <double*> calloc(d*d, sizeof(double))
 			memset(pair_sum, 0, d*d*sizeof(double))
 
-			dgemm('N', 'T', &d, &d, &n, &alpha, y, &d, X, &d, &beta, pair_sum, &d)
+			dgemm('N', 'T', &d, &d, &n, &alpha, y, &d, y, &d, &beta, pair_sum, &d)
 
 			with gil:
-				self.w_sum += w_sum
-
 				for j in range(d):
-					self.column_sum[j] += column_sum[j]
+					self.column_w_sum[j] += column_w_sum[j]
 
 					for k in range(d):
 						self.pair_sum[j*d + k] += pair_sum[j*d + k]
+						self.pair_w_sum[j*d + k] += pair_w_sum[j*d + k] + w_sum
+						self.column_sum[j*d + k] += column_sum[j*d + k]
 
 			free(pair_sum)
 
 		free(column_sum)
+		free(column_w_sum)
+		free(pair_w_sum)
 		free(y)
 
 	def from_summaries(self, inertia=0.0, min_covar=1e-5):
@@ -2085,51 +2196,66 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		specified, it holds a sequence of value to weight each item by.
 		"""
 
-		# If no summaries stored or the summary is frozen, don't do anything.
-		if self.frozen == True or self.w_sum < 1e-7:
-			return
-
 		cdef int d = self.d, i, j, k
 		cdef double* column_sum = self.column_sum
-		cdef double* pair_sum = self.pair_sum
-		cdef double* u = self._mu_new
+		cdef double pair_sum
+		cdef double* mu = self._mu_new
 		cdef double cov
 		cdef numpy.ndarray chol
+		cdef double w_sum = 0.0
+
+		for i in range(self.d):
+			w_sum += self.column_w_sum[i]
+
+		# If no summaries stored or the summary is frozen, don't do anything.
+		if self.frozen == True or w_sum < 1e-7:
+			return
+
 
 		for i in range(d):
-			u[i] = self.column_sum[i] / self.w_sum
-			self._mu[i] = self._mu[i] * inertia + u[i] * (1-inertia)
+			mu[i] = self.column_sum[i*d + i] / self.column_w_sum[i]
+			self._mu[i] = self._mu[i] * inertia + mu[i] * (1-inertia)
 
 		for j in range(d):
 			for k in range(d):
-				cov = (pair_sum[j*d + k] - column_sum[j]*u[k]) / self.w_sum
-				self._cov[j*d + k] = self._cov[j*d + k] * inertia + cov * (1-inertia)
+				x_jk = self.pair_sum[j*d + k]
+				w_jk = self.pair_w_sum[j*d + k]
+	            
+				if j == k:
+					x_j = self.column_sum[j*d + j]
+					x_k = self.column_sum[k*d + k]
+				else:
+					x_j = self.column_sum[j*d + j] + self.column_sum[j*d + k]
+					x_k = self.column_sum[k*d + k] + self.column_sum[k*d + j]
 
-		memset(column_sum, 0, d*sizeof(double))
-		memset(pair_sum, 0, d*d*sizeof(double))
-		self.w_sum = 0.0
+				cov = (x_jk - x_j*x_k/w_jk) / w_jk if w_jk > 0.0 else 0
+				self._cov[j*d + k] = self._cov[j*d + k] * inertia + cov * (1-inertia)
 
 		try:
 			chol = scipy.linalg.cholesky(self.cov, lower=True)
+			self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d),
+				lower=True).T
 		except:
-			# Taken from sklearn.gmm, it's possible there are not enough observations
-			# to get a good measurement, so reinitialize this component.
-			self.cov += min_covar * numpy.eye(d)
+			min_eig = numpy.linalg.eig(self.cov)[0].min()
+			self.cov -= numpy.eye(d) * min_eig
+			
 			chol = scipy.linalg.cholesky(self.cov, lower=True)
+			self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d),
+				lower=True).T
 
 		_, self._log_det = numpy.linalg.slogdet(self.cov)
-		self.inv_cov = scipy.linalg.solve_triangular(chol, numpy.eye(d),
-			lower=True).T
-
 		self._inv_cov = <double*> self.inv_cov.data
+
 		mdot(self._mu, self._inv_cov, self._inv_dot_mu, 1, d, d)
+		self.clear_summaries()
 
 	def clear_summaries(self):
 		"""Clear the summary statistics stored in the object."""
 
-		memset(self.column_sum, 0, self.d*sizeof(double))
+		memset(self.column_sum, 0, self.d*self.d*sizeof(double))
+		memset(self.column_w_sum, 0, self.d*sizeof(double))
 		memset(self.pair_sum, 0, self.d*self.d*sizeof(double))
-		self.w_sum = 0.0
+		memset(self.pair_w_sum, 0, self.d*self.d*sizeof(double))
 
 	@classmethod
 	def from_samples(cls, X, weights=None, **kwargs):

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -17,6 +17,7 @@ from .base cimport Model
 from .utils cimport ndarray_wrap_cpointer
 from .utils cimport mdot
 from .utils cimport _is_gpu_enabled
+from .utils cimport isnan
 
 import time
 import json
@@ -34,6 +35,15 @@ except:
 DEF NEGINF = float("-inf")
 DEF INF = float("inf")
 
+cdef double distance(double* X, double* centroid, int d) nogil:
+	cdef int i
+	cdef double distance = 0.0
+	
+	for i in range(d):
+		if not isnan(X[i]):
+			distance += (X[i] - centroid[i]) ** 2
+
+	return distance
 
 cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 	init='first-k', double oversampling_factor=0.95):
@@ -70,22 +80,22 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 
 	cdef int n = X.shape[0], d = X.shape[1]
 	cdef int count, i, j, l, m
-	cdef double distance
+	cdef double dist
 	cdef numpy.ndarray centroids
 	cdef numpy.ndarray min_distance
 	cdef numpy.ndarray min_idxs
+	cdef numpy.ndarray mask
 
 	cdef double* X_ptr = <double*> X.data
 	cdef double* weights_ptr
 	cdef double* min_distance_ptr
 	cdef double* centroids_ptr
-	cdef int* min_idxs_ptr
 	cdef double phi
 
 	if weights is None:
 		weights = numpy.ones(len(X), dtype='float64') / len(X)
 	else:
-		weights = weights / weights.sum()
+		weights = weights.astype('float64') / weights.sum()
 
 	weights_ptr = <double*> (<numpy.ndarray> weights).data
 
@@ -105,32 +115,35 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 
 		idx = numpy.random.choice(n, p=weights)
 		centroids[0] = X[idx]
+		centroids[0][numpy.isnan(centroids[0])] = 0.0
 
 		min_distance = numpy.zeros(n, dtype='float64') + INF
 		min_distance_ptr = <double*> min_distance.data
 
 		for m in range(k-1):
 			for i in range(n):
-				distance = 0
-				for j in range(d):
-					distance += (X_ptr[i*d + j] - centroids_ptr[m*d + j]) ** 2
-				distance *= weights_ptr[i]
+				dist = distance(X_ptr + i*d, centroids_ptr + m*d, d)
+				dist *= weights_ptr[i]
 
-				if distance < min_distance_ptr[i]:
-					min_distance_ptr[i] = distance
+				if dist < min_distance_ptr[i]:
+					min_distance_ptr[i] = dist
 
 			idx = numpy.random.choice(n, p=min_distance / min_distance.sum())
 			centroids[m+1] = X[idx]
+			centroids[m+1][numpy.isnan(centroids[m+1])] = 0.0
 
 	elif init == 'kmeans||':
-		phi = 0
-
 		centroids = numpy.zeros((1, d))
 		idx = numpy.random.choice(n, p=weights)
 		centroids[0] = X[idx]
+		centroids[0][numpy.isnan(centroids[0])] = 0
+		centroids_ptr = <double*> centroids.data
 
-		min_distance = ((X - centroids[0]) ** 2).sum(axis=1)
+		min_distance = numpy.zeros(n, dtype='float64')
 		min_distance_ptr = <double*> min_distance.data
+
+		for i in range(n):
+			min_distance_ptr[i] = distance(X_ptr + i*d, centroids_ptr, d)
 
 		min_idxs = numpy.zeros(n, dtype='int32')
 		min_idxs_ptr = <int*> min_idxs.data
@@ -143,19 +156,17 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 			thresh = oversampling_factor * min_distance / phi
 
 			centroids = numpy.concatenate((centroids, X[prob < thresh]))
+			centroids[numpy.isnan(centroids)] = 0.0
 			centroids_ptr = <double*> centroids.data
 			m = centroids.shape[0] - count
 
 			if m > 0:
 				for i in range(n):
 					for l in range(m):
-						distance = 0
-						for j in range(d):
-							distance += (X_ptr[i*d + j] - centroids_ptr[(l + count)*d + j]) ** 2
-
-						if distance < min_distance_ptr[i]:
-							phi += distance - min_distance_ptr[i]
-							min_distance_ptr[i] = distance
+						dist = distance(X_ptr + i*d, centroids_ptr + (l+count)*d, d)
+						if dist < min_distance_ptr[i]:
+							phi += dist - min_distance_ptr[i]
+							min_distance_ptr[i] = dist
 							min_idxs_ptr[i] = l + count
 
 				count = centroids.shape[0]
@@ -166,6 +177,9 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 		clf.fit(centroids, w)
 		centroids = clf.centroids
 
+	centroids[numpy.isnan(centroids)] = 0.0
+	print "INITIAL CENTROIDS"
+	print centroids
 	return numpy.array(centroids)
 
 cdef class Kmeans(Model):
@@ -225,6 +239,7 @@ cdef class Kmeans(Model):
 			self.centroids_ptr = <double*> self.centroids.data
 			self.centroids_T = self.centroids.T.copy()
 			self.centroids_T_ptr = <double*> self.centroids_T.data
+			self.d = self.centroids.shape[1]
 
 			for i in range(self.k):
 				self.centroid_norms[i] = self.centroids[i].dot(self.centroids[i])
@@ -282,19 +297,49 @@ cdef class Kmeans(Model):
 	cdef void _predict(self, double* X, int* y, int n) nogil:
 		cdef int i, j, l, k = self.k, d = self.d
 		cdef double dist, min_dist
+		cdef double* centroid
 
 		for i in range(n):
 			min_dist = INF
 
 			for j in range(k):
-				dist = 0.0
-
-				for l in range(d):
-					dist += (X[i*d + l] - self.centroids_ptr[j*d + l]) ** 2.0
+				centroid = self.centroids_ptr + j*d
+				dist = distance(X + i*d, centroid, d)
 
 				if dist < min_dist:
 					min_dist = dist
 					y[i] = j
+
+	def distance(self, X):
+		"""Calculate the distance to each centroid.
+
+		Parameters
+		----------
+		X : array-like, shape (n_samples, n_dim)
+			The data to fit to.
+
+		Returns
+		-------
+		y : array-like, shape (n_samples, n_centroids)
+			The index of the nearest centroid.
+		"""
+
+		cdef int i, j, n = X.shape[0], d = self.d
+		cdef double* X_ptr
+		cdef double* centroid
+
+		X = numpy.array(X, dtype='float64')
+		X_ptr = <double*> (<numpy.ndarray> X).data
+
+		dist = numpy.zeros((X.shape[0], self.k))
+
+
+		for i in range(X.shape[0]):
+			for j in range(self.k):
+				centroid = self.centroids_ptr + j*d
+				dist[i, j] = distance(X_ptr + i*d, centroid, d) 
+
+		return dist
 
 	def fit(self, X, weights=None, inertia=0.0, stop_threshold=1e-3,
                 max_iterations=1e3, batch_size=None, batches_per_epoch=None,
@@ -371,7 +416,7 @@ cdef class Kmeans(Model):
 		training_start_time = time.time()
 
 		self.d = d
-		self.summary_sizes = <double*> calloc(self.k, sizeof(double))
+		self.summary_sizes = <double*> calloc(self.k*d, sizeof(double))
 		self.summary_weights = <double*> calloc(self.k*d, sizeof(double))
 
 		if batch_size is None:
@@ -389,18 +434,25 @@ cdef class Kmeans(Model):
 		batches_per_epoch = batches_per_epoch or len(starts)
 		n_seen_batches = 0
 
+		if self.centroids is not None:
+			initial_centroids = self.centroids.copy()
+		else:
+			initial_centroids = None
+
 		with Parallel(n_jobs=n_jobs, backend='threading') as parallel:
 			for i in range(self.n_init):
 				self.clear_summaries()
 				initial_distance_sum = INF
 				iteration, improvement = 0, INF
 
-				if weights is not None:
+				if weights is not None and initial_centroids is None:
 					self.centroids = initialize_centroids(X[:ends[0]], 
 						weights[:ends[0]], self.k, self.init)
-				else:
+				elif weights is None and initial_centroids is None:
 					self.centroids = initialize_centroids(X[:ends[0]], 
 						None, self.k, self.init)
+				else:
+					self.centroids = initial_centroids.copy()
 
 				self.centroids_ptr = <double*> self.centroids.data
 				self.centroids_T = self.centroids.T.copy()
@@ -513,42 +565,61 @@ cdef class Kmeans(Model):
 		int column_idx, int d) nogil:
 		cdef int i, j, l, y, k = self.k, inc = 1
 		cdef double min_dist, dist, total_dist, pdist = 0.0
-		cdef double* summary_sizes = <double*> calloc(k, sizeof(double))
+		cdef double* summary_sizes = <double*> calloc(k*d, sizeof(double))
 		cdef double* summary_weights = <double*> calloc(k*d, sizeof(double))
-		memset(summary_sizes, 0, k*sizeof(double))
+		memset(summary_sizes, 0, k*d*sizeof(double))
 		memset(summary_weights, 0, k*d*sizeof(double))
 
 		cdef double* dists = <double*> calloc(n*k, sizeof(double))
 		memset(dists, 0, n*k*sizeof(double))
-		mdot(X, self.centroids_T_ptr, dists, n, k, d)
+
+		cdef double* X_ = <double*> calloc(n*d, sizeof(double))
+		memset(X_, 0, n*d*sizeof(double))
+
+		cdef double* bias = <double*> calloc(n*k, sizeof(double))
+		memset(bias, 0, n*k*sizeof(double))
+
+		for i in range(n):
+			for j in range(d):
+				idx = i*d + j
+				if isnan(X[idx]):
+					X_[idx] = 0.0
+					for l in range(k):
+						bias[i*k + l] += self.centroids_T_ptr[j*k + l] ** 2
+
+				else:
+					X_[idx] = X[idx]
+
+		mdot(X_, self.centroids_T_ptr, dists, n, k, d)
 
 		for i in range(n):
 			min_dist = INF
-			pdist = ddot(&d, X + i*d, &inc, X + i*d, &inc)
+			pdist = ddot(&d, X_ + i*d, &inc, X_ + i*d, &inc)
 
 			for j in range(k):
-				dist = self.centroid_norms[j] + pdist - 2*dists[i*k + j]
-
+				dist = self.centroid_norms[j] + pdist - 2*dists[i*k + j] - bias[i*k + j]
 				if dist < min_dist:
 					min_dist = dist
 					y = j
 			
 			total_dist += min_dist
-			summary_sizes[y] += weights[i]
 			
 			for l in range(d):
-				summary_weights[y*d + l] += X[i*d + l] * weights[i]
+				if not isnan(X[i*d + l]):
+					summary_sizes[y*d + l] += weights[i]
+					summary_weights[y*d + l] += X[i*d + l] * weights[i]
 
 		with gil:
 			for j in range(k):
-				self.summary_sizes[j] += summary_sizes[j]
-
 				for l in range(d):
+					self.summary_sizes[j*d + l] += summary_sizes[j*d + l]
 					self.summary_weights[j*d + l] += summary_weights[j*d + l]
 
 		free(summary_sizes)
 		free(summary_weights)
 		free(dists)
+		free(X_)
+		free(bias)
 		return total_dist
 
 	def from_summaries(self, double inertia=0.0, clear_summaries=True):
@@ -577,20 +648,25 @@ cdef class Kmeans(Model):
 		None
 		"""
 
-		cdef int l, j, k = self.k, d = self.d
+		cdef int i, l, j, k = self.k, d = self.d
 		cdef double w_sum = 0
 
 		with nogil:
-			for i in range(k):
+			for i in range(k*d):
 				w_sum += self.summary_sizes[i]
 
 			if w_sum > 1e-8:
 				for j in range(k):
 					for l in range(d):
-						self.centroids_ptr[j*d + l] = \
-							inertia * self.centroids_ptr[j*d + l] \
-							+ (1-inertia) * self.summary_weights[j*d + l] \
-							/ self.summary_sizes[j]
+						i = j*d + l
+
+						if self.summary_weights[i] == 0:
+							continue
+						
+						self.centroids_ptr[i] = \
+							inertia * self.centroids_ptr[i] \
+							+ (1-inertia) * self.summary_weights[i] \
+							/ self.summary_sizes[i]
 
 		self.centroids_T = self.centroids.T.copy()
 		self.centroids_T_ptr = <double*> self.centroids_T.data
@@ -602,7 +678,7 @@ cdef class Kmeans(Model):
 			self.clear_summaries()
 
 	def clear_summaries(self):
-		memset(self.summary_sizes, 0, self.k*sizeof(double))
+		memset(self.summary_sizes, 0, self.k*self.d*sizeof(double))
 		memset(self.summary_weights, 0, self.k*self.d*sizeof(double))
 
 	def to_json(self, separators=(',', ' : '), indent=4):

--- a/pomegranate/utils.pxd
+++ b/pomegranate/utils.pxd
@@ -5,6 +5,10 @@ cimport numpy
 
 cdef int* GPU
 
+cdef extern from "numpy/npy_math.h":
+	bint npy_isnan(double x) nogil
+
+cdef bint isnan(double x) nogil
 cdef int _is_gpu_enabled() nogil
 cdef ndarray_wrap_cpointer(void* data, int n)
 cdef void mdot(double* X, double* Y, double* A, int m, int n, int k) nogil

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -38,6 +38,8 @@ numpy.import_array()
 cdef extern from "numpy/ndarraytypes.h":
 	void PyArray_ENABLEFLAGS(numpy.ndarray X, int flags)
 
+cdef bint isnan(double x) nogil:
+	return npy_isnan(x)
 
 # Define some useful constants
 DEF NEGINF = float("-inf")

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -78,7 +78,7 @@ def test_normal():
 	assert_almost_equal(d.log_probability(1e8), -8674697942168743.0, -4)
 
 	d = NormalDistribution(5, 1e-10)
-	assert_almost_equal(d.log_probability(1e100), -4.9999999999999994e+219)
+	assert_almost_equal(d.log_probability(1e100), -4.9999999999999987e+219)
 
 
 	d.fit([0, 2, 3, 2, 100], weights=[0, 5, 2, 3, 200])

--- a/tests/test_gmm.py
+++ b/tests/test_gmm.py
@@ -1,5 +1,3 @@
-from __future__ import  (division, print_function)
-
 from pomegranate import *
 from nose.tools import with_setup
 from nose.tools import assert_true
@@ -8,12 +6,17 @@ from nose.tools import assert_greater
 from nose.tools import assert_raises
 from nose.tools import assert_not_equal
 from numpy.testing import assert_almost_equal
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal
 import random
 import pickle
 import numpy as np
 
 np.random.seed(0)
 random.seed(0)
+
+def setup_nothing():
+	pass
 
 def setup_multivariate_gaussian():
 	"""
@@ -30,6 +33,45 @@ def setup_multivariate_gaussian():
 	gmm = GeneralMixtureModel(mgs)
 
 
+def setup_multivariate_mixed():
+	d11 = NormalDistribution(1, 1)
+	d12 = ExponentialDistribution(5)
+	d13 = LogNormalDistribution(0.5, 0.78)
+	d14 = NormalDistribution(0.4, 0.8)
+	d15 = PoissonDistribution(4)
+	d1 = IndependentComponentsDistribution([d11, d12, d13, d14, d15])
+
+	d21 = NormalDistribution(3, 1)
+	d22 = ExponentialDistribution(35)
+	d23 = LogNormalDistribution(1.8, 1.33)
+	d24 = NormalDistribution(0.5, 0.7)
+	d25 = PoissonDistribution(6)
+	d2 = IndependentComponentsDistribution([d21, d22, d23, d24, d25])
+
+	global gmm
+	gmm = GeneralMixtureModel([d1, d2])
+
+
+def setup_univariate_gaussian():
+	"""
+	Set up a three component univariate Gaussian model.
+	"""
+
+	global gmm
+	gmm = GeneralMixtureModel([NormalDistribution(i*3, 1) for i in range(3)])
+
+
+def setup_univariate_mixed():
+	"""Set up a four component univariate mixed model."""
+
+	global gmm
+	d1 = ExponentialDistribution(5)
+	d2 = NormalDistribution(0, 1.2)
+	d3 = LogNormalDistribution(0.3, 1.4)
+	d4 = PoissonDistribution(5)
+	gmm = GeneralMixtureModel([d1, d2, d3, d4])
+
+
 def teardown():
 	"""
 	Teardown the model, so delete it.
@@ -39,33 +81,121 @@ def teardown():
 
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_multivariate_gmm_log_probability():
-	X = np.array([[1.1, 2.7, 3.0, 4.8, 6.2]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -9.8406, 4)
+def test_gmm_multivariate_gaussian_log_probability():
+	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
+					[1.8, 2.1, 3.1, 5.2, 6.5],
+					[0.9, 2.2, 3.2, 5.0, 5.8],
+					[1.0, 2.1, 3.5, 4.3, 5.2],
+					[1.2, 2.9, 3.1, 4.2, 5.5],
+					[1.8, 1.9, 3.0, 4.9, 5.7],
+					[1.2, 3.1, 2.9, 4.2, 5.9],
+					[1.0, 2.9, 3.9, 4.1, 6.0]])
 
-	X = np.array([[1.8, 2.1, 3.1, 5.2, 6.5]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -9.6717, 4)
+	logp_t = [ -9.8405678, -9.67171158, -9.71615297, -9.89404726, 
+	-10.93812212, -11.06611533, -11.31473392, -10.79220257]
+	logp = gmm.log_probability(X)
 
-	X = np.array([[0.9, 2.2, 3.2, 5.0, 5.8]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -9.7162, 4)
-
-	X = np.array([[1.0, 2.1, 3.5, 4.3, 5.2]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -9.894, 4)
-
-	X = np.array([[1.2, 2.9, 3.1, 4.2, 5.5]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -10.9381, 4)
-
-	X = np.array([[1.8, 1.9, 3.0, 4.9, 5.7]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -11.0661, 4)
-
-	X = np.array([[1.2, 3.1, 2.9, 4.2, 5.9]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -11.3147, 4)
-
-	X = np.array([[1.0, 2.9, 3.9, 4.1, 6.0]])
-	assert_almost_equal(gmm.log_probability(X).sum(), -10.7922, 4)
+	assert_array_almost_equal(logp, logp_t)
 
 
-def test_multivariate_gmm_json():
+@with_setup(setup_multivariate_mixed, teardown)
+def test_gmm_multivariate_mixed_log_probability():
+	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
+					[1.8, 2.1, 3.1, 5.2, 6.5],
+					[0.9, 2.2, 3.2, 5.0, 5.8],
+					[1.0, 2.1, 3.5, 4.3, 5.2],
+					[1.2, 2.9, 3.1, 4.2, 5.5],
+					[1.8, 1.9, 3.0, 4.9, 5.7],
+					[1.2, 3.1, 2.9, 4.2, 5.9],
+					[1.0, 2.9, 3.9, 4.1, 6.0]])
+
+	logp_t = [-33.75384631, -34.1714099,  -32.59702495, -27.39375394, 
+	-30.66715208, -30.52489174, -31.71056782, -30.79589904]
+	logp = gmm.log_probability(X)
+
+	assert_array_almost_equal(logp, logp_t)
+
+
+@with_setup(setup_univariate_gaussian, teardown)
+def test_gmm_univariate_gaussian_log_probability():
+	X = np.array([[1.1], [2.7], [3.0], [4.8], [6.2]])
+	logp = [-2.35925975, -2.03120691, -1.99557605, -2.39638244, -2.03147258]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.8], [2.1], [3.1], [5.2], [6.5]])
+	logp = [-2.39618117, -2.26893273, -1.9995911,  -2.22202965, -2.14007514]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[0.9], [2.2], [3.2], [5.0], [5.8]])
+	logp = [-2.26957032, -2.22113386, -2.01155305, -2.31613252, -2.01751101]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.0], [2.1], [3.5], [4.3], [5.2]])
+	logp = [-2.31613252, -2.26893273, -2.09160506, -2.42491769, -2.22202965]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.2], [2.9], [3.1], [4.2], [5.5]])
+	logp = [-2.39638244, -1.9995911,  -1.9995911,  -2.39618117, -2.09396318]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.8], [1.9], [3.0], [4.9], [5.7]])
+	logp = [-2.39618117, -2.35895351, -1.99557605, -2.35925975, -2.03559364]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.2], [3.1], [2.9], [4.2], [5.9]])
+	logp = [-2.39638244, -1.9995911,  -1.9995911,  -2.39618117, -2.00766654]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.0], [2.9], [3.9], [4.1], [6.0]])
+	logp = [-2.31613252, -1.9995911,  -2.26893273, -2.35895351, -2.00650306]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+
+@with_setup(setup_univariate_mixed, teardown)
+def test_gmm_mixed_log_probability():
+	X = np.array([[1.1], [2.7], [3.0], [4.8], [6.2]])
+	logp = [-2.01561437061559, -2.7951359521294536, -2.8314639809821918, 
+			-2.9108132001193265, -3.1959940375620945]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.8], [2.1], [3.1], [5.2], [6.5]])
+	logp = [-2.4758296236378774, -2.6201420691379314, -2.8383034405278975, 
+			-2.966292939154318, -3.2891059316267657]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[0.9], [2.2], [3.2], [5.0], [5.8]])
+	logp = [-1.8326789033955484, -2.660084457680723, -2.8432332382831653, 
+			-2.9359363402629808, -3.0888100501157312]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.0], [2.1], [3.5], [4.3], [5.2]])
+	logp = [-1.9296484854978633, -2.6201420691379314, -2.850660742142904, 
+			-2.8698462265150058, -2.966292939154318]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.2], [2.9], [3.1], [4.2], [5.5]])
+	logp = [-2.0938404063492411, -2.8222781320451804, -2.8383034405278975, 
+			-2.8650550479352965, -3.0216937107055277]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.8], [1.9], [3.0], [4.9], [5.7]])
+	logp = [-2.4758296236378774, -2.527780058213545, -2.8314639809821918, 
+			-2.9227254358998933, -3.0651517040535605]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.2], [3.1], [2.9], [4.2], [5.9]])
+	logp = [-2.0938404063492411, -2.8383034405278975, -2.8222781320451804, 
+			-2.8650550479352965, -3.1137381280223324]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+	X = np.array([[1.0], [2.9], [3.9], [4.1], [6.0]])
+	logp = [-1.9296484854978633, -2.8222781320451804, -2.8560160466782816, 
+			-2.8612291168066575, -3.1399218398841575]
+	assert_array_almost_equal(gmm.log_probability(X), logp)
+
+
+@with_setup(setup_multivariate_gaussian, teardown)
+def test_gmm_multivariate_gaussian_json():
 	gmm_2 = GeneralMixtureModel.from_json(gmm.to_json())
 
 	X = np.array([[1.1, 2.7, 3.0, 4.8, 6.2]])
@@ -92,9 +222,30 @@ def test_multivariate_gmm_json():
 	X = np.array([[1.0, 2.9, 3.9, 4.1, 6.0]])
 	assert_almost_equal(gmm_2.log_probability(X).sum(), -10.7922, 4)
 
+@with_setup(setup_multivariate_mixed, teardown)
+def test_gmm_multivariate_mixed_json():
+	gmm2 = GeneralMixtureModel.from_json(gmm.to_json())
+
+	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
+					[1.8, 2.1, 3.1, 5.2, 6.5],
+					[0.9, 2.2, 3.2, 5.0, 5.8],
+					[1.0, 2.1, 3.5, 4.3, 5.2],
+					[1.2, 2.9, 3.1, 4.2, 5.5],
+					[1.8, 1.9, 3.0, 4.9, 5.7],
+					[1.2, 3.1, 2.9, 4.2, 5.9],
+					[1.0, 2.9, 3.9, 4.1, 6.0]])
+
+	logp_t = [-33.75384631, -34.1714099,  -32.59702495, -27.39375394, 
+	-30.66715208, -30.52489174, -31.71056782, -30.79589904]
+	logp1 = gmm.log_probability(X)
+	logp2 = gmm2.log_probability(X)
+
+	assert_array_almost_equal(logp2, logp_t)
+	assert_array_almost_equal(logp1, logp2)
+
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_multivariate_gmm_posterior():
+def test_gmm_multivariate_gaussian_predict_log_proba():
 	posterior = np.array([[-2.10001234e+01, -1.23402948e-04, -9.00012340e+00, -4.80001234e+01, -1.17000123e+02],
                           [-2.30009115e+01, -9.11466556e-04, -7.00091147e+00, -4.40009115e+01, -1.11000911e+02]])
 
@@ -106,7 +257,7 @@ def test_multivariate_gmm_posterior():
 
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_multivariate_gmm_maximum_a_posteriori():
+def test_gmm_multivariate_gaussian_predict():
 	X = np.array([[2., 5., 7., 3., 2.],
 		          [1., 2., 5., 2., 5.],
 				  [2., 1., 8., 2., 1.],
@@ -115,7 +266,7 @@ def test_multivariate_gmm_maximum_a_posteriori():
 	assert_almost_equal(gmm.predict(X), gmm.predict_proba(X).argmax(axis=1))
 
 
-def test_multivariate_gmm_train():
+def test_gmm_multivariate_gaussian_fit():
 	d1 = MultivariateGaussianDistribution([0, 0], [[1, 0], [0, 1]])
 	d2 = MultivariateGaussianDistribution([2, 2], [[1, 0], [0, 1]])
 	gmm = GeneralMixtureModel([d1, d2])
@@ -129,10 +280,10 @@ def test_multivariate_gmm_train():
 		          [1.4,  3.1],
 		          [1.0,  1.0]])
 
-	assert_almost_equal(gmm.fit(X, verbose=True), 15.242416, 4)
+	assert_almost_equal(gmm.fit(X), 15.242416, 4)
 
 
-def test_multivariate_gmm_train_iterations():
+def test_gmm_multivariate_gaussian_fit_iterations():
 	X = numpy.concatenate([numpy.random.randn(1000, 3) + i for i in range(2)])
 
 	mu = np.ones(3) * 2
@@ -147,7 +298,7 @@ def test_multivariate_gmm_train_iterations():
 
 	assert_greater(improvement, gmm.fit(X, max_iterations=1))
 
-def test_initialization():
+def test_gmm_initialization():
 	assert_raises(ValueError, GeneralMixtureModel, [])
 
 	assert_raises(TypeError, GeneralMixtureModel, [NormalDistribution(5, 2), MultivariateGaussianDistribution([5, 2], [[1, 0], [0, 1]])])
@@ -157,44 +308,42 @@ def test_initialization():
 
 	MGD = MultivariateGaussianDistribution
 
-	gmm1 = GeneralMixtureModel.from_samples(MGD, 2, X, init='kmeans++')
-	gmm2 = GeneralMixtureModel.from_samples(MGD, 2, X, init='kmeans++', max_iterations=1)
+	gmm1 = GeneralMixtureModel.from_samples(MGD, 2, X, init='first-k')
+	gmm2 = GeneralMixtureModel.from_samples(MGD, 2, X, init='first-k', max_iterations=1)
 	assert_greater(gmm1.log_probability(X).sum(), gmm2.log_probability(X).sum())
 
 	assert_equal(gmm1.d, 5)
 	assert_equal(gmm2.d, 5)
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_dimension():
+def test_gmm_dimension():
 	gmm1 = GeneralMixtureModel([NormalDistribution(0, 1), UniformDistribution(0, 10)])
 
 	assert_equal(gmm.d, 5)
 	assert_equal(gmm1.d, 1)
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_json():
+def test_gmm_json():
 	univariate = GeneralMixtureModel([NormalDistribution(5, 2), UniformDistribution(0, 10)])
 
 	j_univ = univariate.to_json()
 	j_multi = gmm.to_json()
 
 	new_univ = univariate.from_json(j_univ)
-	assert isinstance(new_univ.distributions[0], NormalDistribution)
-	assert isinstance(new_univ.distributions[1], UniformDistribution)
-	numpy.testing.assert_array_equal(univariate.weights, new_univ.weights)
-	assert isinstance(new_univ, GeneralMixtureModel)
+	assert_true(isinstance(new_univ.distributions[0], NormalDistribution))
+	assert_true(isinstance(new_univ.distributions[1], UniformDistribution))
+	assert_true(isinstance(new_univ, GeneralMixtureModel))
+	assert_array_equal(univariate.weights, new_univ.weights)
 
 	new_multi = gmm.from_json(j_multi)
-	assert isinstance(new_multi.distributions[0], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[1], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[2], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[3], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[4], MultivariateGaussianDistribution)
-	numpy.testing.assert_array_almost_equal(gmm.weights, new_multi.weights)
-	assert isinstance(new_multi, GeneralMixtureModel)
+	for i in range(5):
+		assert_true(isinstance(new_multi.distributions[i], MultivariateGaussianDistribution))
+
+	assert_true(isinstance(new_multi, GeneralMixtureModel))
+	assert_array_almost_equal(gmm.weights, new_multi.weights)
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_pickling():
+def test_gmm_pickling():
 	univariate = GeneralMixtureModel(
 		[NormalDistribution(5, 2), UniformDistribution(0, 10)],
         weights=np.array([1.0, 2.0]))
@@ -203,22 +352,20 @@ def test_pickling():
 	j_multi = pickle.dumps(gmm)
 
 	new_univ = pickle.loads(j_univ)
-	assert isinstance(new_univ.distributions[0], NormalDistribution)
-	assert isinstance(new_univ.distributions[1], UniformDistribution)
-	numpy.testing.assert_array_equal(univariate.weights, new_univ.weights)
-	assert isinstance(new_univ, GeneralMixtureModel)
+	assert_true(isinstance(new_univ.distributions[0], NormalDistribution))
+	assert_true(isinstance(new_univ.distributions[1], UniformDistribution))
+	assert_true(isinstance(new_univ, GeneralMixtureModel))
+	assert_array_equal(univariate.weights, new_univ.weights)
 
 	new_multi = pickle.loads(j_multi)
-	assert isinstance(new_multi.distributions[0], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[1], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[2], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[3], MultivariateGaussianDistribution)
-	assert isinstance(new_multi.distributions[4], MultivariateGaussianDistribution)
-	numpy.testing.assert_array_almost_equal(gmm.weights, new_multi.weights)
-	assert isinstance(new_multi, GeneralMixtureModel)
+	for i in range(5):
+		assert_true(isinstance(new_multi.distributions[i], MultivariateGaussianDistribution))
+
+	assert_true(isinstance(new_multi, GeneralMixtureModel))
+	assert_array_almost_equal(gmm.weights, new_multi.weights)
 
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_ooc():
+def test_gmm_multivariate_gaussian_ooc():
 	X = numpy.concatenate([numpy.random.randn(1000, 3) + i for i in range(3)])
 
 	gmm = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
@@ -234,8 +381,9 @@ def test_ooc():
 	assert_almost_equal(gmm.log_probability(X).sum(), gmm3.log_probability(X).sum(), -2)
 	assert_not_equal(gmm.log_probability(X).sum(), gmm4.log_probability(X).sum())
 
+
 @with_setup(setup_multivariate_gaussian, teardown)
-def test_minibatch():
+def test_gmm_multivariate_gaussian_minibatch():
 	X = numpy.concatenate([numpy.random.randn(1000, 3) + i for i in range(3)])
 
 	gmm = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
@@ -243,11 +391,258 @@ def test_minibatch():
 	gmm2 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
 		3, X, init='first-k', max_iterations=5, batch_size=500, batches_per_epoch=1)
 	gmm3 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 
-		3, X, init='first-k', max_iterations=5, batch_size=500, batches_per_epoch=4)
+		3, X, init='first-k', max_iterations=5, batch_size=500, batches_per_epoch=6)
 	gmm4 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
-		3, X, init='first-k', max_iterations=5, batch_size=1000, batches_per_epoch=2)
+		3, X, init='first-k', max_iterations=5, batch_size=3000, batches_per_epoch=1)
 
 	assert_not_equal(gmm.log_probability(X).sum(), gmm2.log_probability(X).sum())
-	assert_not_equal(gmm.log_probability(X).sum(), gmm4.log_probability(X).sum())
 	assert_not_equal(gmm2.log_probability(X).sum(), gmm3.log_probability(X).sum())
-	assert_almost_equal(gmm3.log_probability(X).sum(), gmm4.log_probability(X).sum(), -2)
+	assert_raises(AssertionError, assert_array_almost_equal, gmm3.log_probability(X), 
+		gmm.log_probability(X))
+
+	assert_array_equal(gmm.log_probability(X), gmm4.log_probability(X))
+
+
+def test_gmm_multivariate_gaussian_nan_from_samples():
+	numpy.random.seed(1)
+	X = numpy.concatenate([numpy.random.normal(0, 1, size=(300, 3)), 
+						   numpy.random.normal(8, 1, size=(300, 3))])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(1800), replace=False, size=500)
+	i, j = idxs // 3, idxs % 3
+	
+	X_nan = X.copy()
+	X_nan[i, j] = numpy.nan
+
+	mu1t = [-0.036813615311095164, 0.05802948506749107, 0.09725454186262805]
+	cov1t = [[ 1.02529437, -0.11391075,  0.03146951],
+ 		  	[-0.11391075,  1.03553592, -0.07852064],
+ 		 	[ 0.03146951, -0.07852064,  0.83874547]]
+
+	mu2t = [8.088079704231793, 7.927924504375215, 8.000474719123183]
+	cov2t = [[ 0.95559825, -0.02582016,  0.07491681],
+ 			[-0.02582016,  0.99427793,  0.03304442],
+ 			[ 0.07491681,  0.03304442,  1.15403456]]
+
+	for init in 'first-k', 'random', 'kmeans++':
+		model = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 2, 
+			X_nan, init=init, n_init=1)
+
+		mu1 = model.distributions[0].parameters[0]
+		cov1 = model.distributions[0].parameters[1]
+
+		mu2 = model.distributions[1].parameters[0]
+		cov2 = model.distributions[1].parameters[1]
+
+		assert_array_almost_equal(mu1, mu1t)
+		assert_array_almost_equal(mu2, mu2t)
+		assert_array_almost_equal(cov1, cov1t)
+		assert_array_almost_equal(cov2, cov2t)
+
+
+def test_gmm_multivariate_gaussian_nan_fit():
+	mu1, mu2, mu3 = numpy.zeros(3), numpy.zeros(3)+3, numpy.zeros(3)+5
+	cov1, cov2, cov3 = numpy.eye(3), numpy.eye(3)*2, numpy.eye(3)*0.5
+
+	d1 = MultivariateGaussianDistribution(mu1, cov1)
+	d2 = MultivariateGaussianDistribution(mu2, cov2)
+	d3 = MultivariateGaussianDistribution(mu3, cov3)
+	model = GeneralMixtureModel([d1, d2, d3])
+
+	numpy.random.seed(1)
+	X = numpy.concatenate([numpy.random.normal(0, 1, size=(300, 3)), 
+						   numpy.random.normal(2.5, 1, size=(300, 3)),
+						   numpy.random.normal(6, 1, size=(300, 3))])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(2700), replace=False, size=1000)
+	i, j = idxs // 3, idxs % 3
+
+	model.fit(X)
+
+	mu1t = [-0.003165176330948316, 0.07462401273020161, 0.04001352280548061]
+	cov1t = [[ 0.98556769, -0.10062447,  0.08213565],
+				[-0.10062447,  1.06955989, -0.03085883],
+				[ 0.08213565, -0.03085883,  0.89728992]]
+
+	mu2t = [2.601485766170187, 2.48231424824341, 2.52771758325412]
+	cov2t = [[ 0.94263451, -0.00361101, -0.02668448],
+	 		[-0.00361101,  1.06339061, -0.00408865],
+			 [-0.02668448, -0.00408865,  1.14789789]]
+
+	mu3t = [5.950490843670593, 5.9572969419328725, 6.025950220056731]
+	cov3t = [[ 1.03991941, -0.0232587,  -0.02457755],
+				[-0.0232587,   1.01047466, -0.04948464],
+				[-0.02457755, -0.04948464,  0.85671553]]
+
+	mu1 = model.distributions[0].parameters[0]
+	cov1 = model.distributions[0].parameters[1]
+
+	mu2 = model.distributions[1].parameters[0]
+	cov2 = model.distributions[1].parameters[1]
+
+	mu3 = model.distributions[2].parameters[0]
+	cov3 = model.distributions[2].parameters[1]
+
+	assert_array_almost_equal(mu1, mu1t)
+	assert_array_almost_equal(mu2, mu2t)
+	assert_array_almost_equal(mu3, mu3t)
+	assert_array_almost_equal(cov1, cov1t)
+	assert_array_almost_equal(cov2, cov2t)
+	assert_array_almost_equal(cov3, cov3t)
+
+
+@with_setup(setup_multivariate_gaussian, teardown)
+def test_gmm_multivariate_gaussian_nan_log_probability():
+	numpy.random.seed(1)
+
+	X = numpy.concatenate([numpy.random.normal(0, 1, size=(5, 5)), 
+						   numpy.random.normal(2.5, 1, size=(5, 5)),
+						   numpy.random.normal(6, 1, size=(5, 5))])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(75), replace=False, size=35)
+	i, j = idxs // 5, idxs % 5
+	X[i, j] = numpy.nan
+
+	logp_t = [ -7.73923053e+00,  -7.81725880e+00,  -4.55182482e+00,  -2.45359578e+01,
+			   -8.01289941e+00,  -1.08630517e+01,  -3.10356303e+00,  -3.06193233e+01,
+ 			   -5.46424483e+00,  -1.84952128e+01,  -3.15420910e+01,  -1.01635415e+01,
+  			    1.66533454e-16,  -2.70671185e+00,  -5.69860159e+00]
+
+	logp = gmm.log_probability(X)
+
+	assert_array_almost_equal(logp, logp_t)
+
+
+def test_gmm_multivariate_gaussian_nan_predict():
+	X = numpy.concatenate([numpy.random.normal(0, 1, size=(300, 5)), 
+						   numpy.random.normal(8, 1, size=(300, 5))])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(3000), replace=False, size=900)
+	i, j = idxs // 5, idxs % 5
+	
+	X_nan = X.copy()
+	X_nan[i, j] = numpy.nan
+
+	for init in 'first-k', 'random', 'kmeans++':
+		model = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 2, 
+			X_nan, init=init, n_init=1)
+
+		for d in model.distributions:
+			assert_equal(numpy.isnan(d.parameters[0]).sum(), 0)
+			assert_equal(numpy.isnan(d.parameters[1]).sum(), 0)
+
+		y_hat = model.predict(X)
+		assert_equal(y_hat.sum(), 300)
+
+
+def test_gmm_multivariate_gaussian_ooc_nan_from_samples():
+	numpy.random.seed(2)
+	X = numpy.concatenate([numpy.random.normal(i*3, 0.5, size=(200, 3)) for i in range(2)])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(1200), replace=False, size=100)
+	i, j = idxs // 3, idxs % 3
+	X[i, j] = numpy.nan
+
+	model1 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
+		2, X, init='first-k', batch_size=None, max_iterations=3)
+	model2 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 
+		2, X, init='first-k', batch_size=400, max_iterations=3)
+	model3 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 
+		2, X, init='first-k', batch_size=100, max_iterations=3)
+
+	cov1 = model1.distributions[0].parameters[1]
+	cov2 = model2.distributions[0].parameters[1]
+	cov3 = model3.distributions[0].parameters[1]
+
+	assert_array_almost_equal(cov1, cov2)
+	assert_array_almost_equal(cov1, cov3)
+
+
+def test_gmm_multivariate_gaussian_ooc_nan_fit():
+	X = numpy.concatenate([numpy.random.normal(i*3, 0.5, size=(100, 3)) for i in range(2)])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(600), replace=False, size=100)
+	i, j = idxs // 3, idxs % 3
+	X[i, j] = numpy.nan
+
+	mus = [numpy.ones(3)*i*3 for i in range(2)]
+	covs = [numpy.eye(3) for i in range(2)]
+
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model1 = GeneralMixtureModel(distributions)
+	model1.fit(X, max_iterations=3)
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model2 = GeneralMixtureModel(distributions)
+	model2.fit(X, batch_size=10, max_iterations=3)
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model3 = GeneralMixtureModel(distributions)
+	model3.fit(X, batch_size=1, max_iterations=3)
+
+	cov1 = model1.distributions[0].parameters[1]
+	cov2 = model2.distributions[0].parameters[1]
+	cov3 = model3.distributions[0].parameters[1]
+
+	assert_array_almost_equal(cov1, cov2)
+	assert_array_almost_equal(cov1, cov3)
+
+
+def test_gmm_multivariate_gaussian_minibatch_nan_from_samples():
+	X = numpy.concatenate([numpy.random.normal(i*2, 1, size=(100, 3)) for i in range(2)])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(600), replace=False, size=100)
+	i, j = idxs // 3, idxs % 3
+	X[i, j] = numpy.nan
+
+	model1 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
+		2, X, init='first-k', batch_size=None, max_iterations=5)
+	model2 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
+		2, X, init='first-k', batch_size=200, max_iterations=5)
+	model3 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
+		2, X, init='first-k', batch_size=50, batches_per_epoch=4,
+		max_iterations=5)
+	model4 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
+		2, X, init='first-k', batch_size=50, batches_per_epoch=1,
+		max_iterations=5)
+
+	cov1 = model1.distributions[0].parameters[1]
+	cov2 = model2.distributions[0].parameters[1]
+	cov3 = model3.distributions[0].parameters[1]
+	cov4 = model4.distributions[0].parameters[1]
+
+	assert_array_almost_equal(cov1, cov2)
+	assert_raises(AssertionError, assert_array_almost_equal, cov1, cov3)
+	assert_raises(AssertionError, assert_array_almost_equal, cov1, cov4)
+
+
+def test_gmm_multivariate_gaussian_minibatch_nan_fit():
+	X = numpy.concatenate([numpy.random.normal(i*3, 0.5, size=(100, 3)) for i in range(2)])
+	numpy.random.shuffle(X)
+	idxs = numpy.random.choice(numpy.arange(600), replace=False, size=100)
+	i, j = idxs // 3, idxs % 3
+	X[i, j] = numpy.nan
+
+	mus = [numpy.ones(3)*i*3 for i in range(2)]
+	covs = [numpy.eye(3) for i in range(2)]
+
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model1 = GeneralMixtureModel(distributions)
+	model1.fit(X, batch_size=None, max_iterations=3)
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model2 = GeneralMixtureModel(distributions)
+	model2.fit(X, batch_size=10, max_iterations=3)
+
+	distributions = [MultivariateGaussianDistribution(mu, cov) for mu, cov in zip(mus, covs)]
+	model3 = GeneralMixtureModel(distributions)
+	model3.fit(X, batch_size=10, batches_per_epoch=5, max_iterations=3)
+
+	cov1 = model1.distributions[0].parameters[1]
+	cov2 = model2.distributions[0].parameters[1]
+	cov3 = model3.distributions[0].parameters[1]
+
+	assert_array_almost_equal(cov1, cov2)
+	assert_raises(AssertionError, assert_array_equal, cov1, cov3)

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -1,0 +1,420 @@
+from pomegranate import *
+from nose.tools import with_setup
+from nose.tools import assert_true
+from nose.tools import assert_equal
+from nose.tools import assert_greater
+from nose.tools import assert_raises
+from nose.tools import assert_not_equal
+from numpy.testing import assert_almost_equal
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_equal
+import random
+import pickle
+import numpy as np
+
+numpy.random.seed(0)
+
+def setup_three_dimensions():
+	global X
+	X = numpy.array([[-0.13174492,  0.51895916, -1.13141796],
+		 [ 7.92260379,  7.86325294,  7.9884075 ],
+         [-0.63378039, -0.96394236, -1.34125012],
+         [ 8.16216236,  8.04655182,  6.68825619],
+         [-0.69595565, -0.19004012,  0.40768949],
+         [ 7.76271281,  8.94969945,  7.03687617],
+         [-1.92481462, -1.03905815, -0.44048926],
+         [ 7.90926091,  7.21944418,  7.15989354],
+         [-0.97493454, -0.04714556, -0.38607725],
+         [ 9.65781658,  7.04832845,  6.47613347]])
+
+	idxs = numpy.array([29, 19, 26, 11,  8, 27, 21,  7, 14, 13])
+	i, j = idxs // 3, idxs % 3
+	
+	global X_nan
+	X_nan = X.copy()
+	X_nan[i, j] = numpy.nan
+
+    
+	global centroids
+	centroids = numpy.array([[0, 0, 0],
+							 [8, 8, 8]])
+
+	global model
+	model = Kmeans(2, centroids)
+
+
+def setup_five_dimensions():
+	global X
+	X = numpy.array([[-0.04320239,  2.25402395, -0.3075753 ,  0.01710706,  2.88816037],
+	      [ 3.6483074 ,  5.03958367,  3.14457941,  4.94180558,  4.32880698],
+	      [ 7.48485345,  8.54100011,  7.90936486,  8.12260819,  6.6466098 ],
+	      [ 12.15394848,  10.52091121,  13.55495735,  10.48190106, 10.94417476],
+          [ 1.21068778,  0.77311369, -0.31479566, -0.51865649,  0.4408653 ],
+          [-0.62796182, -0.34947675, -1.09050772, -0.34591408,  0.78866514],
+          [ 0.5661847 ,  0.30785453,  0.38823634,  1.99717206, -0.99415221],
+          [ 0.10871016,  2.06244903, -0.19580087, -0.22100353, -0.43777027],
+	      [ 3.06987578,  4.8633418 ,  4.23645519,  4.20563589,  3.40046883],
+          [ 3.0471144 ,  3.43070459,  3.88690894,  3.61962816,  3.52399965],
+          [ 3.3020318 ,  5.16491752,  3.85249134,  2.7075964 ,  4.03831846],
+          [ 3.55266908,  2.69803949,  4.13340743,  5.72527752,  4.9840009 ],
+	      [ 7.27689336,  8.99614296,  7.10109146,  7.81354687,  7.27320546],
+          [ 9.55443921,  7.70358635,  8.9762396 ,  7.8054752 ,  7.95933534],
+          [ 7.55150108,  9.09523173,  8.38379803,  8.18932292,  7.70853   ],
+          [ 9.59329137,  8.26811547,  9.82226673,  8.35257773,  8.21768809],
+          [ 11.77294852,  12.33135372,  13.02160394,  12.05536766, 11.96375761],
+          [ 11.08768408,  13.15689157,  12.59002102,  11.16137415, 9.84335332],
+          [ 11.41978669,  11.45646564,  11.77622614,  11.96590564, 12.33083825],
+          [ 12.13323296,  11.89683824,  12.18373541,  13.21432431, 11.79987739]])
+
+	idxs = numpy.array([77, 26, 61, 46, 18, 30, 94, 96, 45, 67,  4, 20, 23, 73, 37, 21, 58,
+       99, 51,  7, 69, 53, 81, 85, 95,  9, 98, 24, 28, 38])
+	i, j = idxs // 5, idxs % 5
+	
+	global X_nan
+	X_nan = X.copy()
+	X_nan[i, j] = numpy.nan
+
+	global centroids
+	centroids = numpy.array([[0, 0, 0, 0, 0],
+							 [4, 4, 4, 4, 4],
+							 [8, 8, 8, 8, 8],
+							 [12, 12, 12, 12, 12]])
+
+	global model
+	model = Kmeans(4, centroids)
+
+
+def test_kmeans_init():
+	centroids = [[2, 3], [5, 7]]
+	model = Kmeans(2, centroids)
+	assert_equal(model.d, 2)
+	assert_equal(model.k, 2)
+	assert_array_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_from_samples():
+	model = Kmeans.from_samples(2, X, init='first-k')
+	centroids = [[-0.872246, -0.344245, -0.578309],
+      			 [ 8.282911,  7.825455,  7.069913]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_from_samples_parallel():
+	model = Kmeans.from_samples(2, X, init='first-k', n_jobs=2)
+	centroids = [[-0.872246, -0.344245, -0.578309],
+      			 [ 8.282911,  7.825455,  7.069913]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_predict():
+	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+	y_hat = model.predict(X)
+	assert_array_equal(y, y_hat)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_predict_parallel():
+	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+	y_hat = model.predict(X, n_jobs=2)
+	assert_array_equal(y, y_hat)
+
+	y_hat = model.predict(X, n_jobs=4)
+	assert_array_equal(y, y_hat)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_predict_large():
+	y = [0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+	y_hat = model.predict(X)
+	assert_array_equal(y, y_hat)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_predict_large_parallel():
+	y = [0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+	y_hat = model.predict(X, n_jobs=2)
+	assert_array_equal(y, y_hat)
+
+	y_hat = model.predict(X, n_jobs=4)
+	assert_array_equal(y, y_hat)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_fit():
+	model.fit(X)
+
+	centroids = [[-0.872246, -0.344245, -0.578309],
+       			 [ 8.282911,  7.825455,  7.069913]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_fit_parallel():
+	model.fit(X, n_jobs=2)
+
+	centroids = [[-0.872246, -0.344245, -0.578309],
+       			 [ 8.282911,  7.825455,  7.069913]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+	model.fit(X, n_jobs=4)
+
+	centroids = [[-0.872246, -0.344245, -0.578309],
+       			 [ 8.282911,  7.825455,  7.069913]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_multiple_init():
+	model1 = Kmeans.from_samples(4, X, init='kmeans++', n_init=1)
+	model2 = Kmeans.from_samples(4, X, init='kmeans++', n_init=25)
+	
+	dist1 = model1.distance(X).min(axis=1).sum()
+	dist2 = model2.distance(X).min(axis=1).sum()
+
+	assert_greater(dist1, dist2)
+
+	model1 = Kmeans.from_samples(4, X, init='first-k', n_init=1)
+	model2 = Kmeans.from_samples(4, X, init='first-k', n_init=5)
+	
+	dist1 = model1.distance(X).min(axis=1).sum()
+	dist2 = model2.distance(X).min(axis=1).sum()
+
+	assert_equal(dist1, dist2)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_ooc_from_samples():
+	numpy.random.seed(0)
+
+	model1 = Kmeans.from_samples(5, X, init='first-k', batch_size=20)
+	model2 = Kmeans.from_samples(5, X, init='first-k', batch_size=None)
+
+	assert_array_equal(model1.centroids, model2.centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_ooc_fit():
+	centroids_copy = numpy.copy(centroids)
+	model1 = Kmeans(2, centroids_copy, n_init=1)
+	model1.fit(X)
+
+	centroids_copy = numpy.copy(centroids)
+	model2 = Kmeans(2, centroids_copy, n_init=1)
+	model2.fit(X, batch_size=10)
+
+	centroids_copy = numpy.copy(centroids)
+	model3 = Kmeans(2, centroids_copy, n_init=1)
+	model3.fit(X, batch_size=1)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+	assert_array_almost_equal(model1.centroids, model3.centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_minibatch_from_samples():
+	model1 = Kmeans.from_samples(4, X, init='first-k', batch_size=10)
+	model2 = Kmeans.from_samples(4, X, init='first-k', batch_size=None)
+	model3 = Kmeans.from_samples(4, X, init='first-k', batch_size=10, batches_per_epoch=1)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_minibatch_fit():
+	centroids_copy = numpy.copy(centroids)
+	model1 = Kmeans(4, centroids_copy)
+	model1.fit(X, batch_size=10)
+
+	centroids_copy = numpy.copy(centroids)
+	model2 = Kmeans(4, centroids_copy)
+	model2.fit(X, batch_size=None)
+
+	centroids_copy = numpy.copy(centroids)
+	model3 = Kmeans(4, centroids_copy)
+	model3.fit(X, batch_size=5, batches_per_epoch=1)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_from_samples():
+	model = Kmeans.from_samples(2, X_nan, init='first-k')
+	centroids = [[-0.872246,  0.235907, -0.785954],
+      			 [ 7.94916 ,  7.825455,  7.395059]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_from_samples_parallel():
+	model = Kmeans.from_samples(2, X_nan, init='first-k', n_jobs=2)
+	centroids = [[-0.872246,  0.235907, -0.785954],
+      			 [ 7.94916 ,  7.825455,  7.395059]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_fit():
+	model.fit(X_nan)
+
+	centroids = [[-0.872246,  0.235907, -0.785954],
+      			 [ 7.94916 ,  7.825455,  7.395059]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_fit_parallel():
+	model.fit(X_nan, n_jobs=2)
+
+	centroids = [[-0.872246,  0.235907, -0.785954],
+      			 [ 7.94916 ,  7.825455,  7.395059]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_nan_fit_large():
+	model.fit(X_nan)
+
+	centroids = [[ -0.187485,   1.541443,  -0.331161,   1.00714 ,  -0.214419],
+		         [  3.393221,   4.200322,   4.027316,   4.25569 ,   3.986697],
+		         [  8.292196,   8.401983,   7.798085,   8.023552,   7.461508],
+		         [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_nan_fit_large_parallel():
+	model.fit(X_nan, n_jobs=2)
+
+	centroids = [[ -0.187485,   1.541443,  -0.331161,   1.00714 ,  -0.214419],
+		         [  3.393221,   4.200322,   4.027316,   4.25569 ,   3.986697],
+		         [  8.292196,   8.401983,   7.798085,   8.023552,   7.461508],
+		         [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
+
+	assert_array_almost_equal(model.centroids, centroids)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_predict():
+	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+	y_hat = model.predict(X_nan)
+
+	assert_array_almost_equal(y, y_hat)
+
+
+@with_setup(setup_three_dimensions)
+def test_kmeans_nan_predict_parallel():
+	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+	y_hat = model.predict(X_nan, n_jobs=2)
+
+	assert_array_almost_equal(y, y_hat)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_nan_large_predict():
+	y = numpy.array([0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
+	y_hat = model.predict(X_nan)
+
+	assert_array_almost_equal(y, y_hat)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_nan_large_predict_parallel():
+	y = numpy.array([0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
+	y_hat = model.predict(X_nan, n_jobs=2)
+
+	assert_array_almost_equal(y, y_hat)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_nan_multiple_init():
+	model1 = Kmeans.from_samples(4, X_nan, init='kmeans++', n_init=1)
+	model2 = Kmeans.from_samples(4, X_nan, init='kmeans++', n_init=25)
+	
+	dist1 = model1.distance(X).min(axis=1).sum()
+	dist2 = model2.distance(X).min(axis=1).sum()
+
+	assert_greater(dist1, dist2)
+
+	model1 = Kmeans.from_samples(4, X_nan, init='first-k', n_init=1)
+	model2 = Kmeans.from_samples(4, X_nan, init='first-k', n_init=5)
+	
+	dist1 = model1.distance(X).min(axis=1).sum()
+	dist2 = model2.distance(X).min(axis=1).sum()
+
+	assert_equal(dist1, dist2)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_ooc_nan_from_samples():
+	model1 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=20)
+	model2 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=None)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_ooc_nan_fit():
+	centroids_copy = numpy.copy(centroids)
+	model1 = Kmeans(4, centroids_copy, n_init=1)
+	model1.fit(X_nan)
+
+	centroids_copy = numpy.copy(centroids)
+	model2 = Kmeans(4, centroids_copy, n_init=1)
+	model2.fit(X_nan, batch_size=10)
+
+	centroids_copy = numpy.copy(centroids)
+	model3 = Kmeans(4, centroids_copy, n_init=1)
+	model3.fit(X_nan, batch_size=1)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids, 4)
+	assert_array_almost_equal(model1.centroids, model3.centroids, 4)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_minibatch_nan_from_samples():
+	model1 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=10)
+	model2 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=None)
+	model3 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=10, batches_per_epoch=1)
+	model4 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=10, batches_per_epoch=2)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+	assert_array_almost_equal(model1.centroids, model4.centroids)
+	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+
+
+@with_setup(setup_five_dimensions)
+def test_kmeans_minibatch_nan_fit():
+	centroids_copy = numpy.copy(centroids)
+	model1 = Kmeans(4, centroids_copy, n_init=1)
+	model1.fit(X, batch_size=10)
+
+	centroids_copy = numpy.copy(centroids)
+	model2 = Kmeans(4, centroids_copy, n_init=1)
+	model2.fit(X, batch_size=None)
+
+	centroids_copy = numpy.copy(centroids)
+	model3 = Kmeans(4, centroids_copy, n_init=1)
+	model3.fit(X, batch_size=10, batches_per_epoch=1)
+
+	centroids_copy = numpy.copy(centroids)
+	model4 = Kmeans(4, centroids_copy, n_init=1)
+	model4.fit(X, batch_size=10, batches_per_epoch=2)
+
+	assert_array_almost_equal(model1.centroids, model2.centroids)
+	assert_array_almost_equal(model1.centroids, model4.centroids)
+	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)

--- a/tests/test_naive_bayes.py
+++ b/tests/test_naive_bayes.py
@@ -97,7 +97,7 @@ def test_univariate_prediction():
 	assert_equal(predicts[3], 0)
 
 def test_multivariate_prediction():
-	X = numpy.concatenate([numpy.random.normal(2, 1, (10, 3)), numpy.random.normal(7, 2, (20, 3))])
+	X = numpy.concatenate([numpy.random.normal(2, 1, (10, 3)), numpy.random.normal(7, 1, (20, 3))])
 	y = numpy.concatenate([numpy.zeros(10), numpy.ones(20)])
 
 	model = NaiveBayes.from_samples(NormalDistribution, X, y)


### PR DESCRIPTION
Added in missing value support for most probability distributions (except JointProbabilityTable, ConditionalProbabilityTable, and DirichletDistribution), k-means clustering, and all compositional models based off of the probability distributions.

Missing values should be indicated using `numpy.nan` in the place of the missing value. The implementations assume missing at random (MAR) missingness, and make updates simply by ignoring the value when calculating sufficient statistics. In the case of univariate distributions this simply means ignoring the missing values. In the case of multivariate Gaussians, this means calculating dot products only on pairs of values that both exist and calculating appropriate summations. Care was taken to make it so that when extra calculations needed to be done for missing data, they were only done when data was actually missing and not when the data is dense. 

Here is an example of the error of the learned covariance matrix when fitting a multivariate Gaussian distribution by ignoring values (like in pomegranate) versus doing a mean imputation step (as you might do to use sklearn). The data is a tilted Gaussian generated using the following code:

```python
tilt = numpy.random.exponential(1.4, size=(d, d))
X = numpy.random.normal(8, 4, size=(n, d)).dot(tilt)
```

![image](https://user-images.githubusercontent.com/3916816/34330166-72c334b4-e8cd-11e7-9367-2a00df9dd273.png)

It is possible to impute missing values using the EM algorithm. This PR does not do that. A future PR will try adding that in. 

When calculating the log probability of a missing value for a single feature, a 1. is returned. This means that the log probability for a multidimensional samples with some missing values is just the log probability of the existing data, ignoring the missing data. In a multivariate Gaussian model, a new Gaussian distribution is created over the existing values (necessary because the inverse covariance matrix changes when you subset the covariance matrix). 

While adding in the unit tests, I realized that they're going to need a lot of refactoring, so I haven't added in unit tests for naive Bayes, Bayes classifiers, or hidden Markov models yet. This does not support missing values for Bayesian networks yet.