### PR TITLE
Make the utils.isnan function inline

### DIFF
--- a/pomegranate/utils.pxd
+++ b/pomegranate/utils.pxd
@@ -8,7 +8,9 @@ cdef int* GPU
 cdef extern from "numpy/npy_math.h":
 	bint npy_isnan(double x) nogil
 
-cdef bint isnan(double x) nogil
+cdef inline bint isnan(double x) nogil:
+	return npy_isnan(x)
+
 cdef int _is_gpu_enabled() nogil
 cdef python_log_probability(model, double* X, double* log_probability, int n)
 cdef python_summarize(model, double* X, double* weights, int n)

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -44,9 +44,6 @@ numpy.import_array()
 cdef extern from "numpy/ndarraytypes.h":
 	void PyArray_ENABLEFLAGS(numpy.ndarray X, int flags)
 
-cdef bint isnan(double x) nogil:
-	return npy_isnan(x)
-
 # Define some useful constants
 DEF NEGINF = float("-inf")
 DEF INF = float("inf")


### PR DESCRIPTION
Bayes net training is about 35% faster when `isnan` is inlined, which makes sense because `npy_isnan` was designed to be an inline function.

Test program:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from random import random

X = np.round(np.random.rand(10000, 16))
train = delayed(BayesianNetwork)().from_samples(X)

print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
```

Non-inline `isnan`:

```
      wall_time  cpu_time                                                                                                     
mean   8.369287  8.361042
max    8.488417  8.471947
std    0.103549  0.112760
```

Inline `isnan`:

```
      wall_time  cpu_time                                                                                                     
mean   5.361331  5.360565
max    5.379823  5.376542
std    0.030915  0.019036
```