### PR TITLE
Avoid using numpy slices in FactorGraph.predict_proba

### DIFF
--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -371,16 +371,20 @@ cdef class FactorGraph(GraphModel):
 			iteration += 1
 
 
-		marginals = numpy.where(self.marginals == 1)
+		y_hat = numpy.empty(n, dtype=Distribution)
 
-		# We've already computed the current belief about the marginals, so
-		# we can just return that.
-		y_hat = current_distributions[marginals]
+		j = 0
+		for i, state in enumerate(self.states):
+			if self.marginals[i]:
+				if state.name in data:
+					y_hat[j] = data[state.name]
+				else:
+					# We've already computed the current belief about the
+					# marginals, so we can just return that.
+					y_hat[j] = current_distributions[i]
+				j += 1
 
-		for i, state in enumerate(numpy.array(self.states)[marginals]):
-			if state.name in data:
-				y_hat[i] = data[state.name]
-
+		y_hat.resize(j)
 		return y_hat
 
 


### PR DESCRIPTION
This reduces the time required to make Bayes net predictions by about 2%.

Test program:

```
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:10]
net = BayesianNetwork().from_samples(X)

predict = delayed(net.predict_proba)({str(x): 0 for x in range(5)})

print(Benchmark(wall_time=True, cpu_time=True, repeat=50)(predict))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.001286  0.001286
max    0.001304  0.001318
std    0.000005  0.000006
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.001258  0.001255
max    0.001276  0.001268
std    0.000006  0.000004
```