### PR TITLE
Include LICENSE file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include *.txt
-include pomegranate/*.c
-include pomegranate/*.pxd
-include pomegranate/*.pyx
-include pomegranate/distributions/*.c
-include pomegranate/distributions/*.pxd
-include pomegranate/distributions/*.pyx
+include LICENSE
+
+graft tests
+
+recursive-include pomegranate *.py *.c *.pxd *.pyx


### PR DESCRIPTION
Include the LICENSE file, as the MIT license requires it be included in all copies of the software.  Also simplify the `MANIFEST.in` file a little.