### PR TITLE
Add test for hmm using gmm from_json

### DIFF
--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -83,7 +83,7 @@ cdef class NaiveBayes(BayesModel):
 		nb = {
 			'class' : 'NaiveBayes',
 			'models' : [json.loads(model.to_json()) for model in self.distributions],
-			'weights' : self.weights.tolist()
+			'weights' : numpy.exp(self.weights).tolist()
 		}
 
 		return json.dumps(nb, separators=separators, indent=indent)

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -454,6 +454,7 @@ cdef class State(object):
 		# Otherwise it has a distribution, so decode that
 		name = str(d['name'])
 		weight = d['weight']
+		from .gmm import GeneralMixtureModel
 
 		c = d['distribution']['class']
 		dist = eval(c).from_json( json.dumps( d['distribution'] ) )

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -421,7 +421,7 @@ cdef class GeneralMixtureModel(BayesModel):
                     'class' : 'GeneralMixtureModel',
                     'distributions'  : [ json.loads(dist.to_json())
                                          for dist in self.distributions ],
-                    'weights' : self.weights.tolist()
+                    'weights' : numpy.exp(self.weights).tolist()
                 }
 
         return json.dumps(model, separators=separators, indent=indent)


### PR DESCRIPTION
This patch set allows GeneralMixtureModels to be used with
HiddenMarkovModel.from_json() and adds a test.

It is a bit of a mystery why the GeneralMixtureModel class is not in
scope already.