### PR TITLE
Store Chow-Liu structure in lists while it is being built

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1284,7 +1284,7 @@ def discrete_chow_liu_tree(numpy.ndarray X_ndarray, numpy.ndarray weights_ndarra
 						mutual_info[k*d + j] = mutual_info[j*d + k]
 
 
-	structure = [() for i in range(d)]
+	structure = [[] for i in range(d)]
 	visited = [root]
 	unvisited = list(range(d))
 	unvisited.remove(root)
@@ -1298,14 +1298,14 @@ def discrete_chow_liu_tree(numpy.ndarray X_ndarray, numpy.ndarray weights_ndarra
 				if score < min_score:
 					min_score, min_x, min_y = score, x, y
 
-		structure[min_y] += (min_x,)
+		structure[min_y].append(min_x)
 		visited.append(min_y)
 		unvisited.remove(min_y)
 
 	free(marg_j)
 	free(marg_k)
 	free(joint_count)
-	return tuple(structure)
+	return tuple(tuple(x) for x in structure)
 
 
 def discrete_exact_with_constraints(numpy.ndarray X, numpy.ndarray weights,


### PR DESCRIPTION
This decreases the time it takes to train a Chow-Liu net by about 5%. (Tuples, being immutable, are expensive to manipulate.)

Test program:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from random import random

X = np.round(np.random.rand(10000, 100))
train = delayed(BayesianNetwork)().from_samples(X, algorithm='chow-liu')

print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   9.900260  9.883265
max    9.965771  9.914445
std    0.073636  0.037711
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   9.445535  9.361896
max    9.481115  9.454669
std    0.052243  0.080365
```