### PR TITLE
[MRG] BayesianNetwork missing value support

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -5,15 +5,15 @@
 Release History
 ===============
 
-Version 0.8.2
+Version 0.9.0
 =============
 
 Highlights
 ----------
 
-	- Missing value support has been added in for all models except Bayesian networks and factor graphs. This is done by included the string `nan` in string datasets, or `numpy.nan` in numeric datasets. Model fitting and inference is supported for all models except Bayesian networks for this. The technique is to not collect sufficient statistics from missing data, not to impute the missing values.
+	- Missing value support has been added in for all models except factor graphs. This is done by included the string `nan` in string datasets, or `numpy.nan` in numeric datasets. Model fitting and inference is supported for all models for this. The technique is to not collect sufficient statistics from missing data, not to impute the missing values.
 
-	- The unit testing suite has been greatly expanded, from around 140 tests to around 360 tests.
+	- The unit testing suite has been greatly expanded, from around 140 tests to around 370 tests.
 
 Changelog
 ---------
@@ -41,7 +41,7 @@ Distributions
 
 	- Fixed an issue where IndependentComponentDistribution would have incorrect per-dimension weights after serialization.
 
-	- Added in missing value support for fitting and log probability calculations for all univariate distributions, ICD, and MGD through calculating sufficient statistics only on data that exists
+	- Added in missing value support for fitting and log probability calculations for all univariate distributions, ICD, MGD, and CPTs through calculating sufficient statistics only on data that exists. The only distributions that currently do not support missing values are JointProbabilityTables and DirichletDistributions.
 
 	- Fixed an issue with multivariate Gaussian distributions where the covariance matrix is no longer invertible with enough missing data by subtracting the smallest eigenvalue from the diagonal
 
@@ -77,6 +77,8 @@ BayesianNetwork
 	- Factored out `_check_input` into a function that be used independently
 
 	- Added unit tests to check each of the above functions extensively
+
+	- Missing value support added for the `log_probability`, `fit`, and `from_samples` methods. Chow-Liu trees are not supported for missing values, but using a constraint graph still works.
 
 
 Version 0.8.1

--- a/tests/test_bayes_net.py
+++ b/tests/test_bayes_net.py
@@ -31,6 +31,17 @@ datasets = [numpy.random.randint(2, size=(10, 4)),
             numpy.random.randint(2, size=(1000, 7)),
             numpy.random.randint(2, size=(100, 9))]
 
+datasets_nan = []
+for dataset in datasets:
+    X = dataset.copy().astype('float64')
+    n, d = X.shape
+    
+    idx = numpy.random.choice(n*d, replace=False, size=n*d//5)
+    i, j = idx // d, idx % d
+    X[i, j] = numpy.nan
+
+    datasets_nan.append(X)
+
 def setup_monty():
     # Build a model of the Monty Hall Problem
     global monty_network, monty_index, prize_index, guest_index
@@ -886,3 +897,21 @@ def test_chow_liu_structure_learning():
     for X, logp in zip(datasets, logps):
         model = BayesianNetwork.from_samples(X, algorithm='chow-liu')
         assert_almost_equal(model.log_probability(X).sum(), logp, 4)
+
+
+def test_exact_nan_structure_learning():
+    logps = -6.13764, -159.6505, -2055.76364, -201.73615
+    for X, logp in zip(datasets_nan, logps):
+        model = BayesianNetwork.from_samples(X, algorithm='exact')
+        model2 = BayesianNetwork.from_samples(X, algorithm='exact-dp')
+
+        assert_equal(model.log_probability(X).sum(), model2.log_probability(X).sum())
+        assert_almost_equal(model.log_probability(X).sum(), logp, 4)  
+
+
+def test_greedy_nan_structure_learning():
+    logps = -7.5239, -159.6505, -2058.5706, -203.7662
+    for X, logp in zip(datasets_nan, logps):
+        model = BayesianNetwork.from_samples(X, algorithm='greedy')
+        assert_almost_equal(model.log_probability(X).sum(), logp, 4)
+

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -898,13 +898,11 @@ def test_conditional():
 							 DiscreteDistribution({False: 0.941, True: 0.059}))
 
 
-def test_monty():
+def setup_cpt():
 	guest = DiscreteDistribution({'A': 1. / 3, 'B': 1. / 3, 'C': 1. / 3})
-
-	# The actual prize is independent of the other distributions
 	prize = DiscreteDistribution({'A': 1. / 3, 'B': 1. / 3, 'C': 1. / 3})
 
-	# Monty is dependent on both the guest and the prize.
+	global monty
 	monty = ConditionalProbabilityTable(
 		[['A', 'A', 'A', 0.0],
 		 ['A', 'A', 'B', 0.5],
@@ -934,36 +932,293 @@ def test_monty():
 		 ['C', 'C', 'B', 0.5],
 		 ['C', 'C', 'C', 0.0]], [guest, prize])
 
+	global X
+	X = [['A', 'A', 'C'],
+	 	['A', 'A', 'B'],
+		['A', 'A', 'C'],
+		['A', 'A', 'B'],
+		['A', 'A', 'A'],
+		['A', 'B', 'A'],
+		['A', 'B', 'A'],
+		['A', 'B', 'B'],
+		['A', 'B', 'C'],
+		['A', 'C', 'A'],
+		['A', 'C', 'C'],
+		['A', 'C', 'C'],
+		['A', 'C', 'C'],
+		['A', 'C', 'B'],
+		['B', 'A', 'A'],
+		['B', 'A', 'B'],
+		['B', 'A', 'B'],
+		['B', 'A', 'B'],
+		['B', 'B', 'B'],
+		['B', 'B', 'C'],
+		['B', 'C', 'A'],
+		['B', 'C', 'B'],
+		['B', 'C', 'A'],
+		['B', 'C', 'B'],
+		['C', 'A', 'B'],
+		['C', 'B', 'B'],
+		['C', 'B', 'C'],
+		['C', 'C', 'A'],
+		['C', 'C', 'C'],
+		['C', 'C', 'C'],
+		['C', 'C', 'C']]
+
+
+	global X_nan
+	X_nan = [['nan', 'A', 'C'],
+	 	['A', 'A', 'nan'],
+		['A', 'nan', 'C'],
+		['A', 'A', 'B'],
+		['A', 'A', 'A'],
+		['A', 'B', 'nan'],
+		['A', 'B', 'A'],
+		['A', 'B', 'nan'],
+		['A', 'B', 'C'],
+		['A', 'C', 'A'],
+		['A', 'nan', 'C'],
+		['A', 'C', 'C'],
+		['A', 'C', 'C'],
+		['A', 'C', 'B'],
+		['B', 'nan', 'A'],
+		['B', 'A', 'B'],
+		['nan', 'A', 'B'],
+		['B', 'A', 'B'],
+		['B', 'B', 'B'],
+		['B', 'B', 'C'],
+		['B', 'C', 'A'],
+		['nan', 'C', 'B'],
+		['B', 'C', 'A'],
+		['nan', 'C', 'B'],
+		['C', 'A', 'B'],
+		['C', 'B', 'B'],
+		['C', 'nan', 'C'],
+		['C', 'nan', 'A'],
+		['C', 'nan', 'C'],
+		['C', 'C', 'C'],
+		['C', 'C', 'C']]
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_initialization():
+	assert_equal(monty.name, "ConditionalProbabilityTable")
+	assert_array_equal(monty.parameters[0], [['A', 'A', 'A', 0.0],
+		 ['A', 'A', 'B', 0.5],
+		 ['A', 'A', 'C', 0.5],
+		 ['A', 'B', 'A', 0.0],
+		 ['A', 'B', 'B', 0.0],
+		 ['A', 'B', 'C', 1.0],
+		 ['A', 'C', 'A', 0.0],
+		 ['A', 'C', 'B', 1.0],
+		 ['A', 'C', 'C', 0.0],
+		 ['B', 'A', 'A', 0.0],
+		 ['B', 'A', 'B', 0.0],
+		 ['B', 'A', 'C', 1.0],
+		 ['B', 'B', 'A', 0.5],
+		 ['B', 'B', 'B', 0.0],
+		 ['B', 'B', 'C', 0.5],
+		 ['B', 'C', 'A', 1.0],
+		 ['B', 'C', 'B', 0.0],
+		 ['B', 'C', 'C', 0.0],
+		 ['C', 'A', 'A', 0.0],
+		 ['C', 'A', 'B', 1.0],
+		 ['C', 'A', 'C', 0.0],
+		 ['C', 'B', 'A', 1.0],
+		 ['C', 'B', 'B', 0.0],
+		 ['C', 'B', 'C', 0.0],
+		 ['C', 'C', 'A', 0.5],
+		 ['C', 'C', 'B', 0.5],
+		 ['C', 'C', 'C', 0.0]])
+
+	assert_equal(monty.n_columns, 3)
+	assert_equal(monty.m, 2)
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_log_probability():
 	assert_equal(monty.log_probability(('A', 'B', 'C')), 0.)
 	assert_equal(monty.log_probability(('C', 'B', 'A')), 0.)
-	assert_equal(monty.log_probability(('C', 'C', 'C')), float("-inf"))
-	assert_equal(monty.log_probability(('A', 'A', 'A')), float("-inf"))
+	assert_equal(monty.log_probability(('C', 'C', 'C')), -inf)
+	assert_equal(monty.log_probability(('A', 'A', 'A')), -inf)
 	assert_equal(monty.log_probability(('B', 'A', 'C')), 0.)
 	assert_equal(monty.log_probability(('C', 'A', 'B')), 0.)
 
-	data = [['A', 'A', 'C'],
-			['A', 'A', 'C'],
-			['A', 'A', 'B'],
-			['A', 'A', 'A'],
-			['A', 'A', 'C'],
-			['B', 'B', 'B'],
-			['B', 'B', 'C'],
-			['C', 'C', 'A'],
-			['C', 'C', 'C'],
-			['C', 'C', 'C'],
-			['C', 'C', 'C'],
-			['C', 'B', 'A']]
 
-	monty.fit(data, weights=[1, 1, 3, 3, 1, 1, 3, 7, 1, 1, 1, 1])
+@with_setup(setup_cpt)
+def test_distributions_cpt_nan_log_probability():
+	assert_equal(monty.log_probability(('A', 'nan', 'C')), 0.)
+	assert_equal(monty.log_probability(('nan', 'nan', 'C')), 0.)
+	assert_equal(monty.log_probability(('A', 'nan', 'nan')), 0.)
+	assert_equal(monty.log_probability(('nan', 'nan', 'nan')), 0.)
+	assert_equal(monty.log_probability(('nan', 'B', 'C')), 0.)
+	assert_equal(monty.log_probability(('A', 'B', 'nan')), 0.)
 
-	assert_equal(monty.log_probability(('A', 'A', 'A')),
-				 monty.log_probability(('A', 'A', 'C')))
-	assert_equal(monty.log_probability(('A', 'A', 'A')),
-				 monty.log_probability(('A', 'A', 'B')))
-	assert_equal(monty.log_probability(('B', 'A', 'A')),
-				 monty.log_probability(('B', 'A', 'C')))
-	assert_equal(monty.log_probability(('B', 'B', 'A')), float("-inf"))
-	assert_equal(monty.log_probability(('C', 'C', 'B')), float("-inf"))
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_probability():
+	assert_equal(monty.probability(('A', 'B', 'C')), 1.)
+	assert_equal(monty.probability(('C', 'B', 'A')), 1.)
+	assert_equal(monty.probability(('C', 'C', 'C')), 0.)
+	assert_equal(monty.probability(('A', 'A', 'A')), 0.)
+	assert_equal(monty.probability(('B', 'A', 'C')), 1.)
+	assert_equal(monty.probability(('C', 'A', 'B')), 1.)
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_nan_probability():
+	assert_equal(monty.probability(('A', 'nan', 'C')), 1.)
+	assert_equal(monty.probability(('nan', 'nan', 'C')), 1.)
+	assert_equal(monty.probability(('A', 'nan', 'nan')), 1.)
+	assert_equal(monty.probability(('nan', 'nan', 'nan')), 1.)
+	assert_equal(monty.probability(('nan', 'B', 'C')), 1.)
+	assert_equal(monty.probability(('A', 'B', 'nan')), 1.)
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_fit():
+	monty.fit(X)
+
+	assert_array_equal(monty.parameters[0],
+		[['A', 'A', 'A', 0.2], 
+		['A', 'A', 'B', 0.4], 
+		['A', 'A', 'C', 0.4], 
+		['A', 'B', 'A', 0.5], 
+		['A', 'B', 'B', 0.25], 
+		['A', 'B', 'C', 0.25], 
+		['A', 'C', 'A', 0.2], 
+		['A', 'C', 'B', 0.2], 
+		['A', 'C', 'C', 0.6], 
+		['B', 'A', 'A', 0.25], 
+		['B', 'A', 'B', 0.75], 
+		['B', 'A', 'C', 0.0], 
+		['B', 'B', 'A', 0.0], 
+		['B', 'B', 'B', 0.5], 
+		['B', 'B', 'C', 0.5], 
+		['B', 'C', 'A', 0.5], 
+		['B', 'C', 'B', 0.5], 
+		['B', 'C', 'C', 0.0], 
+		['C', 'A', 'A', 0.0], 
+		['C', 'A', 'B', 1.0], 
+		['C', 'A', 'C', 0.0], 
+		['C', 'B', 'A', 0.0], 
+		['C', 'B', 'B', 0.5], 
+		['C', 'B', 'C', 0.5], 
+		['C', 'C', 'A', 0.25], 
+		['C', 'C', 'B', 0.0], 
+		['C', 'C', 'C', 0.75]])
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_nan_fit():
+	monty.fit(X_nan)
+
+	assert_array_equal(monty.parameters[0],
+		[['A', 'A', 'A', 0.5], 
+		['A', 'A', 'B', 0.5], 
+		['A', 'A', 'C', 0.0], 
+		['A', 'B', 'A', 0.5], 
+		['A', 'B', 'B', 0.0], 
+		['A', 'B', 'C', 0.5], 
+		['A', 'C', 'A', 0.25], 
+		['A', 'C', 'B', 0.25], 
+		['A', 'C', 'C', 0.5], 
+		['B', 'A', 'A', 0.0], 
+		['B', 'A', 'B', 1.0], 
+		['B', 'A', 'C', 0.0], 
+		['B', 'B', 'A', 0.0], 
+		['B', 'B', 'B', 0.5], 
+		['B', 'B', 'C', 0.5], 
+		['B', 'C', 'A', 1.0], 
+		['B', 'C', 'B', 0.0], 
+		['B', 'C', 'C', 0.0], 
+		['C', 'A', 'A', 0.0], 
+		['C', 'A', 'B', 1.0], 
+		['C', 'A', 'C', 0.0], 
+		['C', 'B', 'A', 0.0], 
+		['C', 'B', 'B', 1.0], 
+		['C', 'B', 'C', 0.0], 
+		['C', 'C', 'A', 0.0], 
+		['C', 'C', 'B', 0.0], 
+		['C', 'C', 'C', 1.0]])
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_exclusive_nan_fit():
+	X = [['nan', 'nan', 'nan'],
+		 ['nan', 'nan', 'nan'],
+		 ['nan', 'nan', 'nan'],
+		 ['nan', 'nan', 'nan'],
+		 ['nan', 'nan', 'nan']]
+
+	monty.fit(X)
+
+	assert_array_equal(monty.parameters[0],
+		[['A', 'A', 'A', 0.0],
+		 ['A', 'A', 'B', 0.5],
+		 ['A', 'A', 'C', 0.5],
+		 ['A', 'B', 'A', 0.0],
+		 ['A', 'B', 'B', 0.0],
+		 ['A', 'B', 'C', 1.0],
+		 ['A', 'C', 'A', 0.0],
+		 ['A', 'C', 'B', 1.0],
+		 ['A', 'C', 'C', 0.0],
+		 ['B', 'A', 'A', 0.0],
+		 ['B', 'A', 'B', 0.0],
+		 ['B', 'A', 'C', 1.0],
+		 ['B', 'B', 'A', 0.5],
+		 ['B', 'B', 'B', 0.0],
+		 ['B', 'B', 'C', 0.5],
+		 ['B', 'C', 'A', 1.0],
+		 ['B', 'C', 'B', 0.0],
+		 ['B', 'C', 'C', 0.0],
+		 ['C', 'A', 'A', 0.0],
+		 ['C', 'A', 'B', 1.0],
+		 ['C', 'A', 'C', 0.0],
+		 ['C', 'B', 'A', 1.0],
+		 ['C', 'B', 'B', 0.0],
+		 ['C', 'B', 'C', 0.0],
+		 ['C', 'C', 'A', 0.5],
+		 ['C', 'C', 'B', 0.5],
+		 ['C', 'C', 'C', 0.0]])
+
+
+@with_setup(setup_cpt)
+def test_distributions_cpt_weighted_fit():
+	weights = [1, 3, 2, 3, 7, 4, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 1, 2, 1, 3, 1, 
+		1, 1, 2, 1, 1, 1, 3, 1, 1, 1]
+
+	monty.fit(X, weights=weights)
+
+	assert_array_equal(monty.parameters[0],
+		[['A', 'A', 'A', 0.4375], 
+		['A', 'A', 'B', 0.375], 
+		['A', 'A', 'C', 0.1875], 
+		['A', 'B', 'A', 0.6], 
+		['A', 'B', 'B', 0.2], 
+		['A', 'B', 'C', 0.2], 
+		['A', 'C', 'A', 0.25], 
+		['A', 'C', 'B', 0.0], 
+		['A', 'C', 'C', 0.75], 
+		['B', 'A', 'A', 0.0], 
+		['B', 'A', 'B', 1.0], 
+		['B', 'A', 'C', 0.0], 
+		['B', 'B', 'A', 0.0], 
+		['B', 'B', 'B', 0.25], 
+		['B', 'B', 'C', 0.75], 
+		['B', 'C', 'A', 0.4], 
+		['B', 'C', 'B', 0.6], 
+		['B', 'C', 'C', 0.0], 
+		['C', 'A', 'A', 0.0], 
+		['C', 'A', 'B', 1.0], 
+		['C', 'A', 'C', 0.0], 
+		['C', 'B', 'A', 0.0], 
+		['C', 'B', 'B', 0.5], 
+		['C', 'B', 'C', 0.5], 
+		['C', 'C', 'A', 0.5], 
+		['C', 'C', 'B', 0.0], 
+		['C', 'C', 'C', 0.5]])
+
 
 def test_univariate_log_probability():
 	distributions = [UniformDistribution, NormalDistribution, ExponentialDistribution,


### PR DESCRIPTION
This PR adds missing value support for fitting Bayesian networks, calculating probabilities of samples, and learning the structure of the network. This means that one can learn the structure of a Bayesian network on data sets with missing values now. 