### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pomegranate is pip-installable using `pip install pomegranate` and conda-install
 * [Markov Chains](http://pomegranate.readthedocs.io/en/latest/MarkovChain.html)
 * [Discrete Bayesian Networks](http://pomegranate.readthedocs.io/en/latest/BayesianNetwork.html)
 
-The discrete Bayesian networks also support novel work on structure learning in the presence of constraints through a constraint graph. These constraints can dramatically speed up structure learning through the use of loose general prior knowledge, and can frequently make the exact learning task take only polynomial time instead of exponential time. See the [PeerJ manuscript](https://peerj.com/articles/cs-122/) for the theory and the [pomegranate tutorial](https://github.com/jmschrei/pomegranate/blob/master/tutorials/Tutorial_4b_Bayesian_Network_Structure_Learning.ipynb) for the practical usage! 
+The discrete Bayesian networks also support novel work on structure learning in the presence of constraints through a constraint graph. These constraints can dramatically speed up structure learning through the use of loose general prior knowledge, and can frequently make the exact learning task take only polynomial time instead of exponential time. See the [PeerJ manuscript](https://peerj.com/articles/cs-122/) for the theory and the [pomegranate tutorial](https://github.com/jmschrei/pomegranate/blob/master/tutorials/B_Model_Tutorial_4b_Bayesian_Network_Structure_Learning.ipynb) for the practical usage! 
 
 To support the above algorithms, it has efficient implementations of the following:
 


### PR DESCRIPTION
The link in the README for the tutorial Bayesian network structure learning was broken. I've updated it to the current notebook's link.