### PR TITLE
Add zip_safe=False to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,5 @@ setup(
         'pomegranate': ['*.pyd']
     },
     include_package_data=True,
+    zip_safe=False,
 )


### PR DESCRIPTION
If someone installs pomegranate into site-libraries using the
traditional command of "python setup.py install", the sources will
install as a zipped egg without this option.  Current cython will not
work with cimport from the zipped file.

With this change, users will be protected from seeing this error when
installing in this way.