### PR TITLE
added explicit casting of input X to C-layout

### DIFF
--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -406,13 +406,14 @@ def _check_input(X, keymap=None):
 	cdef numpy.ndarray X_ndarray
 
 	try:
-		X_ndarray = numpy.array(X, dtype='float64', ndmin=2)
+		X_ndarray = numpy.array(X, dtype='float64', ndmin=2, order='C')
 	except:
 		if not isinstance(X, (numpy.ndarray, list, tuple)):
-			X_ndarray = numpy.array(keymap[0][X], dtype='float64', ndmin=2)
+			X_ndarray = numpy.array(keymap[0][X], dtype='float64',
+			                        ndmin=2, order='C')
 		else:
 			X = numpy.array(X)
-			X_ndarray = numpy.empty(X.shape, dtype='float64')
+			X_ndarray = numpy.empty(X.shape, dtype='float64', order='C')
 
 			if X.ndim == 1:
 				for i in range(X.shape[0]):


### PR DESCRIPTION
Adding an explicit casting of input array to C-layout in the utils check_input method (see #717 ) not sure if this is a full fix, as there might be some places where the method is not used. 