### PR TITLE
Remove unnecessary calls to memset after calloc

### DIFF
--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -58,9 +58,6 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 			dtype = str(type(column)).split()[-1].strip('>').strip("'")
 			self.dtypes.append(dtype)
 
-		memset(self.counts, 0, self.n*sizeof(double))
-		memset(self.marginal_counts, 0, self.n*sizeof(double)/self.k)
-
 		self.idxs[0] = 1
 		self.idxs[1] = self.k
 		for i in range(self.m-1):
@@ -281,9 +278,6 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		cdef int i, j, idx, k
 		cdef double* counts = <double*> calloc(self.n, sizeof(double))
 		cdef double* marginal_counts = <double*> calloc(self.n / self.k, sizeof(double))
-
-		memset(counts, 0, self.n*sizeof(double))
-		memset(marginal_counts, 0, self.n / self.k * sizeof(double))
 
 		for i in range(n):
 			idx = 0

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -233,7 +233,6 @@ cdef class DiscreteDistribution(Distribution):
 		self.encoded_summary = 1
 
 		encoded_counts = <double*> calloc(self.n, sizeof(double))
-		memset(encoded_counts, 0, self.n*sizeof(double))
 
 		for i in range(n):
 			item = items[i*d + column_idx]

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -53,8 +53,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 			dtype = str(type(column)).split()[-1].strip('>').strip("'")
 			self.dtypes.append(dtype)
 
-		memset(self.counts, 0, self.n*sizeof(double))
-
 		self.idxs[0] = 1
 		self.idxs[1] = self.k
 		for i in range(self.m-1):
@@ -214,8 +212,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		cdef int i, j, idx
 		cdef double count = 0
 		cdef double* counts = <double*> calloc(self.n, sizeof(double))
-
-		memset(counts, 0, self.n*sizeof(double))
 
 		for i in range(n):
 			idx = 0

--- a/pomegranate/distributions/MultivariateGaussianDistribution.pyx
+++ b/pomegranate/distributions/MultivariateGaussianDistribution.pyx
@@ -158,10 +158,6 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 		cdef double* pair_sum
 		cdef double* pair_w_sum = <double*> calloc(d*d, sizeof(double))
 
-		memset(column_sum, 0, d*d*sizeof(double))
-		memset(column_w_sum, 0, d*sizeof(double))
-		memset(pair_w_sum, 0, d*d*sizeof(double))
-
 		cdef double* y = <double*> calloc(n*d, sizeof(double))
 		cdef double alpha = 1
 		cdef double beta = 0
@@ -203,7 +199,6 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 
 		else:
 			pair_sum = <double*> calloc(d*d, sizeof(double))
-			memset(pair_sum, 0, d*d*sizeof(double))
 
 			dgemm('N', 'T', &d, &d, &n, &alpha, y, &d, y, &d, &beta, pair_sum, &d)
 

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -380,8 +380,6 @@ cdef class GeneralMixtureModel(BayesModel):
         cdef int i, j
         cdef double total, logp, log_probability_sum = 0.0
 
-        memset(summaries, 0, self.n*sizeof(double))
-
         for j in range(self.n):
             if self.cython == 0:
                 with gil:


### PR DESCRIPTION
The calloc function is guaranteed to zero out the memory before returning a pointer to it.