### PR TITLE
Get rid of a couple more calls to calloc and numpy.zeros

### DIFF
--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -100,7 +100,7 @@ cdef class FactorGraph(GraphModel):
 		n, m = len(self.states), len(self.edges)
 
 		# Initialize the arrays
-		self.marginals = numpy.zeros(n)
+		self.marginals = numpy.empty(n, dtype=numpy.bool_)
 
 		# We need a good way to get transition probabilities by state index that
 		# isn't N^2 to build or store. So we will need a reverse of the above
@@ -118,10 +118,10 @@ cdef class FactorGraph(GraphModel):
 		# Go through each node and classify it as either a marginal node or a
 		# factor node.
 		for i, node in enumerate(self.states):
-			if not isinstance(node.distribution, MultivariateDistribution):
-				self.marginals[i] = 1
-			if node.name.endswith('-joint'):
-				self.marginals[i] = 0
+			self.marginals[i] = (
+				not isinstance(node.distribution, MultivariateDistribution) and
+				not node.name.endswith('-joint')
+			)
 
 		# Now we need to find a way of storing edges for a state in a manner
 		# that can be called in the cythonized methods below. This is basically

--- a/pomegranate/MarkovNetwork.pyx
+++ b/pomegranate/MarkovNetwork.pyx
@@ -488,7 +488,7 @@ cdef class MarkovNetwork(Model):
 			raise ValueError("must bake model before summarizing data")
 
 		n, d = len(X), len(X[0])
-		X_int = numpy.zeros((n, d), dtype='float64')
+		X_int = numpy.empty((n, d), dtype='float64')
 
 		for i in range(n):
 			for j in range(d):

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -366,7 +366,7 @@ cdef class GraphModel(Model):
 		"""
 
 		m = len(self.states)
-		transition_log_probabilities = numpy.zeros((m, m)) + NEGINF
+		transition_log_probabilities = numpy.full((m, m), NEGINF)
 
 		for i in range(m):
 			for n in range( self.out_edge_count[i], self.out_edge_count[i+1] ):

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -11,7 +11,7 @@ import random
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free
-from libc.string cimport memset
+from libc.stdlib cimport malloc
 
 from ..utils cimport _log
 from ..utils cimport isnan
@@ -153,7 +153,7 @@ cdef class DiscreteDistribution(Distribution):
 		free(self.encoded_log_probability)
 
 		self.encoded_counts = <double*> calloc(n, sizeof(double))
-		self.encoded_log_probability = <double*> calloc(n, sizeof(double))
+		self.encoded_log_probability = <double*> malloc(n * sizeof(double))
 		self.n = n
 
 		for i in range(n):


### PR DESCRIPTION
This is the wad of memory cleanups that I found while investigating other performance improvements.