### PR TITLE
Optimization of HMM fitting.

### DIFF
--- a/benchmarks/benchmark_hmm.py
+++ b/benchmarks/benchmark_hmm.py
@@ -79,8 +79,8 @@ def benchmark_viterbi( model, sample ):
 
 def benchmark_training( model, samples, n_jobs ):
 	tic = time.time()
-	improvement = model.train( samples, max_iterations=10, verbose=False, n_jobs=n_jobs )
-	print("{:16}: time: {:5.5}, improvement: {:5.5} ({} jobs)".format( "BW TRAINING", time.time() - tic, improvement, n_jobs ))
+	improvement = model.fit( samples, max_iterations=10, verbose=False, n_jobs=n_jobs , return_history=True)
+	print("{:16}: time: {:5.5}, improvement: {:5.5} ({} jobs)".format( "BW TRAINING", time.time() - tic, improvement[1].total_improvement[0], n_jobs ))
 
 def main():
 	n = 15

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -2537,7 +2537,8 @@ cdef class HiddenMarkovModel(GraphModel):
         cdef bint check_input = alg == 'viterbi'
         cdef list X = []
         cdef list checked_sequences=[]
-        cdef list Z = []
+        cdef list W=[]
+        cdef list L=[]
 
         training_start_time = time.time()
 
@@ -2555,7 +2556,17 @@ cdef class HiddenMarkovModel(GraphModel):
             sequences=checked_sequences
             data_generator = SequenceGenerator(sequences, weights, labels)
         else:
-            data_generator = sequences
+            for batch in sequences.batches():
+                sequence_ndarray= _check_input(batch[0][0],self)
+                checked_sequences.append(sequence_ndarray)
+                W.append(batch[1])
+                if len(batch)==3:
+                    L.append(batch[2])
+            weights=W
+            if len(L)>0:
+                lables=L
+
+            data_generator = SequenceGenerator(checked_sequences, weights, labels)
 
 
         n = data_generator.shape[0]

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -2561,10 +2561,10 @@ cdef class HiddenMarkovModel(GraphModel):
                 checked_sequences.append(sequence_ndarray)
                 W.append(batch[1])
                 if len(batch)==3:
-                    L.append(batch[2])
+                    L.append(batch[2][0])
             weights=W
             if len(L)>0:
-                lables=L
+                labels=L
 
             data_generator = SequenceGenerator(checked_sequences, weights, labels)
 
@@ -2609,7 +2609,7 @@ cdef class HiddenMarkovModel(GraphModel):
 
                 elif labels is not None:
                     log_probability_sum = sum(parallel(f(*batch, 
-                        algorithm=algorithm) for batch in data_generator.batches()))
+                        algorithm=algorithm, check_input=False) for batch in data_generator.batches()))
 
                 else:
                     log_probability_sum = sum(parallel(f(*batch, algorithm=algorithm,

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -1115,6 +1115,21 @@ def test_hmm_viterbi_fit_w_pseudocount_inertia():
     total_improvement = history.total_improvement[-1]
     assert_equal(round(total_improvement, 4), 83.2834)
 
+@with_setup(setup, teardown)
+def test_hmm_viterbi_fit_one_check_input():
+    seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
+    'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
+    'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
+
+    _, history = model.fit(seqs,
+                               return_history=True,
+                               algorithm='viterbi',
+                               verbose=False,
+                               use_pseudocount=True,
+                               multiple_check_input=False)
+
+    total_improvement = history.total_improvement[-1]
+    assert_equal(round(total_improvement, 4), 83.2834)
 
 @with_setup(setup, teardown)
 def test_hmm_bw_fit():
@@ -1641,6 +1656,22 @@ def test_hmm_bw_fit_w_edge_a_distribution_inertia():
     total_improvement = history.total_improvement[-1]
     assert_equal(round(total_improvement, 4), 81.5447)
 
+@with_setup(setup, teardown)
+def test_hmm_bw_fit_one_check_input():
+    seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
+        'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
+        'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
+
+    _, history = model.fit(seqs,
+                               return_history=True,
+                                     algorithm='baum-welch',
+                                     verbose=False,
+                                     use_pseudocount=True,
+                                     max_iterations=5,
+                                     multiple_check_input=False)
+
+    total_improvement = history.total_improvement[-1]
+    assert_equal(round(total_improvement, 4), 83.1132)
 
 def test_hmm_initialization():
     hmmd1 = HiddenMarkovModel()
@@ -1805,6 +1836,17 @@ def test_hmm_univariate_discrete_from_samples_with_labels():
 
     assert_greater(logp2, logp1)
 
+@with_setup(setup_univariate_discrete_dense, teardown)
+def test_hmm_univariate_discrete_from_samples_one_check_input():
+    X = [model.sample(random_state=0) for i in range(25)]
+    model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, 
+                                            max_iterations=25,
+                                            multiple_check_input=False)
+
+    logp1 = sum(map(model.log_probability, X))
+    logp2 = sum(map(model2.log_probability, X))
+
+    assert_greater(logp2, logp1)
 
 @with_setup(setup_univariate_gaussian_dense, teardown)
 def test_hmm_univariate_gaussian_from_samples():


### PR DESCRIPTION
In https://github.com/jmschrei/pomegranate/issues/802 i proposed adding transcoding of input sequences in hmm.fit to avoid invoking _check_input in hmm.summarize. This fix speed up fitting HMM models about two times.

With fix:
```
[1] Improvement: 253389.81343831721	Time (s): 0.2847
[2] Improvement: 213.1332476385287	Time (s): 0.2908
[3] Improvement: 76.93109403923154	Time (s): 0.2974
[4] Improvement: 44.39238843484782	Time (s): 0.283
[5] Improvement: 28.537198789825197	Time (s): 0.2837
[6] Improvement: 17.950176118465606	Time (s): 0.2804
[7] Improvement: 11.243089165887795	Time (s): 0.2813
[8] Improvement: 7.315842745301779	Time (s): 0.2797
Total Training Improvement: 253789.3164752493
Total Training Time (s): 2.9646
```

With pomegranate 0.13.4:
```
[1] Improvement: 253389.81343831721	Time (s): 0.71
[2] Improvement: 213.1332476385287	Time (s): 0.722
[3] Improvement: 76.93109403923154	Time (s): 0.7147
[4] Improvement: 44.39238843484782	Time (s): 0.7168
[5] Improvement: 28.537198789825197	Time (s): 0.7143
[6] Improvement: 17.950176118465606	Time (s): 0.7111
[7] Improvement: 11.243089165887795	Time (s): 0.7141
[8] Improvement: 7.315842745301779	Time (s): 0.7134
Total Training Improvement: 253789.3164752493
Total Training Time (s): 6.4269
```