### PR TITLE
Add shortcuts for missing data

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -2069,7 +2069,7 @@ cdef discrete_find_best_parents(numpy.ndarray X_ndarray,
 
 cdef double discrete_score_node(double* X, double* weights, int* m, int* parents,
 	int n, int d, int l, double pseudocount) nogil:
-	cdef int i, j, k, idx, is_na
+	cdef int i, j, k, idx
 	cdef double w_sum = 0
 	cdef double logp = 0
 	cdef double count, marginal_count
@@ -2080,23 +2080,21 @@ cdef double discrete_score_node(double* X, double* weights, int* m, int* parents
 	memset(marginal_counts, 0, m[d-1]*sizeof(double))
 
 	for i in range(n):
-		idx, is_na = 0, 0
+		idx = 0
 		for j in range(d-1):
 			k = parents[j]
 			if isnan(X[i*l + k]):
-				is_na = 1
-			else:
-				idx += <int> X[i*l+k] * m[j]
+				break
+			idx += <int> X[i*l+k] * m[j]
+		else:
+			k = parents[d-1]
 
-		k = parents[d-1]
+			if isnan(X[i*l+k]):
+				continue
 
-		if is_na == 1 or isnan(X[i*l+k]):
-			continue
-
-
-		marginal_counts[idx] += weights[i]
-		idx += <int> X[i*l+k] * m[d-1]
-		counts[idx] += weights[i]
+			marginal_counts[idx] += weights[i]
+			idx += <int> X[i*l+k] * m[d-1]
+			counts[idx] += weights[i]
 
 	for i in range(m[d]):
 		w_sum += counts[i]

--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -183,18 +183,15 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		return self.values[idx]
 
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
-		cdef int i, j, idx, is_na = 0
+		cdef int i, j, idx
 
 		for i in range(n):
-			idx, is_na = 0, 0
+			idx = 0
 			for j in range(self.m+1):
 				if isnan(X[self.m-j]):
-					is_na = 1
-
+					log_probability[i] = 0.
+					break
 				idx += self.idxs[j] * <int> X[self.m-j]
-
-			if is_na == 1:
-				log_probability[i] = 0.
 			else:
 				log_probability[i] = self.values[idx]
 

--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -259,25 +259,21 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		self.__summarize(items, weights)
 
 	cdef void __summarize(self, items, double [:] weights):
-		cdef int i, n = len(items), is_na
+		cdef int i, n = len(items)
 		cdef tuple item
 
 		for i in range(n):
-			is_na = 0
 			item = tuple(items[i])
 
 			for symbol in item:
 				if _check_nan(symbol):
-					is_na = 1
+					break
+			else:
+				key = self.keymap[item]
+				self.counts[key] += weights[i]
 
-			if is_na:
-				continue
-
-			key = self.keymap[item]
-			self.counts[key] += weights[i]
-
-			key = self.marginal_keymap[item[:-1]]
-			self.marginal_counts[key] += weights[i]
+				key = self.marginal_keymap[item[:-1]]
+				self.marginal_counts[key] += weights[i]
 
 	cdef double _summarize(self, double* items, double* weights, int n,
 		int column_idx, int d) nogil:

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -210,25 +210,22 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 	cdef double _summarize(self, double* items, double* weights, int n,
 		int column_idx, int d) nogil:
-		cdef int i, j, idx, is_na
+		cdef int i, j, idx
 		cdef double count = 0
 		cdef double* counts = <double*> calloc(self.n, sizeof(double))
 
 		memset(counts, 0, self.n*sizeof(double))
 
 		for i in range(n):
-			idx, is_na = 0, 0
+			idx = 0
 			for j in range(self.m+1):
 				if isnan(items[self.m-i]):
-					is_na = 1
-
+					break
 				idx += self.idxs[i] * <int> items[self.m-i]
 
-			if is_na == 1:
-				continue
-
-			counts[idx] += weights[i]
-			count += weights[i]
+			else:
+				counts[idx] += weights[i]
+				count += weights[i]
 
 		with gil:
 			self.count += count

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -124,18 +124,15 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		return self.values[key]
 
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
-		cdef int i, j, idx, is_na
+		cdef int i, j, idx
 
 		for i in range(n):
-			idx, is_na = 0, 0
+			idx = 0
 			for j in range(self.m+1):
 				if isnan(X[self.m-j]):
-					is_na = 1
-
+					log_probability[i] = 0
+					break
 				idx += self.idxs[j] * <int> X[self.m-j]
-
-			if is_na == 1:
-				log_probability[i] = 0
 			else:
 				log_probability[i] = self.values[idx]
 


### PR DESCRIPTION
The following benchmarking program shows that on sklearn's ["digits" dataset](https://scikit-learn.org/stable/auto_examples/datasets/plot_digits_last_image.html), which is their dataset most suited for Bayesian analysis, adding these shortcuts reduces the total execution time by about 10% when there are missing values and does not increase the execution time when there are no missing values.

Interestingly, I could not reproduce the missing values slowdown on this dataset that I see with our own dataset or a randomly generated dataset. Nonetheless, the benchmarks show that there is a significant benefit to adding shortcuts.

Script:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from random import random
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
train = delayed(BayesianNetwork)().from_samples(X)

print('Without missing values:')
print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
print()

for i in range(X.shape[0]):
    for j in range(X.shape[1]):
        if random() <= 0.1:
            X[i][j] = np.nan

print('With missing values:')
print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
print()
```

Without NaN shortcuts:

```
Without missing values:
      wall_time  cpu_time
mean  11.357033  7.907993
max   11.491907  7.944401
std    0.117067  0.031715

With missing values:
      wall_time  cpu_time
mean  10.816061  7.586988
max   10.831504  7.742489
std    0.013388  0.148912
```

With NaN shortcuts:

```
Without missing values:
      wall_time  cpu_time
mean  11.586937  7.937418
max   12.074349  8.004921
std    0.422112  0.067759

With missing values:
      wall_time  cpu_time
mean   9.708813  6.849663
max    9.726768  6.869913
std    0.020418  0.025905
```

Please let me know if there's anything else you need.