### PR TITLE
Deprecation warning YAMLLoadWarning: Add Loader argument for yaml loading

### DIFF
--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -70,7 +70,7 @@ cdef class Model(object):
 	@classmethod
 	def from_yaml( cls, yml ):
 		"""Deserialize this object from its YAML representation."""
-		return cls.from_json(json.dumps(yaml.load(yml, Loader=yaml.Loader)))
+		return cls.from_json(json.dumps(yaml.load(yml, Loader=yaml.SafeLoader)))
 
 	def copy(self):
 		"""Return a deep copy of this distribution object.

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -70,7 +70,7 @@ cdef class Model(object):
 	@classmethod
 	def from_yaml( cls, yml ):
 		"""Deserialize this object from its YAML representation."""
-		return cls.from_json(json.dumps(yaml.load(yml)))
+		return cls.from_json(json.dumps(yaml.load(yml, Loader=yaml.Loader)))
 
 	def copy(self):
 		"""Return a deep copy of this distribution object.


### PR DESCRIPTION
Small change made, in order to deal with deprecation warning: YAMLLoadWarning, when calling from_yaml e.g. for an HMM instantiation from yaml string
"default loader is unsafe" so I offer to replace it by yaml.Loader,
(see also https://msg.pyyaml.org/load)
(one of my first pull requests, plz be gentle =))