### PR TITLE
Use C isnan function instead of numpy.isnan in _check_nan

### DIFF
--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -5,6 +5,7 @@ from libc.math cimport log as clog
 from libc.math cimport exp as cexp
 from libc.math cimport floor
 from libc.math cimport fabs
+from libc.math cimport isnan
 
 from scipy.linalg.cython_blas cimport dgemm
 
@@ -453,7 +454,7 @@ def _check_nan(X):
 	if isinstance(X, (str, unicode, numpy.string_)):
 		return X == 'nan'
 	if isinstance(X, (float, numpy.float, numpy.float32, numpy.float64)):
-		return numpy.isnan(X)
+		return isnan(X)
 	return X is None
 
 def check_random_state(seed):


### PR DESCRIPTION
This makes Bayes net predictions about 37% faster.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.002025  0.002019
max    0.002062  0.002119
std    0.000007  0.000016
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.001275  0.001270
max    0.001294  0.001322
std    0.000005  0.000008
```