### PR TITLE
DOCS fixes code-block in installation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,11 +23,15 @@
 Home
 ====
 
-pomegranate is a python package which implements fast, efficient, and extremely flexible probabilistic models ranging from probability distributions to Bayesian networks to mixtures of hidden Markov models. The most basic level of probabilistic modeling is the a simple probability distribution. If we're modeling language, this may be a simple distribution over the frequency of all possible words a person can say. 
+pomegranate is a python package which implements fast, efficient, and extremely flexible probabilistic models ranging from probability distributions to Bayesian networks to mixtures of hidden Markov models.
+The most basic level of probabilistic modeling is the simple probability distribution.
+If we're modeling a human language, this may be a simple distribution over the frequency of all possible words a person can say.
 
 (1) :ref:`distributions`
 
-The next level up are probabilistic models which use the simple distributions in more complex ways. A markov chain can extend a simple probability distribution to say that the probability of a certain word depends on the word(s) which have been said previously. A hidden Markov model may say that the probability of a certain words depends on the latent/hidden state of the previous word, such as a noun usually follows an adjective.
+The next level up are probabilistic models which use the simple distributions in more complex ways.
+A Markov chain can extend a simple probability distribution to say that the probability of a certain word depends on the word(s) which have been said previously.
+A hidden Markov model may say that the probability of a certain word depends on the latent/hidden state of the previous word, such as the case where a noun usually follows an adjective.
 
 (2) :ref:`markovchain`
 (3) :ref:`naivebayes`
@@ -36,7 +40,9 @@ The next level up are probabilistic models which use the simple distributions in
 (6) :ref:`bayesiannetwork`
 (7) :ref:`factorgraph`
 
-The third level are stacks of probabilistic models which can model even more complex phenomena. If a single hidden Markov model can capture a dialect of a language (such as a certain persons speech usage) then a mixture of hidden Markov models may fine tune this to be situation specific. For example, a person may use more formal language at work and more casual language when speaking with friends. By modeling this as a mixture of HMMs, we represent the persons language as a "mixture" of these dialects.
+The third level are stacks of probabilistic models which can model even more complex phenomena.
+If a single hidden Markov model can capture a dialect of a language (such as a certain person's speech usage) then a mixture of hidden Markov models may fine tune this to be situation specific.
+For example, a person may use more formal language at work and more casual language when speaking with friends. By modeling this as a mixture of HMMs, we represent the person's language as a "mixture" of these dialects.
 
 (8) GMM-HMMs
 (9) Mixtures of Models

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,6 +6,7 @@ Installation
 The easiest way to get pomegranate is through pip using the command
 
 .. code-block:: bash
+
 	pip install pomegranate
 
 This should install all the dependencies in addition to the package.
@@ -13,6 +14,7 @@ This should install all the dependencies in addition to the package.
 You can also get pomegranate through conda using the command
 
 .. code-block:: bash
+
 	conda install pomegranate
 
 This version may not be as up to date as the pip version though.
@@ -42,6 +44,7 @@ Q. I've been getting the following error: ```ModuleNotFoundError: No module name
 A. A reported solution is to uninstall and reinstall without cached files using the following:
 
 .. code-block:: bash
+
 	pip uninstall pomegranate
 	pip install pomegranate --no-cache-dir
 


### PR DESCRIPTION
Fixes #379 

Added a blank line before the bash code in the Installation page of the documentation.
Also fixed two other code-blocks.