### PR TITLE
Remove unused variable d from BayesianNetwork.from_structure

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -949,8 +949,6 @@ cdef class BayesianNetwork(GraphModel):
 		model.add_nodes(*states)
 
 		for i, parents in enumerate(structure):
-			d = states[i].distribution
-
 			for parent in parents:
 				model.add_edge(states[parent], states[i])
 


### PR DESCRIPTION
It looks like the variable d was accidentally introduced here from a copy and paste.