### PR TITLE
Drop support for Python 2

### DIFF
--- a/benchmarks/benchmark_distributions.py
+++ b/benchmarks/benchmark_distributions.py
@@ -17,7 +17,7 @@ random.seed(0)
 def print_benchmark( distribution, duration ):
 	"""Formatted print."""
 
-	print "{:25}: {:.4}s".format( distribution.__class__.__name__, duration )
+	print( "{:25}: {:.4}s".format( distribution.__class__.__name__, duration ) )
 
 def bench_log_probability( distribution, n=10000000, symbol=5 ):
 	"""Bench a log probability distribution."""
@@ -115,11 +115,11 @@ def benchmark_distribution_train():
 
 	print_benchmark( distribution, bench_from_sample( distribution, sample ) )
 
-print "DISTRIBUTION BENCHMARKS"
-print "-----------------------"
-print
-print "LOG PROBABILITY (N=10,000,000 iterations, N=100,000 FOR MVG)"
+print( "DISTRIBUTION BENCHMARKS" )
+print( "-----------------------" )
+print()
+print( "LOG PROBABILITY (N=10,000,000 iterations, N=100,000 FOR MVG)" )
 benchmark_distribution_log_probabilities()
-print
-print "TRAINING (N=1,000 ITERATIONS, BATCHES=10,000 ITEMS)"
+print()
+print( "TRAINING (N=1,000 ITERATIONS, BATCHES=10,000 ITEMS)" )
 benchmark_distribution_train()

--- a/benchmarks/benchmark_hmm.py
+++ b/benchmarks/benchmark_hmm.py
@@ -54,26 +54,26 @@ def global_alignment( match_distributions, insert_distribution ):
 
 def benchmark_forward( model, sample ):
 	tic = time.time()
-	for i in xrange(25000):
+	for i in range(25000):
 		logp = model.forward( sample )[-1, model.end_index]
 	print("{:16}: time: {:5.5}, logp: {:5.5}".format( "FORWARD", time.time() - tic, logp ))
 
 def benchmark_backward( model, sample ):
 	tic = time.time()
-	for i in xrange(25000):
+	for i in range(25000):
 		logp = model.backward( sample )[0, model.start_index]
 	print("{:16}: time: {:5.5}, logp: {:5.5}".format( "BACKWARD", time.time() - tic, logp ))
 
 def benchmark_forward_backward( model, sample ):
 	tic = time.time()
-	for i in xrange(25000):
+	for i in range(25000):
 		model.forward_backward( sample )
 	print("{:16}: time: {:5.5}".format( "FORWARD-BACKWARD", time.time() - tic ))
 
 def benchmark_viterbi( model, sample ):
 
 	tic = time.time()
-	for i in xrange(25000):
+	for i in range(25000):
 		logp, path = model.viterbi( sample )
 	print("{:16}: time: {:5.5}, logp: {:5.5}".format( "VITERBI", time.time() - tic, logp ))
 

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -63,6 +63,6 @@ The following callbacks are built in to pomegranate:
 	>>> from pomegranate import *
 	>>> 
 	>>> def on_training_end(logs):
-	>>> 	print "Total Improvement: {:4.4}".format(logs['total_improvement'])
+	>>> 	print("Total Improvement: {:4.4}".format(logs['total_improvement']))
 	>>> 
 	>>> HiddenMarkovModel.from_samples(X, callbacks=[LambdaCheckpoint(on_training_end=on_training_end)])

--- a/docs/ooc.rst
+++ b/docs/ooc.rst
@@ -78,10 +78,10 @@ This is a simple example with a simple distribution, but all models and model st
 	>>> model2 = model.copy()
 	>>>
 	>>> X = numpy.random.randint(2, size=(10000, 4))
-	>>> print model.states[0].distribution.equals( model2.states[0].distribution )
+	>>> print(model.states[0].distribution.equals(model2.states[0].distribution))
 	True
 	>>> model.fit(X)
-	>>> print model.states[0].distribution.equals( model2.states[0].distribution )
+	>>> print(model.states[0].distribution.equals(model2.states[0].distribution))
 	False
 	>>> model2.summarize(X[:2500])
 	>>> model2.summarize(X[2500:5000])
@@ -89,7 +89,7 @@ This is a simple example with a simple distribution, but all models and model st
 	>>> model2.summarize(X[7500:])
 	>>> model2.from_summaries()
 	>>>
-	>>> print model.states[0].distribution.equals( model2.states[0].distribution )
+	>>> print(model.states[0].distribution.equals(model2.states[0].distribution))
 	True
 
 We can see that before fitting to any data, the distribution in one of the states is equal for both. After fitting the first distribution they become different as would be expected. After fitting the second one through summarize the distributions become equal again, showing that it is recovering an exact update.

--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -184,9 +184,9 @@ cdef class BayesianNetwork(GraphModel):
 	>>> model.add_nodes([s1, s2])
 	>>> model.add_edge(s1, s2)
 	>>> model.bake()
-	>>> print model.log_probability(['A', 'B'])
+	>>> print(model.log_probability(['A', 'B']))
 	-1.71479842809
-	>>> print model.predict_proba({'s2' : 'A'})
+	>>> print(model.predict_proba({'s2' : 'A'}))
 	array([ {
 		"frozen" :false,
 		"class" :"Distribution",
@@ -209,7 +209,7 @@ cdef class BayesianNetwork(GraphModel):
 		],
 		"name" :"DiscreteDistribution"
 	}], dtype=object)
-	>>> print model.impute([[None, 'A']])
+	>>> print(model.impute([[None, 'A']]))
 	[['B', 'A']]
 	"""
 

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -5,7 +5,6 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import numpy
-import sys
 import itertools as it
 import json
 import random
@@ -25,13 +24,6 @@ from libc.math cimport sqrt as csqrt
 DEF NEGINF = float("-inf")
 DEF INF = float("inf")
 eps = numpy.finfo(numpy.float64).eps
-
-if sys.version_info[0] > 2:
-	# Set up for Python 3
-	xrange = range
-	izip = zip
-else:
-	izip = it.izip
 
 cdef class DiscreteDistribution(Distribution):
 	"""
@@ -236,7 +228,7 @@ cdef class DiscreteDistribution(Distribution):
 
 		self.summaries[1] += weights.sum()
 		characters = self.summaries[0]
-		for i in xrange(len(items)):
+		for i in range(len(items)):
 			characters[items[i]] += weights[i]
 
 	cdef double _summarize(self, double* items, double* weights, int n,
@@ -337,7 +329,7 @@ cdef class DiscreteDistribution(Distribution):
 		Xs = {}
 		total = 0
 
-		for X, weight in izip(items, weights):
+		for X, weight in zip(items, weights):
 			if _check_nan(X):
 				continue
 

--- a/pomegranate/distributions/GammaDistribution.pyx
+++ b/pomegranate/distributions/GammaDistribution.pyx
@@ -196,7 +196,7 @@ cdef class GammaDistribution(Distribution):
 				scipy.special.polygamma(0, shape) -
 				statistic) / (1.0 / shape - scipy.special.polygamma(1, shape))
 
-			#print new_shape, scipy.special.polygamma(1, shape)
+			#print(new_shape, scipy.special.polygamma(1, shape))
 
 			# Don't let shape escape from valid values
 			if abs(new_shape) == float("inf") or new_shape == 0:

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -4,8 +4,6 @@
 # Authors: Jacob Schreiber <jmschreiber91@gmail.com>
 #          Adam Novak <anovak1@ucsc.edu>
 
-from __future__ import print_function
-
 from libc.math cimport exp as cexp
 from operator import attrgetter
 import math, random, itertools as it, sys, json


### PR DESCRIPTION
No one should be using Python 2 anymore, and creating aliases for the range and zip functions prevents the Cython compiler from replacing those functions with optimized C code.

When putting parentheses around the arguments to the print function, I have preserved the extra spaces in files that use that convention when calling functions, and left them out in files that generally do not use that convention.

I have not attempted to update any of the Jupyter notebooks.