### PR TITLE
Construct the parent subset more efficiently in ParentGraph.__getitem__

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1218,8 +1218,8 @@ cdef class ParentGraph(object):
 		else:
 			best_parents, best_score = value, self.calculate_value(value)
 
-		for variable in value:
-			parent_subset = tuple(parent for parent in value if parent != variable)
+		for i in range(len(value)):
+			parent_subset = value[:i] + value[i+1:]
 			parents, score = self[parent_subset]
 
 			if score > best_score:


### PR DESCRIPTION
This speeds up exact Bayes net training by up to 34% when there is little to no variability in the data.

Test program:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork

X = np.zeros([10000, 17])
train = delayed(BayesianNetwork)().from_samples(X, algorithm='exact')
```

Before:

```
      wall_time  cpu_time
mean   6.998546  6.838988
max    7.118689  6.925751
std    0.110920  0.098881
```

After:

```
      wall_time  cpu_time
mean   4.597856  4.502262
max    4.603789  4.547125
std    0.005501  0.048928
```

The speed improvement diminishes as variability in the training dataset increases. If 5% of the zeroes are replaced with ones at random, the speed improvement drops to about 17%, and if 10% of the zeroes are replaced with ones at random, the speed improvement drops to about 11%.

I checked to make sure that the resulting Bayes net is the same with or without this change.