### PR TITLE
Convert from random.random to numpy random_sample

### DIFF
--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -17,7 +17,6 @@ from ..utils import check_random_state
 import itertools as it
 import json
 import numpy
-import random
 import scipy
 
 from collections import OrderedDict

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -8,7 +8,6 @@ import numpy
 import sys
 import itertools as it
 import json
-import random
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free

--- a/pomegranate/distributions/GammaDistribution.pyx
+++ b/pomegranate/distributions/GammaDistribution.pyx
@@ -6,7 +6,6 @@
 
 import numpy
 import scipy
-import random
 
 
 from ..utils cimport _log
@@ -205,7 +204,7 @@ cdef class GammaDistribution(Distribution):
 				shape = new_shape
 
 				# Re-start at some random place.
-				new_shape = random.random()
+				new_shape = numpy.random.random_sample()
 
 			iteration += 1
 

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -16,7 +16,6 @@ from ..utils import check_random_state
 import itertools as it
 import json
 import numpy
-import random
 import scipy
 
 from collections import OrderedDict


### PR DESCRIPTION
- Replaced the uses of random.random() with numpy.random.random_sample()
  so that numpy is consistently used throughout the implementation of
  pomegranate.
- One concern was raised about the speed enhancement of viterbi which
  depends on setting the random seed to a deterministic value.  Doing
  this could affect the quality of random number generation during
  non-testing use of pomegranate.  This was introduced in PR#118
- Note this discussion about the thread safety of numpy.  When joblib is
  used for parallelization and a seed has been set, then the jobs will
  not generate diversity from each other in their samples.
  - https://stackoverflow.com/a/31058798