### PR TITLE
Add (from|to)_dict methods for fast, reusable (de)serialization

### DIFF
--- a/pomegranate/BayesClassifier.pyx
+++ b/pomegranate/BayesClassifier.pyx
@@ -3,7 +3,6 @@
 # BayesClassifier.pyx
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
-import json
 import numpy
 cimport numpy
 
@@ -73,39 +72,28 @@ cdef class BayesClassifier(BayesModel):
 	def __reduce__(self):
 		return self.__class__, (self.distributions, self.weights)
 
-	def to_json( self, separators=(',', ' : '), indent=4 ):
+	def to_dict(self):
 		if self.d == 0:
 			raise ValueError("must fit components to the data before prediction")
 
-		model = {
+		return {
 			'class' : 'BayesClassifier',
-			'models' : [ json.loads( model.to_json() ) for model in self.distributions ],
+			'models' : [ model.to_dict() for model in self.distributions ],
 			'weights' : self.weights.tolist()
 		}
 
-		return json.dumps(model, separators=separators, indent=indent)
-
 	@classmethod
-	def from_json(cls, s):
-		try:
-			d = json.loads(s)
-		except:
-			try:
-				with open(s, 'r') as f:
-					d = json.load(f)
-			except:
-				raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+	def from_dict(cls, d):
 		models = list()
 		for j in d['models']:
 			if j['class'] == 'Distribution':
-				models.append(Distribution.from_json(json.dumps(j)))
+				models.append(Distribution.from_dict(j))
 			elif j['class'] == 'GeneralMixtureModel':
-				models.append(GeneralMixtureModel.from_json(json.dumps(j)))
+				models.append(GeneralMixtureModel.from_dict(j))
 			elif j['class'] == 'HiddenMarkovModel':
-				models.append(HiddenMarkovModel.from_json(json.dumps(j)))
+				models.append(HiddenMarkovModel.from_dict(j))
 			elif j['class'] == 'BayesianNetwork':
-				models.append(BayesianNetwork.from_json(json.dumps(j)))
+				models.append(BayesianNetwork.from_dict(j))
 
 		nb = cls( models, numpy.array(d['weights']))
 		return nb

--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -2,7 +2,6 @@
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
 import itertools as it
-import json
 import time
 import networkx as nx
 import numpy
@@ -782,65 +781,22 @@ cdef class BayesianNetwork(GraphModel):
 
 		self.bake()
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Serialize the model to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-			The two separators to pass to the json.dumps function for formatting.
-
-		indent : int, optional
-			The indentation to use at each level. Passed to json.dumps for
-			formatting.
-
-		Returns
-		-------
-		json : str
-			A properly formatted JSON object.
-		"""
-
+	def to_dict(self):
 		states = [ state.copy() for state in self.states ]
 
-		model = {
-					'class' : 'BayesianNetwork',
-					'name'  : self.name,
-					'structure' : self.structure,
-					'states' : [ json.loads( state.to_json() ) for state in states ]
-				}
-
-		return json.dumps( model, separators=separators, indent=indent )
+		return {
+			'class' : 'BayesianNetwork',
+			'name'  : self.name,
+			'structure' : self.structure,
+			'states' : [ state.to_dict() for state in states ]
+		}
 
 	@classmethod
-	def from_json(cls, s):
-		"""Read in a serialized Bayesian Network and return the appropriate object.
-
-		Parameters
-		----------
-		s : str
-			A JSON formatted string containing the file.
-
-		Returns
-		-------
-		model : object
-			A properly initialized and baked model.
-		"""
-
-		# Load a dictionary from a JSON formatted string
-		try:
-			d = json.loads(s)
-		except:
-			try:
-				with open(s, 'r') as infile:
-					d = json.load(infile)
-			except:
-				raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+	def from_dict(cls, d):
 		# Make a new generic Bayesian Network
 		model = cls(str(d['name']))
 
-		# Load all the states from JSON formatted strings
-		states = [State.from_json(json.dumps(j)) for j in d['states']]
+		states = [State.from_dict(j) for j in d['states']]
 		structure = d['structure']
 		for state, parents in zip(states, structure):
 			if len(parents) > 0:

--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -2,7 +2,6 @@
 # Contact: Jacob Schreiber (jmschreiber91@gmail.com)
 
 cimport numpy
-import json
 import numpy
 
 try:
@@ -392,51 +391,18 @@ cdef class FactorGraph(GraphModel):
 		return y_hat
 
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Serialize the model to JSON
-
-		Parameters
-		----------
-		separators: tuple, optional
-			The two separators to pass to the json.dumps function for formatting.
-
-		indent: int, optional
-			The indentation to use at each level. Passed to json.dumps for
-			formatting.
-		"""
-		model = {
+	def to_dict(self):
+		return {
 			"class": "FactorGraph",
 			"name": self.name,
-			"states": [json.loads(state.to_json()) for state in self.states],
+			"states": [state.to_dict() for state in self.states],
 			"edges": self.edges
 		}
-		return json.dumps(model, separators=separators, indent=indent, sort_keys=True)
 
 	@classmethod
-	def from_json(cls, s):
-		"""Read in a serialized FactorGraph and return the appropriate instance.
-
-		Parameters
-		----------
-		s: str
-			A JSON formatted string containing the file.
-
-		Returns
-		-------
-		model: object
-			A properly instantiated and baked model.
-		"""
-		try:
-			d = json.loads(s)
-		except:
-			try:
-				with open(s, 'r') as infile:
-					d = json.load(infile)
-			except:
-				raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+	def from_dict(cls, d):
 		model = cls(str(d["name"]))
-		states = [State.from_json(json.dumps(j)) for j in d['states']]
+		states = [State.from_dict(j) for j in d['states']]
 		model.add_states(*states)
 		for node1, node2 in d["edges"]:
 			model.add_edge(states[node1], states[node2])

--- a/pomegranate/MarkovChain.pyx
+++ b/pomegranate/MarkovChain.pyx
@@ -247,7 +247,7 @@ cdef class MarkovChain(object):
 
 		model = {
 		            'class' : 'MarkovChain',
-		            'distributions' : [ json.loads( d.to_json() )
+		            'distributions' : [ d.to_dict()
 		                                for d in self.distributions ]
 		        }
 
@@ -269,7 +269,7 @@ cdef class MarkovChain(object):
 		"""
 
 		d = json.loads(s)
-		distributions = [ Distribution.from_json( json.dumps(j) )
+		distributions = [ Distribution.from_dict(j)
 		                  for j in d['distributions'] ]
 		model = cls(distributions)
 		return model

--- a/pomegranate/MarkovNetwork.pyx
+++ b/pomegranate/MarkovNetwork.pyx
@@ -1,5 +1,4 @@
 import itertools
-import json
 import time
 import numpy
 cimport numpy
@@ -535,63 +534,11 @@ cdef class MarkovNetwork(Model):
 
 		self.bake(calculate_partition=calculate_partition)
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Serialize the model to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-			The two separators to pass to the json.dumps function for formatting.
-
-		indent : int, optional
-			The indentation to use at each level. Passed to json.dumps for
-			formatting.
-
-		Returns
-		-------
-		json : str
-			A properly formatted JSON object.
-		"""
-
-		states = [distribution.copy() for distribution in self.distributions]
-
-		model = {
-					'class' : 'MarkovNetwork',
-					'name'  : self.name,
-					'distributions' : [json.loads(d.to_json()) 
-						for d in self.distributions]
-		}
-
-		return json.dumps(model, separators=separators, indent=indent)
-
 	@classmethod
-	def from_json(cls, s):
-		"""Read in a serialized Markov Network and return the appropriate object.
-
-		Parameters
-		----------
-		s : str
-			A JSON formatted string containing the file.
-
-		Returns
-		-------
-		model : object
-			A properly initialized and baked model.
-		"""
-
-		# Load a dictionary from a JSON formatted string
-		try:
-			d = json.loads(s)
-		except:
-			try:
-				with open(s, 'r') as infile:
-					d = json.load(infile)
-			except:
-				raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+	def from_dict(cls, d):
 		distributions = []
 		for j in d['distributions']:
-			distribution = JointProbabilityTable.from_json(json.dumps(j))
+			distribution = JointProbabilityTable.from_dict(j)
 			distributions.append(distribution)
 
 		model = cls(distributions, str(d['name']))

--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -3,7 +3,6 @@
 # NaiveBayes.pyx
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
-import json
 import numpy
 cimport numpy
 
@@ -70,35 +69,24 @@ cdef class NaiveBayes(BayesModel):
 	def __reduce__(self):
 		return self.__class__, (self.distributions, self.weights)
 
-	def to_json(self, separators=(',', ' : '), indent=4):
+	def to_dict(self):
 		if self.d == 0:
 			raise ValueError("must fit components to the data before prediction")
 
-		nb = {
+		return {
 			'class' : 'NaiveBayes',
-			'models' : [json.loads(model.to_json()) for model in self.distributions],
+			'models' : [model.to_dict() for model in self.distributions],
 			'weights' : numpy.exp(self.weights).tolist()
 		}
 
-		return json.dumps(nb, separators=separators, indent=indent)
-
 	@classmethod
-	def from_json(cls, s):
-		try:
-			d = json.loads(s)
-		except:
-			try:
-				with open(s, 'r') as f:
-					d = json.load(f)
-			except:
-				raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+	def from_dict(cls, d):
 		models = list()
 		for j in d['models']:
 			if j['class'] == 'Distribution':
-				models.append(Distribution.from_json(json.dumps(j)))
+				models.append(Distribution.from_dict(j))
 			elif j['class'] == 'GeneralMixtureModel':
-				models.append(GeneralMixtureModel.from_json(json.dumps(j)))
+				models.append(GeneralMixtureModel.from_dict(j))
 
 		nb = cls(models, numpy.array(d['weights']))
 		return nb

--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -452,7 +452,6 @@ cdef class State(object):
 
 	def to_yaml(self):
 		"""Convert this state to YAML format."""
-		import yaml
 		return yaml.safe_dump(json.loads(self.to_json()))
 
 	@classmethod

--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -16,7 +16,6 @@ from ..utils import _check_nan
 from ..utils import check_random_state
 
 import itertools as it
-import json
 import numpy
 import random
 import scipy
@@ -344,37 +343,17 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 			memset(self.counts, 0, self.n*sizeof(double))
 			memset(self.marginal_counts, 0, self.n*sizeof(double)/self.k)
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Serialize the model to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-		    The two separators to pass to the json.dumps function for formatting.
-		    Default is (',', ' : ').
-
-		indent : int, optional
-		    The indentation to use at each level. Passed to json.dumps for
-		    formatting. Default is 4.
-
-		Returns
-		-------
-		json : str
-		    A properly formatted JSON object.
-		"""
-
+	def to_dict(self):
 		table = [list(key + tuple([cexp(self.values[i])])) for key, i in self.keymap.items()]
 		table = [[str(item) for item in row] for row in table]
 
-		model = {
-					'class' : 'Distribution',
-		            'name' : 'ConditionalProbabilityTable',
-		            'table' : table,
-		            'dtypes' : self.dtypes,
-		            'parents' : [json.loads(dist.to_json()) for dist in self.parents]
-		        }
-
-		return json.dumps(model, separators=separators, indent=indent)
+		return {
+			'class' : 'Distribution',
+			'name' : 'ConditionalProbabilityTable',
+			'table' : table,
+			'dtypes' : self.dtypes,
+			'parents' : [dist.to_dict() for dist in self.parents]
+		}
 
 	@classmethod
 	def from_samples(cls, X, parents=None, weights=None, pseudocount=0.0, keys=None):

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -6,7 +6,6 @@
 
 import numpy
 import itertools as it
-import json
 import random
 
 from libc.stdlib cimport calloc
@@ -324,32 +323,14 @@ cdef class DiscreteDistribution(Distribution):
 			for i in range(len(self.encoded_keys)):
 				self.encoded_counts[i] = 0
 
-	def to_json(self, separators=(',', ' :'), indent=4):
-		"""Serialize the distribution to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-			The two separators to pass to the json.dumps function for formatting.
-			Default is (',', ' : ').
-
-		indent : int, optional
-			The indentation to use at each level. Passed to json.dumps for
-			formatting. Default is 4.
-
-		Returns
-		-------
-		json : str
-			A properly formatted JSON object.
-		"""
-
-		return json.dumps({
-								'class' : 'Distribution',
-								'dtype' : self.dtype,
-								'name'  : self.name,
-								'parameters' : [{str(key): value for key, value in self.dist.items()}],
-								'frozen' : self.frozen
-						   }, separators=separators, indent=indent)
+	def to_dict(self):
+		return {
+			'class' : 'Distribution',
+			'dtype' : self.dtype,
+			'name'  : self.name,
+			'parameters' : [{str(key): value for key, value in self.dist.items()}],
+			'frozen' : self.frozen
+		}
 
 	@classmethod
 	def from_samples(cls, items, weights=None, pseudocount=0, keys=None):

--- a/pomegranate/distributions/IndependentComponentsDistribution.pyx
+++ b/pomegranate/distributions/IndependentComponentsDistribution.pyx
@@ -5,7 +5,6 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import numpy
-import json
 
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free
@@ -235,16 +234,13 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 		for d in self.parameters[0]:
 			d.clear_summaries()
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Convert the distribution to JSON format."""
-
-		return json.dumps({
-								'class' : 'Distribution',
-								'name'  : self.name,
-								'parameters' : [[json.loads(dist.to_json()) for dist in self.parameters[0]],
-								                 self.parameters[1]],
-								'frozen' : self.frozen
-						   }, separators=separators, indent=indent)
+	def to_dict(self):
+		return {
+			'class' : 'Distribution',
+			'name'  : self.name,
+			'parameters' : [[dist.to_dict() for dist in self.parameters[0]], self.parameters[1]],
+			'frozen' : self.frozen
+		}
 
 	@classmethod
 	def from_samples(cls, X, weights=None, distribution_weights=None,

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -16,7 +16,6 @@ from ..utils import check_random_state
 from ..utils import _check_nan
 
 import itertools as it
-import json
 import numpy
 import random
 import scipy
@@ -277,36 +276,16 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		self.summarize(items, weights)
 		self.from_summaries(inertia, pseudocount)
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		"""Serialize the model to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-		    The two separators to pass to the json.dumps function for formatting.
-		    Default is (',', ' : ').
-
-		indent : int, optional
-		    The indentation to use at each level. Passed to json.dumps for
-		    formatting. Default is 4.
-
-		Returns
-		-------
-		json : str
-		    A properly formatted JSON object.
-		"""
-
+	def to_dict(self):
 		table = [list(key + tuple([cexp(self.values[i])])) for key, i in self.keymap.items()]
 
-		model = {
-					'class' : 'Distribution',
-		            'name' : 'JointProbabilityTable',
-		            'table' : table,
-		            'dtypes' : self.dtypes,
-		            'parents' : [dist if isinstance(dist, int) else json.loads(dist.to_json()) for dist in self.parameters[1]]
-		        }
-		
-		return json.dumps(model, separators=separators, indent=indent)
+		return {
+			'class' : 'Distribution',
+			'name' : 'JointProbabilityTable',
+			'table' : table,
+			'dtypes' : self.dtypes,
+			'parents' : [dist if isinstance(dist, int) else dist.to_dict() for dist in self.parameters[1]]
+		}
 
 	@classmethod
 	def from_samples(cls, X, parents=None, weights=None, pseudocount=0.0, 

--- a/pomegranate/distributions/MultivariateGaussianDistribution.pyx
+++ b/pomegranate/distributions/MultivariateGaussianDistribution.pyx
@@ -6,7 +6,6 @@
 
 import numpy
 import scipy
-import json
 
 try:
 	import cupy

--- a/pomegranate/distributions/distributions.pyx
+++ b/pomegranate/distributions/distributions.pyx
@@ -5,7 +5,6 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-import json
 import numpy
 import sys
 
@@ -238,54 +237,21 @@ cdef class Distribution(Model):
 		import matplotlib.pyplot as plt
 		plt.hist(self.sample(n), **kwargs)
 
-	def to_json(self, separators=(',', ' :'), indent=4):
-		"""Serialize the distribution to a JSON.
-
-		Parameters
-		----------
-		separators : tuple, optional
-			The two separators to pass to the json.dumps function for formatting.
-			Default is (',', ' : ').
-
-		indent : int, optional
-			The indentation to use at each level. Passed to json.dumps for
-			formatting. Default is 4.
-
-		Returns
-		-------
-		json : str
-			A properly formatted JSON object.
-		"""
-
-		return json.dumps({
-								'class' : 'Distribution',
-								'name'  : self.name,
-								'parameters' : self.parameters,
-								'frozen' : self.frozen
-						   }, separators=separators, indent=indent)
+	def to_dict(self):
+		return {
+			'class' : 'Distribution',
+			'name'  : self.name,
+			'parameters' : self.parameters,
+			'frozen' : self.frozen
+		}
 
 	@classmethod
-	def from_json(cls, s):
-		"""Read in a serialized distribution and return the appropriate object.
-
-		Parameters
-		----------
-		s : str
-			A JSON formatted string containing the file.
-
-		Returns
-		-------
-		model : object
-			A properly initialized and baked model.
-		"""
-
-		d = json.loads(s)
-
+	def from_dict(cls, d):
 		if ' ' in d['class'] or 'Distribution' not in d['class']:
 			raise SyntaxError("Distribution object attempting to read invalid object.")
 
 		if d['name'] == 'IndependentComponentsDistribution':
-			d['parameters'][0] = [cls.from_json(json.dumps(dist)) for dist in d['parameters'][0]]
+			d['parameters'][0] = [cls.from_dict(dist) for dist in d['parameters'][0]]
 			return IndependentComponentsDistribution(d['parameters'][0], d['parameters'][1], d['frozen'])
 
 		elif d['name'] == 'DiscreteDistribution':
@@ -308,7 +274,7 @@ cdef class Distribution(Model):
 			return DiscreteDistribution(dist, frozen=d['frozen'])
 
 		elif 'Table' in d['name']:
-			parents = [j if isinstance(j, int) else Distribution.from_json(json.dumps(j)) for j in d['parents']]
+			parents = [j if isinstance(j, int) else Distribution.from_dict(j) for j in d['parents']]
 			table = []
 
 			for row in d['table']:

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -8,7 +8,6 @@ from libc.stdlib cimport free
 from libc.stdlib cimport malloc
 from libc.math cimport exp as cexp
 
-import json
 import time
 
 import numpy
@@ -397,23 +396,16 @@ cdef class GeneralMixtureModel(BayesModel):
         free(summaries)
         return log_probability_sum
 
-    def to_json(self):
-        separators=(',', ' : ')
-        indent=4
-
-        model = {
-                    'class' : 'GeneralMixtureModel',
-                    'distributions'  : [ json.loads(dist.to_json())
-                                         for dist in self.distributions ],
-                    'weights' : numpy.exp(self.weights).tolist()
-                }
-
-        return json.dumps(model, separators=separators, indent=indent)
+    def to_dict(self):
+        return {
+            'class' : 'GeneralMixtureModel',
+            'distributions' : [ dist.to_dict() for dist in self.distributions ],
+            'weights' : numpy.exp(self.weights).tolist()
+        }
 
     @classmethod
-    def from_json(cls, s):
-        d = json.loads(s)
-        distributions = [ Distribution.from_json(json.dumps(j))
+    def from_dict(cls, d):
+        distributions = [ Distribution.from_dict(j)
                           for j in d['distributions'] ]
         model = cls(distributions, numpy.array( d['weights'] ))
         return model

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 from libc.math cimport exp as cexp
 from operator import attrgetter
-import json
 import math
 import networkx
 import tempfile
@@ -323,7 +322,6 @@ cdef class HiddenMarkovModel(GraphModel):
 
         self.name = state['name']
 
-        # Load all the states from JSON formatted strings
         states = state['states']
         for i, j in state['distribution ties']:
             # Tie appropriate states together
@@ -541,7 +539,7 @@ cdef class HiddenMarkovModel(GraphModel):
             A deep copy of the model with entirely new objects.
         """
 
-        return self.__class__.from_json(self.to_json())
+        return self.__class__.from_dict(self.to_dict())
 
     def freeze_distributions(self):
         """Freeze all the distributions in model.
@@ -3178,34 +3176,17 @@ cdef class HiddenMarkovModel(GraphModel):
         for state in self.states[:self.silent_start]:
             state.distribution.clear_summaries()
 
-    def to_json(self, separators=(',', ' : '), indent=4):
-        """Serialize the model to a JSON.
-
-        Parameters
-        ----------
-        separators : tuple, optional
-            The two separators to pass to the json.dumps function for formatting.
-
-        indent : int, optional
-            The indentation to use at each level. Passed to json.dumps for
-            formatting.
-
-        Returns
-        -------
-        json : str
-            A properly formatted JSON object.
-        """
-
+    def to_dict(self):
         model = {
-                    'class' : 'HiddenMarkovModel',
-                    'name'  : self.name,
-                    'start' : json.loads(self.start.to_json()),
-                    'end'   : json.loads(self.end.to_json()),
-                    'states' : [json.loads(state.to_json()) for state in self.states],
-                    'end_index' : self.end_index,
-                    'start_index' : self.start_index,
-                    'silent_index' : self.silent_start
-                }
+            'class' : 'HiddenMarkovModel',
+            'name'  : self.name,
+            'start' : self.start.to_dict(),
+            'end'   : self.end.to_dict(),
+            'states' : [state.to_dict() for state in self.states],
+            'end_index' : self.end_index,
+            'start_index' : self.start_index,
+            'silent_index' : self.silent_start
+        }
 
         indices = { state: i for i, state in enumerate(self.states)}
 
@@ -3250,37 +3231,14 @@ cdef class HiddenMarkovModel(GraphModel):
                 ties.append((i, self.tied[j]))
 
         model['distribution ties'] = ties
-        return json.dumps(model, separators=separators, indent=indent)
+        return model
 
     @classmethod
-    def from_json(cls, s, verbose=False):
-        """Read in a serialized model and return the appropriate classifier.
-
-        Parameters
-        ----------
-        s : str
-            A JSON formatted string containing the file.
-        Returns
-        -------
-        model : object
-            A properly initialized and baked model.
-        """
-
-        # Load a dictionary from a JSON formatted string
-        try:
-            d = json.loads(s)
-        except:
-            try:
-                with open(s, 'r') as infile:
-                    d = json.load(infile)
-            except:
-                raise IOError("String must be properly formatted JSON or filename of properly formatted JSON.")
-
+    def from_dict(cls, d, verbose=False):
         # Make a new generic HMM
         model = cls(str(d['name']))
 
-        # Load all the states from JSON formatted strings
-        states = [State.from_json(json.dumps(j)) for j in d['states']]
+        states = [State.from_dict(j) for j in d['states']]
         for i, j in d['distribution ties']:
             # Tie appropriate states together
             states[i].tie(states[j])

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -17,7 +17,6 @@ from .utils cimport mdot
 from .utils cimport isnan
 
 import time
-import json
 import numpy
 cimport numpy
 
@@ -669,18 +668,15 @@ cdef class Kmeans(Model):
 		memset(self.summary_sizes, 0, self.k*self.d*sizeof(double))
 		memset(self.summary_weights, 0, self.k*self.d*sizeof(double))
 
-	def to_json(self, separators=(',', ' : '), indent=4):
-		model = {
-					'class' : 'Kmeans',
-					'k' : self.k,
-					'centroids'  : self.centroids.tolist()
-				}
-
-		return json.dumps(model, separators=separators, indent=indent)
+	def to_dict(self):
+		return {
+			'class' : 'Kmeans',
+			'k' : self.k,
+			'centroids'  : self.centroids.tolist()
+		}
 
 	@classmethod
-	def from_json(cls, s):
-		d = json.loads(s)
+	def from_dict(cls, d):
 		model = cls(d['k'], d['centroids'])
 		return model
 


### PR DESCRIPTION
This decreases the time required to load a 5 MB Bayes net from JSON by about 33%, while at the same time it cleans up the code by factoring out JSON serialization and deserialization logic that is common to all models.

Test program:

```
from pomegranate import BayesianNetwork
from neurtu import Benchmark, delayed

json = open('test.json').read()
load_net = delayed(BayesianNetwork.from_json)(json)
print(Benchmark(wall_time=True, cpu_time=True, repeat=100)(load_net))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.296894  0.294889
max    0.303662  0.299657
std    0.002196  0.002272
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   0.198973  0.196935
max    0.220578  0.203941
std    0.002785  0.002416
```