### PR TITLE
Skip previously checked combinations in ParentGraph

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1288,9 +1288,10 @@ cdef class ParentGraph(object):
 
 		return score
 
-	def __getitem__(self, value):
-		if value in self.values:
-			return self.values[value]
+	def get(self, value, frozen=0):
+		key = (value, frozen)
+		if key in self.values:
+			return self.values[key]
 
 		best_parents, best_score = (), NEGINF
 		if len(value) <= max(self.max_parents, len(self.include_parents)):
@@ -1305,16 +1306,19 @@ cdef class ParentGraph(object):
 					best_parents, best_score = value, self.calculate_value(
 						value)
 
-		for i in range(len(value)):
-			parent_subset = value[:i] + value[i+1:]
-			parents, score = self[parent_subset]
+		for i in range(frozen, len(value)):
+			parent_subset = value[frozen:i] + value[i+1:]
+			parents, score = self.get(parent_subset, i)
 
 			if score > best_score:
 				best_score = score
 				best_parents = parents
 
-		self.values[value] = (best_parents, best_score)
-		return self.values[value]
+		self.values[key] = (best_parents, best_score)
+		return self.values[key]
+
+	def __getitem__(self, value):
+		return self.get(value)
 
 
 def discrete_chow_liu_tree(numpy.ndarray X_ndarray, numpy.ndarray weights_ndarray,


### PR DESCRIPTION
This reduces by about 8% the time required to train a Bayes net with the exact algorithm when 10% of the values are missing.

Test program:

```
import numpy as np
from neurtu import delayed, Benchmark
from pomegranate import BayesianNetwork
from random import random
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:,:8]
train = delayed(BayesianNetwork)().from_samples(X, algorithm='exact')

print('Without missing values:')
print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
print()

for i in range(X.shape[0]):
    for j in range(X.shape[1]):
        if random() <= 0.1:
            X[i][j] = np.nan

print('With missing values:')
print(Benchmark(wall_time=True, cpu_time=True, repeat=3)(train))
print()
```

Before:

```
Without missing values:
      wall_time  cpu_time                                                                                                     
mean  11.905570  8.175041
max   11.914899  8.266443
std    0.014322  0.083954

With missing values:
      wall_time  cpu_time                                                                                                     
mean  11.850972  8.172969
max   11.908914  8.339340
std    0.050224  0.152950
```

After:

```
Without missing values:
      wall_time  cpu_time                                                                                                     
mean  11.611180  7.963914
max   11.654809  7.985201
std    0.049199  0.028555

With missing values:
      wall_time  cpu_time                                                                                                     
mean  10.858345  7.448042
max   10.866153  7.546919
std    0.012240  0.088464
```