### PR TITLE
Add Makefile for convenience in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+PACKAGE_NAME=pomegranate
+PY2_ENV=py2.7
+PY3_ENV=py3.6
+
+default:
+	echo no default
+
+.PHONY: install test bigclean nbtest nbclean
+.PHONY: bigbuild py2build py3build
+.PHONY: biginstall py2install py3install
+.PHONY: biguninstall py2uninstall py3uninstall
+.PHONY: bigtest py2test py3test
+.PHONY: bignbtest py2nbtest py3nbtest
+
+install:
+	python setup.py install
+
+test:
+	python setup.py test
+
+bigclean: nbclean
+	rm -rf build
+	rm -rf dist
+	rm -rf .eggs
+	rm -rf $(PACKAGE_NAME).egg-info
+	find . -name '*.pyc' -print | xargs rm
+	find . -name '*.so' -print | xargs rm
+ifndef NO_REMOVE_CFILES
+	find . -name '*.c' -print | xargs rm
+endif
+
+# Add python dependencies
+ifdef PY2_ENV
+bigbuild: py2build
+biginstall: py2install
+biguninstall: py2uninstall
+bigtest: py2test
+bignbtest: py2test
+endif
+
+ifdef PY3_ENV
+bigbuild: py3build
+biginstall: py3install
+biguninstall: py3uninstall
+bigtest: py3test
+# Don't know how to override the kernelspec and the notebooks are python2 only anyway
+# bignbtest: py3test
+endif
+
+
+py2build:
+	(source activate $(PY2_ENV) ; python setup.py build ; python setup.py build_ext --inplace )
+py3build:
+	(source activate $(PY3_ENV) ; python setup.py build ; python setup.py build_ext --inplace )
+
+py2install:
+	(source activate $(PY2_ENV) ; python setup.py install )
+py3install:
+	(source activate $(PY3_ENV) ; python setup.py install )
+
+py3uninstall:
+	rm -rf ~/miniconda2/envs/$(PY3_ENV)/lib/python3.6/site-packages/$(PACKAGE_NAME)*
+py2uninstall:
+	rm -rf ~/miniconda2/envs/$(PY2_ENV)/lib/python2.7/site-packages/$(PACKAGE_NAME)*
+
+py3test:
+	(source activate $(PY3_ENV) ; python setup.py test )
+py2test:
+	(source activate $(PY2_ENV) ; python setup.py test )
+
+## Notebook tests
+PYTHON_NOTEBOOKS= examples/*.ipynb tutorials/*.ipynb benchmarks/*.ipynb
+EXECUTE_TIMEOUT=600
+ALLOW_ERRORS=
+# Allow errors if you want to check as many cells as possible
+#ALLOW_ERRORS=--allow-errors
+# Required conda package installs:
+# CONDA_INSTALL_BASE_PACKAGES=cython scipy scikit-learn pandas joblib nose networkx=1.11
+# CONDA_INSTALL_NOTEBOOK_PACKAGES=jupyter jupyter_contrib_nbextensions jupyter_nbextensions_configurator seaborn xlrd pygraphviz pillow
+nbtest:
+	for nb in $(PYTHON_NOTEBOOKS) ; do time jupyter nbconvert $$nb --execute --ExecutePreprocessor.timeout=$(EXECUTE_TIMEOUT) --to html $(ALLOW_ERRORS) ; done
+py2nbtest:
+	(source activate $(PY2_ENV) ; for nb in $(PYTHON_NOTEBOOKS) ; do time jupyter nbconvert $$nb --execute --ExecutePreprocessor.timeout=$(EXECUTE_TIMEOUT) --to html $(ALLOW_ERRORS) ; done )
+py3nbtest:
+	(source activate $(PY3_ENV) ; for nb in $(PYTHON_NOTEBOOKS) ; do time jupyter nbconvert $$nb --execute --ExecutePreprocessor.timeout=$(EXECUTE_TIMEOUT) --to html $(ALLOW_ERRORS) ; done )
+nbclean:
+	for nb in $(PYTHON_NOTEBOOKS) ; do rm -f $${nb%%.ipynb}.html ; done

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -12,6 +12,7 @@ Highlights
 ----------
 
 	- Added in callbacks to all models in the style of keras, with built-ins being History, ModelCheckpoint, and CVLogger. History is calculated for each model. Use `return_history=True` to gt the model and the history object that contains training.
+	- Added top-level Makefile for convenience in development to build/test/clean/install/uninstall with multiple conda environments.
 
 Changelog
 ---------
@@ -61,6 +62,12 @@ BayesClassifier
 	- Added in callback functionality to both the `fit` and `from_samples` methods that will be used only in semi-supervised learning
 
 	- Added in the `return_history` parameter to both the `fit` and `from_samples` methods, which will return the history callback as well as the fit model that will be used only in semi-supervised learning
+
+Makefile
+---------------
+
+	- There is a new top-level "convenience" Makefile for development to make it easy to develop with two conda environments.  The default is for two conda environments, py2.7 and py3.6, but those could be overridden at run time with, for example, `make PY3_ENV=py3.6.2 biginstall`.  Targets exist for `install, test, bigclean, and nbtest` along with variations of each that first activate either one or both conda environments.  For example, `make biginstall` will install for both `py2.7` and `py3.6` environments.  When developing pomegranate, one frequently wants to do a fully clean build, wipe out all installed targets, and replace them.  This can be done with `make bigclean biguninstall biginstall`.  In addition, there is a target `nbtest` for testing all of the jupyter notebooks to ensure that the cells run.  See the Makefile for a list of additional conda packages to install for this to work.  The default is to stop on first error but you can run `make ALLOW_ERRORS=--allow-errors nbtest` to run all cells and then inspect the html output manually for errors.
+
 
 Version 0.9.0
 =============

--- a/tutorials/Tutorial_3_Hidden_Markov_Models.ipynb
+++ b/tutorials/Tutorial_3_Hidden_Markov_Models.ipynb
@@ -1272,11 +1272,10 @@
   }
  ],
  "metadata": {
-  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:pom]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "conda-env-pom-py"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This Makefile will invoke build, install, test, and uninstall on
conda environments for python 2.7 and 3.6.

An nbtest target to use the "jupyter nbconvert --execute" functionality
to find any errors in example and tutorial notebooks.

A minor change to tutorials/Tutorial_3_Hidden_Markov_Models.ipynb
sets the kernelspec to be python2 similar to the other notebooks.