### PR TITLE
Eliminate unnecessary variables X_int and X_int_ptr

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -727,15 +727,14 @@ cdef class BayesianNetwork(GraphModel):
 		indices = {state.distribution: i for i, state in enumerate(self.states)}
 
 		n, d = len(X), len(X[0])
-		cdef numpy.ndarray X_int = numpy.empty((n, d), dtype='float64')
-		cdef double* X_int_ptr = <double*> X_int.data
+		cdef double* X_int = <double*> malloc(n * d * sizeof(double))
 
 		for i in range(n):
 			for j in range(d):
 				if _check_nan(X[i][j]):
-					X_int[i, j] = nan
+					X_int[i * d + j] = nan
 				else:
-					X_int[i, j] = self.keymap[j][X[i][j]]
+					X_int[i * d + j] = self.keymap[j][X[i][j]]
 
 		if weights is None:
 			weights_ndarray = numpy.ones(n, dtype='float64')
@@ -749,11 +748,12 @@ cdef class BayesianNetwork(GraphModel):
 		for i, state in enumerate(self.states):
 			if isinstance(state.distribution, ConditionalProbabilityTable):
 				with nogil:
-					(<Model> self.distributions_ptr[i])._summarize(X_int_ptr, weights_ptr, n,
-						0, 1)
+					(<Model> self.distributions_ptr[i])._summarize(X_int, weights_ptr, n, 0, 1)
 
 			else:
 				state.distribution.summarize([x[i] for x in X], weights)
+
+		free(X_int)
 
 	def from_summaries(self, inertia=0.0, pseudocount=0.0):
 		"""Use MLE on the stored sufficient statistics to train the model.

--- a/pomegranate/MarkovNetwork.pyx
+++ b/pomegranate/MarkovNetwork.pyx
@@ -488,14 +488,6 @@ cdef class MarkovNetwork(Model):
 			raise ValueError("must bake model before summarizing data")
 
 		n, d = len(X), len(X[0])
-		X_int = numpy.empty((n, d), dtype='float64')
-
-		for i in range(n):
-			for j in range(d):
-				if X[i][j] == 'nan' or X[i][j] == None or X[i][j] == nan:
-					X_int[i, j] = nan
-				else:
-					X_int[i, j] = self.keymap[j][X[i][j]]
 
 		if weights is None:
 			weights = numpy.ones(n, dtype='float64')


### PR DESCRIPTION
In MarkovNetwork, `X_int` is not used at all and does not appear to be in any way necessary to calculate.