### PR TITLE
Reimplement DiscreteDistribution.__imul__

### DIFF
--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -55,7 +55,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		self.dtypes = []
 		for column in table[0]:
-			dtype = str(type(column)).split()[-1].strip('>').strip("'")
+			dtype = type(column).__name__
 			self.dtypes.append(dtype)
 
 		self.idxs[0] = 1

--- a/pomegranate/distributions/DiscreteDistribution.pxd
+++ b/pomegranate/distributions/DiscreteDistribution.pxd
@@ -14,6 +14,7 @@ cdef class DiscreteDistribution(Distribution):
 	cdef tuple encoded_keys
 	cdef double* encoded_counts
 	cdef double* encoded_log_probability
+	cdef void __init(self, dict characters, bint frozen=*)
+	cdef dict __mul(self, other)
 	cdef double __probability(self, symbol)
 	cdef double __log_probability(self, symbol)
-

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -51,7 +51,7 @@ cdef class DiscreteDistribution(Distribution):
 			raise ValueError("Must pass in a dictionary with at least one value.")
 
 		self.name = "DiscreteDistribution"
-		self.dtype = str(type(list(characters.keys())[0])).split()[-1].strip('>').strip("'")
+		self.dtype = type(next(iter(characters.keys()))).__name__
 
 		self.__init(characters.copy(), frozen)
 

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -56,7 +56,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 		self.dtypes = []
 		for column in table[0]:
-			dtype = str(type(column)).split()[-1].strip('>').strip("'")
+			dtype = type(column).__name__
 			self.dtypes.append(dtype)
 
 		self.idxs[0] = 1


### PR DESCRIPTION
Avoiding unnecessary reinitialization decreases the time needed to make predictions by about 50%.

Test program:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from random import random
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.002891  0.002878
max    0.002938  0.002927
std    0.000013  0.000011
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.001496  0.001493
max    0.001551  0.001557
std    0.000011  0.000014
```

I took care to keep the behavior identical to the original, but even more time could be saved if the summaries etc. do not need to be reset.

I also threw in a small cleanup that simplifies getting the data type name in the DiscreteDistribution constructor and a couple of other places. Let me know if you'd rather review that in a separate pull request though.