### PR TITLE
Add fast path to get non-log discrete distribution probabilities

### DIFF
--- a/pomegranate/distributions/DiscreteDistribution.pxd
+++ b/pomegranate/distributions/DiscreteDistribution.pxd
@@ -14,5 +14,6 @@ cdef class DiscreteDistribution(Distribution):
 	cdef tuple encoded_keys
 	cdef double* encoded_counts
 	cdef double* encoded_log_probability
+	cdef double __probability(self, symbol)
 	cdef double __log_probability(self, symbol)
 

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -169,6 +169,17 @@ cdef class DiscreteDistribution(Distribution):
 			self.encoded_counts[i] = 0
 			self.encoded_log_probability[i] = self.log_dist.get(key, NEGINF)
 
+	def probability(self, X):
+		"""Return the prob of the X under this distribution."""
+
+		return self.__probability(X)
+
+	cdef double __probability(self, X):
+		if _check_nan(X):
+			return 0.
+		else:
+			return self.dist.get(X, 0)
+
 	def log_probability(self, X):
 		"""Return the log prob of the X under this distribution."""
 


### PR DESCRIPTION
The default implementation of Model.probability exponentiates the result of the model's log_probability function. However, DiscreteDistribution already keeps copies of its probability table in both log space and non-log space, so we can skip the exponentiation and just read from the non-log-space table that we already have.

This patch speeds up Bayes net predictions by about 15%, which is a big deal when the Bayes net is large, complex, and repeatedly queried.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)
predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=10)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.003532  0.003503
max    0.003592  0.003555
std    0.000030  0.000021
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.002951  0.002950
max    0.002958  0.002970
std    0.000006  0.000011
```