### PR TITLE
Don't use numpy.zeros for memory that is about to be reinitialized

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -731,7 +731,7 @@ cdef class BayesianNetwork(GraphModel):
 		indices = {state.distribution: i for i, state in enumerate(self.states)}
 
 		n, d = len(X), len(X[0])
-		cdef numpy.ndarray X_int = numpy.zeros((n, d), dtype='float64')
+		cdef numpy.ndarray X_int = numpy.empty((n, d), dtype='float64')
 		cdef double* X_int_ptr = <double*> X_int.data
 
 		for i in range(n):
@@ -1074,7 +1074,7 @@ cdef class BayesianNetwork(GraphModel):
 			n, d = X.shape
 
 
-		X_int = numpy.zeros((n, d), dtype='float64')
+		X_int = numpy.empty((n, d), dtype='float64')
 		for i in range(n):
 			for j in range(d):
 				if _check_nan(X[i, j]):

--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -114,7 +114,7 @@ cdef class FactorGraph(GraphModel):
 		# edges involving this state. There is no direction, and so it will
 		# be a single array of twice the length of the number of edges,
 		# since each edge belongs to two nodes.
-		self.transitions = numpy.zeros(m*2, dtype=numpy.int32) - 1
+		self.transitions = numpy.full(m*2, -1, dtype=numpy.int32)
 		self.edge_count = numpy.zeros(n+1, dtype=numpy.int32)
 
 		# Go through each node and classify it as either a marginal node or a

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -520,7 +520,7 @@ cdef class HiddenMarkovModel(GraphModel):
         """
 
         m = len(self.states)
-        transition_log_probabilities = numpy.zeros((m, m)) + NEGINF
+        transition_log_probabilities = numpy.full((m, m), NEGINF)
 
         for i in range(m):
             for n in range(self.out_edge_count[i], self.out_edge_count[i+1]):
@@ -935,7 +935,7 @@ cdef class HiddenMarkovModel(GraphModel):
                     self.tied[start] = j
 
         # Unpack the state weights
-        self.state_weights = numpy.zeros(self.silent_start)
+        self.state_weights = numpy.empty(self.silent_start)
         for i in range(self.silent_start):
             self.state_weights[i] = _log(self.states[i].weight)
 
@@ -1378,7 +1378,7 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef int n = len(sequence), m = len(self.states)
         cdef int mv = self.multivariate
         cdef void** distributions = <void**> self.distributions.data
-        cdef numpy.ndarray f_ndarray = numpy.zeros((n+1, m), dtype=numpy.float64)
+        cdef numpy.ndarray f_ndarray = numpy.empty((n+1, m), dtype=numpy.float64)
         cdef double* f
 
         sequence_ndarray = _check_input(sequence, self)
@@ -1550,7 +1550,7 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef double* b
         cdef int n = len(sequence), m = len(self.states)
         cdef int mv = self.multivariate
-        cdef numpy.ndarray b_ndarray = numpy.zeros((n+1, m), dtype=numpy.float64)
+        cdef numpy.ndarray b_ndarray = numpy.empty((n+1, m), dtype=numpy.float64)
 
         sequence_ndarray = _check_input(sequence, self)
         sequence_data = <double*> sequence_ndarray.data

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -120,7 +120,7 @@ cpdef numpy.ndarray initialize_centroids(numpy.ndarray X, weights, int k,
 		centroids[0] = X[idx]
 		centroids[0][numpy.isnan(centroids[0])] = 0.0
 
-		min_distance = numpy.zeros(n, dtype='float64') + INF
+		min_distance = numpy.full(n, INF, dtype='float64')
 		min_distance_ptr = <double*> min_distance.data
 
 		for m in range(k-1):
@@ -332,7 +332,7 @@ cdef class Kmeans(Model):
 		X = numpy.array(X, dtype='float64')
 		X_ptr = <double*> (<numpy.ndarray> X).data
 
-		dist = numpy.zeros((X.shape[0], self.k))
+		dist = numpy.empty((X.shape[0], self.k))
 
 
 		for i in range(X.shape[0]):


### PR DESCRIPTION
In the same vein as #655 and #723, this commit speeds up various functions by eliminating unnecessary memory operations.