### PR TITLE
Don't initialize logp before calling Model._log_probability on it

### DIFF
--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -5,6 +5,7 @@
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free
+from libc.stdlib cimport malloc
 
 import time
 
@@ -238,7 +239,7 @@ cdef class BayesModel(Model):
 
             return numpy.concatenate(logp_array)
 
-        cdef numpy.ndarray logp_ndarray = numpy.zeros(n)
+        cdef numpy.ndarray logp_ndarray = numpy.empty(n)
         cdef double* logp = <double*> logp_ndarray.data
 
         cdef numpy.ndarray X_ndarray
@@ -264,7 +265,7 @@ cdef class BayesModel(Model):
 
     cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
         cdef int i, j, d = self.d
-        cdef double* logp = <double*> calloc(n, sizeof(double))
+        cdef double* logp = <double*> malloc(n * sizeof(double))
 
         if self.cython == 1:
             (<Model> self.distributions_ptr[0])._log_probability(X, log_probability, n)

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -1409,7 +1409,7 @@ cdef class HiddenMarkovModel(GraphModel):
         # Either fill in a new emissions matrix, or use the one which has
         # been provided from a previous call.
         if emissions is NULL:
-            e = <double*> calloc(n*self.silent_start, sizeof(double))
+            e = <double*> malloc(n*self.silent_start*sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
                     if self.cython == 1:
@@ -1580,7 +1580,7 @@ cdef class HiddenMarkovModel(GraphModel):
         # Either fill in a new emissions matrix, or use the one which has
         # been provided from a previous call.
         if emissions is NULL:
-            e = <double*> calloc(n*self.silent_start, sizeof(double))
+            e = <double*> malloc(n*self.silent_start*sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
                     if self.cython == 1:
@@ -1805,7 +1805,7 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef int i, k, j, l, ki, li
         cdef int m=len(self.states)
         cdef int dim = self.d
-        cdef double* e = <double*> calloc(n*self.silent_start, sizeof(double))
+        cdef double* e = <double*> malloc(n*self.silent_start*sizeof(double))
         cdef double* f
         cdef double* b
 
@@ -2004,7 +2004,7 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef int* tracebackx = <int*> calloc((n+1)*m, sizeof(int))
         cdef int* tracebacky = <int*> calloc((n+1)*m, sizeof(int))
         cdef double* v = <double*> calloc((n+1)*m, sizeof(double))
-        cdef double* e = <double*> calloc((n*self.silent_start), sizeof(double))
+        cdef double* e = <double*> malloc((n*self.silent_start)*sizeof(double))
 
         cdef double state_log_probability
         cdef int end_index
@@ -2249,7 +2249,7 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef void** distributions = self.distributions_ptr
 
         if emissions is NULL:
-            e = <double*> calloc(n*self.silent_start, sizeof(double))
+            e = <double*> malloc(n*self.silent_start*sizeof(double))
             for l in range(self.silent_start):
                 for i in range(n):
                     if self.cython == 1:
@@ -2758,7 +2758,7 @@ cdef class HiddenMarkovModel(GraphModel):
 
         cdef double* weights = <double*> calloc(n, sizeof(double))
 
-        e = <double*> calloc(n*self.silent_start, sizeof(double))
+        e = <double*> malloc(n*self.silent_start*sizeof(double))
         for l in range(self.silent_start):
             for i in range(n):
                 if self.cython == 1:


### PR DESCRIPTION
All concrete implementations of Model._log_probability fill the entire
array, so zeroing it out beforehand is a waste of time.