### PR TITLE
Cast everything to str instead of doing type checking in _check_nan

### DIFF
--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -450,11 +450,7 @@ def weight_set(items, weights):
 
 def _check_nan(X):
 	"""Checks to see if a value is nan, either as a float or a string."""
-	if isinstance(X, (str, unicode, numpy.string_)):
-		return X == 'nan'
-	if isinstance(X, (float, numpy.float, numpy.float32, numpy.float64)):
-		return numpy.isnan(X)
-	return X is None
+	return X is None or str(X) == 'nan'
 
 def check_random_state(seed):
 	"""Turn seed into a np.random.RandomState instance.


### PR DESCRIPTION
It's a bit counterintuitive, but this change makes Bayes net predictions about 30% faster.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.002025  0.002019
max    0.002062  0.002119
std    0.000007  0.000016
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.001402  0.001397
max    0.001441  0.001410
std    0.000008  0.000005
```