### PR TITLE
Change init in bayes and gmm to use sum(weights)

### DIFF
--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -85,7 +85,7 @@ cdef class BayesModel(Model):
         if weights is None:
             weights = numpy.ones_like(distributions, dtype='float64') / self.n
         else:
-            weights = numpy.array(weights, dtype='float64') / weights.sum()
+            weights = numpy.array(weights, dtype='float64') / sum(weights)
 
         self.weights = numpy.log(weights)
         self.weights_ptr = <double*> self.weights.data

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -95,7 +95,7 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 	if weights is None:
 		weights = numpy.ones(len(X), dtype='float64') / len(X)
 	else:
-		weights = weights.astype('float64') / weights.sum()
+		weights = weights.astype('float64') / sum(weights)
 
 	weights_ptr = <double*> (<numpy.ndarray> weights).data
 


### PR DESCRIPTION
In bayes.pyx and gmm.pyx, use sum(weights) instead of weights.sum() in
__init__() to permit lists to be passed in.