### PR TITLE
Add .pyx to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
 include pomegranate/*.c
 include pomegranate/*.pxd
+include pomegranate/*.pyx


### PR DESCRIPTION
Ensures that .pyx files are included in the source distribution, and so pomegranate can then be built from source on systems where cython is present. Resolves #333.