### PR TITLE
Revert "Use type.__name__ instead of str(type) and string manipulation (#728)"

### DIFF
--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -56,7 +56,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 
 		self.dtypes = []
 		for column in table[0]:
-			dtype = type(column).__name__
+			dtype = str(type(column)).split()[-1].strip('>').strip("'")
 			self.dtypes.append(dtype)
 
 		self.idxs[0] = 1

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -52,7 +52,7 @@ cdef class DiscreteDistribution(Distribution):
 
 		self.name = "DiscreteDistribution"
 		self.frozen = frozen
-		self.dtype = type(next(iter(characters.keys()))).__name__
+		self.dtype = str(type(list(characters.keys())[0])).split()[-1].strip('>').strip("'")
 
 		self.dist = characters.copy()
 		self.log_dist = { key: _log(value) for key, value in characters.items() }

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -56,7 +56,7 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 		self.dtypes = []
 		for column in table[0]:
-			dtype = type(column).__name__
+			dtype = str(type(column)).split()[-1].strip('>').strip("'")
 			self.dtypes.append(dtype)
 
 		self.idxs[0] = 1


### PR DESCRIPTION
This reverts commit f5f387c8f2ecf6ef5c2be74764b479194ebae4a6.

That was a mistake, sorry. `Distribution.from_json` depends on the dtype starting with `numpy.` if it is a numpy type.