### PR TITLE
Fix math and json imports in hmm.pyx

### DIFF
--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -8,7 +8,8 @@ from __future__ import print_function
 
 from libc.math cimport exp as cexp
 from operator import attrgetter
-import math, random, itertools as it, sys, json
+import json
+import math
 import networkx
 import tempfile
 import warnings


### PR DESCRIPTION
Currently HiddenMarkovModel.to_json is totally broken because the modules it depends on are not imported correctly.