### PR TITLE
Make reduce_dataset option work with missing values

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1057,7 +1057,10 @@ cdef class BayesianNetwork(GraphModel):
 			X_count = {}
 
 			for x, weight in izip(X, weights):
-				x = tuple(x)
+				# Convert NaN to None because two tuples containing
+				# (1.0, 2.0, 3.0, nan) are not considered equal, but two tuples
+				# containing (1.0, 2.0, 3.0, None) are considered equal
+				x = tuple(None if isnan(xn) else xn for xn in x)
 				if x in X_count:
 					X_count[x] += weight
 				else:


### PR DESCRIPTION
This improves running time when a lot of rows are the same due to missing values, such as in the example at https://github.com/jmschrei/pomegranate/issues/589#issuecomment-509419374.

Dataset reduction still adds overhead though, so even with these improvements it's not yet clear whether `reduce_dataset=True` or `reduce_dataset=False` will be faster for our particular data set.