### PR TITLE
Remove unused variables from JointProbabilityTable class

### DIFF
--- a/pomegranate/distributions/JointProbabilityTable.pxd
+++ b/pomegranate/distributions/JointProbabilityTable.pxd
@@ -12,11 +12,8 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 	cdef double count
 	cdef public int n, k, n_columns
 	cdef int* idxs
-	cdef public list parents, parameters, dtypes, column_keys
+	cdef public list parents, parameters, dtypes
 	cdef public object keymap
-	cdef public object marginal_keymap
-	cdef public numpy.ndarray column_idxs
-	cdef double* column_idxs_ptr
 	cdef public int m
 	cdef void __summarize(self, items, double [:] weights)
 

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -52,7 +52,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		self.count = 0
 
 		self.n_columns = len(parents)
-		self.column_idxs = numpy.arange(len(parents)+1, dtype='int32')
 
 		self.dtypes = []
 		for column in table[0]:
@@ -69,7 +68,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 			keys.append((tuple(row[:-1]), i))
 			self.values[i] = _log(row[-1])
 
-		self.column_keys = [numpy.unique([row[i] for row in table]) for i in range(self.m)]
 		self.keymap = OrderedDict(keys)
 		self.parents = list(parents)
 		self.parameters = [[list(row) for row in table], self.parents, self.keymap]
@@ -174,7 +172,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 			wrt = neighbor_values.index(None)
 
 		# Determine the keys for the respective parent distribution
-		#d = {k: 0 for k in self.column_keys[wrt]} #self.parents[wrt].keys()}
 		d = {k: 0 for k in self.parents[wrt].keys()}
 		total = 0.0
 


### PR DESCRIPTION
This commit removes code that was unnecessarily copied and pasted from ConditionalProbabilityTable to JointProbabilityTable, which results in cleaner code, less memory usage, and a slight speed improvement to Bayes net predictions.