### PR TITLE
Move assertion after shortcut in DiscreteDistribution.__mul__

### DIFF
--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -80,7 +80,6 @@ cdef class DiscreteDistribution(Distribution):
 
 		self_keys = self.keys()
 		other_keys = other.keys()
-		assert set(self_keys) == set(other_keys)
 		distribution, total = {}, 0.0
 
 		if isinstance(other, DiscreteDistribution) and self_keys == other_keys:
@@ -93,6 +92,7 @@ cdef class DiscreteDistribution(Distribution):
 					distribution[key] = (x + eps) * (y + eps)
 				total += distribution[key]
 		else:
+			assert set(self_keys) == set(other_keys)
 			self_items = (<DiscreteDistribution>self).dist.items()
 			for key, x in self_items:
 				if _check_nan(key):


### PR DESCRIPTION
This patch makes `DiscreteDistribution.__mul__` look more like `DiscreteDistribution.equals`, which helps make clear that the same shortcut logic is being used in both functions. Plus, when combined with the [isnan improvement I sent earlier](https://github.com/jmschrei/pomegranate/pull/761), moving the assertion improves performance by 1-2% when making predictions from a Bayes net.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

With isnan improvement only:

```
      wall_time  cpu_time                                                                                                     
mean   0.001354  0.001353
max    0.001400  0.001372
std    0.000008  0.000006
```

With isnan improvement and the assertion moved after the shortcut:

```
      wall_time  cpu_time                                                                                                     
mean   0.001332  0.001330
max    0.001348  0.001344
std    0.000006  0.000005
```