### PR TITLE
Move assignment of in messages for marginal nodes outside of loop

### DIFF
--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -260,7 +260,7 @@ cdef class FactorGraph(GraphModel):
 			if self.marginals[i] == 1:
 				for k in range(self.edge_count[i], self.edge_count[i+1]):
 					out_messages[k] = distributions[i]
-					in_messages[i] = distributions[i]
+				in_messages[i] = distributions[i]
 			# Otherwise follow the edge, then set the message to be
 			# the marginal on the other side.
 			else:


### PR DESCRIPTION
Moving this assignment out of the loop makes it clear that `in_messages[i]` is being set and not `in_messages[k]`.