### PR TITLE
Skip convergence checks after the first failed check

### DIFF
--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -275,6 +275,7 @@ cdef class FactorGraph(GraphModel):
 		#   (2) send messages from the factors to the variables, containing
 		#   the factors belief about each marginal.
 		# This is the flooding message schedule for loopy belief propagation.
+		cdef bint done
 		iteration = 0
 		while iteration < max_iterations:
 			# UPDATE MESSAGES LEAVING THE MARGINAL NODES
@@ -345,7 +346,7 @@ cdef class FactorGraph(GraphModel):
 			# Calculate the current estimates on the marginals to compare to the
 			# last iteration, so that we can stop if we reach convergence.
 			done = 1
-			for i in range(len(self.states)):
+			for i in range(n):
 				if self.marginals[i] == 0:
 					continue
 
@@ -355,7 +356,7 @@ cdef class FactorGraph(GraphModel):
 				for k in range(self.edge_count[i], self.edge_count[i+1]):
 					current_distributions[i] *= in_messages[k]
 
-				if not current_distributions[i].equals(prior_distributions[i]):
+				if done and not current_distributions[i].equals(prior_distributions[i]):
 					done = 0
 
 			# If we have converged, then we're done!


### PR DESCRIPTION
This is a simple change that decreases the time required to make Bayes net predictions by about 7%.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.002968  0.002968
max    0.003024  0.003377
std    0.000013  0.000060
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.002737  0.002729
max    0.002787  0.002764
std    0.000018  0.000012
```