### PR TITLE
Refactored and fixed checking NaNs

### DIFF
--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -17,6 +17,7 @@ from libc.string cimport memset
 from ..utils cimport _log
 from ..utils cimport isnan
 from ..utils import check_random_state
+from ..utils import _check_nan
 
 from libc.math cimport sqrt as csqrt
 
@@ -170,13 +171,10 @@ cdef class DiscreteDistribution(Distribution):
 		return self.__log_probability(X)
 
 	cdef double __log_probability(self, X):
-		if isinstance(X, (str, unicode)):
-			if X == 'nan':
-				return 0.
-		elif X is None or numpy.isnan(X):
+		if _check_nan(X):
 			return 0.
-
-		return self.log_dist.get(X, NEGINF)
+		else:
+			return self.log_dist.get(X, NEGINF)
 
 	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
 		cdef int i
@@ -326,9 +324,7 @@ cdef class DiscreteDistribution(Distribution):
 		total = 0
 
 		for X, weight in izip(items, weights):
-			if isinstance(X, str) and X == 'nan':
-				continue
-			elif isinstance(X, (int, float)) and numpy.isnan(X):
+			if _check_nan(X):
 				continue
 
 			total += weight

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -35,6 +35,7 @@ from .utils cimport python_log_probability
 from .utils cimport python_summarize
 
 from .utils import check_random_state
+from .utils import _check_nan
 
 
 from libc.stdlib cimport calloc
@@ -84,9 +85,7 @@ def _check_input(sequence, model):
                 symbol = sequence[i][j]
                 keymap = model.keymap[j]
 
-                if isinstance(symbol, str) and symbol == 'nan':
-                    sequence_ndarray[i, j] = numpy.nan
-                elif isinstance(symbol, (int, float)) and numpy.isnan(symbol):
+                if _check_nan(symbol):
                     sequence_ndarray[i, j] = numpy.nan
                 elif symbol in keymap:
                     sequence_ndarray[i, j] = keymap[symbol]
@@ -100,9 +99,7 @@ def _check_input(sequence, model):
         for i in range(n):
             symbol = sequence[i]
 
-            if isinstance(symbol, str) and symbol == 'nan':
-                sequence_ndarray[i] = numpy.nan
-            elif isinstance(symbol, (int, float)) and numpy.isnan(symbol):
+            if _check_nan(symbol):
                 sequence_ndarray[i] = numpy.nan
             elif sequence[i] in keymap:
                 sequence_ndarray[i] = keymap[symbol]

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -451,15 +451,11 @@ def weight_set(items, weights):
 
 def _check_nan(X):
 	"""Checks to see if a value is nan, either as a float or a string."""
-	
 	if isinstance(X, (str, unicode, numpy.string_)):
-		if X == 'nan':
-			return True
-		return False
-
-	if X is None or numpy.isnan(X):
-		return True
-	return False
+		return X == 'nan'
+	if isinstance(X, (float, numpy.float, numpy.float32, numpy.float64)):
+		return numpy.isnan(X)
+	return X is None
 
 def check_random_state(seed):
 	"""Turn seed into a np.random.RandomState instance.


### PR DESCRIPTION
Sometimes BayesianNetwork ignored a NaN value in the input when trained from samples, because `DiscreteDistribution._log_probability` checked only for Python floats, not also NumPy floats.
Also did some refactoring.