### PR TITLE
Correct spelling of is_gpu_enabled in documentation

### DIFF
--- a/docs/gpu.rst
+++ b/docs/gpu.rst
@@ -10,7 +10,7 @@ By default, pomegranate will activate GPU acceleration if it can import cupy, ot
 .. code-block:: python
 	
 	import pomegranate
-	print(pomegranate.utils._is_gpu_enabled())
+	print(pomegranate.utils.is_gpu_enabled())
 
 If you'd like to deactivate GPU acceleration you can use the following command:
 


### PR DESCRIPTION
The version of this function with a leading underscore is only available to Cython code.