### PR TITLE
Fix copy-paste error in MultivariateDistribution.log_probability

### DIFF
--- a/pomegranate/distributions/distributions.pyx
+++ b/pomegranate/distributions/distributions.pyx
@@ -380,9 +380,6 @@ cdef class MultivariateDistribution(Distribution):
 		logp_array = numpy.empty(n, dtype='float64')
 		logp_ptr = <double*> logp_array.data
 
-		X_ndarray = numpy.array(X, dtype='float64')
-		X_ptr = <double*> X_ndarray.data
-
 		with nogil:
 			self._log_probability(X_ptr, logp_ptr, n)
 


### PR DESCRIPTION
Just a few lines above this, these variables are already defined to the same values they are being set to here.