### PR TITLE
Memory leak in BayesModel._log_probability

### DIFF
--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -243,6 +243,8 @@ cdef class BayesModel(Model):
             for i in range(n):
                 log_probability[i] = pair_lse(log_probability[i], logp[i] + self.weights_ptr[j])
 
+        free(logp)
+
     cdef double _vl_log_probability(self, double* X, int n) nogil:
         cdef int i
         cdef double log_probability_sum = NEGINF


### PR DESCRIPTION
Hello,

Thank you for the great software. Recently, I found my code using pomegranate consume a lot of memory, usually more than 100 GiB, after thousands of calls to `hmm.viterbi()`. This change fixes the problem, and its memory footprint stays at a pretty stable level. Can you reflect this patch in your future release?