### PR TITLE
Fix import error detection of pygraphviz

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -37,11 +37,13 @@ from .utils import parallelize_function
 from .utils import _check_nan
 
 
+
+import tempfile	
+import matplotlib.pyplot as plt
+import matplotlib.image
+
 try:
-	import tempfile
 	import pygraphviz
-	import matplotlib.pyplot as plt
-	import matplotlib.image
 except ImportError:
 	pygraphviz = None
 


### PR DESCRIPTION
In the case when matplotlib is not installed the error message below is printed:
    ValueError: must have pygraphviz installed for visualization
This is very confusing because pygraphviz is actually installed and what fails to
import is matplotlib.