### PR TITLE
Use numpy.asarray instead of numpy.array where possible

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -675,7 +675,7 @@ cdef class BayesianNetwork(GraphModel):
 
 		batch_size = len(X) // n_jobs + len(X) % n_jobs
 		if not isinstance(X, BaseGenerator):
-			data_generator = DataGenerator(numpy.array(X, dtype=object), 
+			data_generator = DataGenerator(numpy.asarray(X, dtype=object),
 				weights, batch_size=batch_size)
 		else:
 			data_generator = X
@@ -740,7 +740,7 @@ cdef class BayesianNetwork(GraphModel):
 		if weights is None:
 			weights_ndarray = numpy.ones(n, dtype='float64')
 		else:
-			weights_ndarray = numpy.array(weights, dtype='float64')
+			weights_ndarray = numpy.asarray(weights, dtype='float64')
 
 		weights_ptr = <double*> weights_ndarray.data
 
@@ -907,11 +907,11 @@ cdef class BayesianNetwork(GraphModel):
 			X = numpy.concatenate([batch[0] for batch in batches])
 			weights = numpy.concatenate([batch[1] for batch in batches])
 		else:
-			X = numpy.array(X)
+			X = numpy.asarray(X)
 			if weights is None:
 				weights = numpy.ones(X.shape[0], dtype='float64')
 			else:
-				weights = numpy.array(weights, dtype='float64')
+				weights = numpy.asarray(weights, dtype='float64')
 
 		d = len(structure)
 		nodes = [None for i in range(d)]
@@ -1083,11 +1083,11 @@ cdef class BayesianNetwork(GraphModel):
 			X = numpy.concatenate([batch[0] for batch in batches])
 			weights = numpy.concatenate([batch[1] for batch in batches])
 		else:
-			X = numpy.array(X)
+			X = numpy.asarray(X)
 			if weights is None:
 				weights = numpy.ones(X.shape[0], dtype='float64')
 			else:
-				weights = numpy.array(weights, dtype='float64')
+				weights = numpy.asarray(weights, dtype='float64')
 
 		n, d = X.shape
 

--- a/pomegranate/MarkovChain.pyx
+++ b/pomegranate/MarkovChain.pyx
@@ -180,7 +180,7 @@ cdef class MarkovChain(object):
 		if weights is None:
 			weights = numpy.ones(len(sequences), dtype='float64')
 		else:
-			weights = numpy.array(weights)
+			weights = numpy.asarray(weights)
 
 		n = max( map(len, sequences) )
 		for i in range(self.k):

--- a/pomegranate/MarkovNetwork.pyx
+++ b/pomegranate/MarkovNetwork.pyx
@@ -444,7 +444,7 @@ cdef class MarkovNetwork(Model):
 		if weights is None:
 			weights = numpy.ones(len(X), dtype='float64')
 		else:
-			weights = numpy.array(weights, dtype='float64')
+			weights = numpy.asarray(weights, dtype='float64')
 
 		starts = [int(i*len(X)/n_jobs) for i in range(n_jobs)]
 		ends = [int(i*len(X)/n_jobs) for i in range(1, n_jobs+1)]
@@ -500,7 +500,7 @@ cdef class MarkovNetwork(Model):
 		if weights is None:
 			weights = numpy.ones(n, dtype='float64')
 		else:
-			weights = numpy.array(weights, dtype='float64')
+			weights = numpy.asarray(weights, dtype='float64')
 
 		for i, d in enumerate(self.distributions):
 			d.summarize(X, weights)
@@ -633,14 +633,14 @@ cdef class MarkovNetwork(Model):
 			A Markov network with the specified structure.
 		"""
 
-		X = numpy.array(X)
+		X = numpy.asarray(X)
 		n, d = X.shape
 		distributions = []
 
 		if weights is None:
 			weights = numpy.ones(X.shape[0], dtype='float64')
 		else:
-			weights = numpy.array(weights, dtype='float64')
+			weights = numpy.asarray(weights, dtype='float64')
 
 		for i, parents in enumerate(structure):
 			distribution = JointProbabilityTable.from_samples(X[:, parents],
@@ -738,7 +738,7 @@ cdef class MarkovNetwork(Model):
 			The learned Markov Network.
 		"""
 
-		X = numpy.array(X)
+		X = numpy.asarray(X)
 		n, d = X.shape
 
 		keys = [set([x for x in X[:,i] if not _check_nan(x)]) for i in range(d)]
@@ -748,7 +748,7 @@ cdef class MarkovNetwork(Model):
 		if weights is None:
 			weights = numpy.ones(X.shape[0], dtype='float64')
 		else:
-			weights = numpy.array(weights, dtype='float64')
+			weights = numpy.asarray(weights, dtype='float64')
 
 		if reduce_dataset:
 			X_count = {}

--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -93,7 +93,7 @@ cdef class BayesModel(Model):
         if weights is None:
             weights = numpy.ones_like(distributions, dtype='float64') / self.n
         else:
-            weights = numpy.array(weights, dtype='float64') / sum(weights)
+            weights = numpy.asarray(weights, dtype='float64') / sum(weights)
 
         self.weights = numpy.log(weights)
         self.weights_ptr = <double*> self.weights.data
@@ -255,7 +255,7 @@ cdef class BayesModel(Model):
             if self.is_vl_:
                 for i in range(n):
                     with gil:
-                        X_ndarray = numpy.array(X[i])
+                        X_ndarray = numpy.asarray(X[i])
                         X_ptr = <double*> X_ndarray.data
                     logp[i] = self._vl_log_probability(X_ptr, n)
             else:
@@ -752,7 +752,7 @@ cdef class BayesModel(Model):
         if weights is None:
             weights = numpy.ones(X.shape[0], dtype='float64')
         else:
-            weights = numpy.array(weights, dtype='float64')
+            weights = numpy.asarray(weights, dtype='float64')
 
         if self.is_vl_:
             for i, distribution in enumerate(self.distributions):

--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -380,7 +380,7 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 	def from_samples(cls, X, parents=None, weights=None, pseudocount=0.0, keys=None):
 		"""Learn the table from data."""
 
-		X = numpy.array(X)
+		X = numpy.asarray(X)
 		n, d = X.shape
 
 		keys = keys or [numpy.unique(X[:,i]) for i in range(d)]

--- a/pomegranate/distributions/IndependentComponentsDistribution.pyx
+++ b/pomegranate/distributions/IndependentComponentsDistribution.pyx
@@ -124,7 +124,7 @@ cdef class IndependentComponentsDistribution(MultivariateDistribution):
 			else:
 				n = len(X)
 
-			X_ndarray = numpy.array(X, dtype='float64')
+			X_ndarray = numpy.asarray(X, dtype='float64')
 			X_ptr = <double*> X_ndarray.data
 
 			logp_array = numpy.empty(n, dtype='float64')

--- a/pomegranate/distributions/KernelDensities.pyx
+++ b/pomegranate/distributions/KernelDensities.pyx
@@ -46,7 +46,7 @@ cdef class KernelDensity(Distribution):
 		n = points.shape[0]
 
 		if weights is not None:
-			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
+			weights = numpy.asarray(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
 			weights = numpy.ones(n, dtype=numpy.float64) / n
 
@@ -78,7 +78,7 @@ cdef class KernelDensity(Distribution):
 
 		# Get the weights, or assign uniform weights
 		if weights is not None:
-			weights = numpy.array(weights, dtype=numpy.float64) / numpy.sum(weights)
+			weights = numpy.asarray(weights, dtype=numpy.float64) / numpy.sum(weights)
 		else:
 			weights = numpy.ones(n, dtype=numpy.float64) / n
 

--- a/pomegranate/distributions/distributions.pyx
+++ b/pomegranate/distributions/distributions.pyx
@@ -132,7 +132,7 @@ cdef class Distribution(Model):
 		logp_array = numpy.empty(n, dtype='float64')
 		logp_ptr = <double*> logp_array.data
 
-		X_ndarray = numpy.array(X, dtype='float64')
+		X_ndarray = numpy.asarray(X, dtype='float64')
 		X_ptr = <double*> X_ndarray.data
 
 		self._log_probability(X_ptr, logp_ptr, n)
@@ -387,7 +387,7 @@ cdef class MultivariateDistribution(Distribution):
 		else:
 			n = len(X)
 
-		X_ndarray = numpy.array(X, dtype='float64')
+		X_ndarray = numpy.asarray(X, dtype='float64')
 		X_ptr = <double*> X_ndarray.data
 
 		logp_array = numpy.empty(n, dtype='float64')

--- a/pomegranate/gmm.pyx
+++ b/pomegranate/gmm.pyx
@@ -324,7 +324,7 @@ cdef class GeneralMixtureModel(BayesModel):
         if weights is None:
             weights_ndarray = numpy.ones(n, dtype='float64')
         else:
-            weights_ndarray = numpy.array(weights, dtype='float64')
+            weights_ndarray = numpy.asarray(weights, dtype='float64')
 
         cdef double* X_ptr
         cdef double* weights_ptr = <double*> weights_ndarray.data

--- a/pomegranate/io.py
+++ b/pomegranate/io.py
@@ -190,7 +190,7 @@ class SequenceGenerator(BaseGenerator):
 
 	@property
 	def shape(self):
-		x_ = numpy.array(self.X[0])
+		x_ = numpy.asarray(self.X[0])
 
 		if x_.ndim == 1:
 			return len(self.X), 1

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -277,7 +277,7 @@ cdef class Kmeans(Model):
 
 				return numpy.concatenate(y_pred)
 
-		X = numpy.array(X, dtype='float64', order='C')
+		X = numpy.asarray(X, dtype='float64', order='C')
 		cdef double* X_ptr = <double*> (<numpy.ndarray> X).data
 		cdef int n = len(X)
 
@@ -325,7 +325,7 @@ cdef class Kmeans(Model):
 		cdef double* X_ptr
 		cdef double* centroid
 
-		X = numpy.array(X, dtype='float64', order='C')
+		X = numpy.asarray(X, dtype='float64', order='C')
 		X_ptr = <double*> (<numpy.ndarray> X).data
 
 		dist = numpy.empty((X.shape[0], self.k))
@@ -404,7 +404,7 @@ cdef class Kmeans(Model):
 			This is the fit kmeans object.
 		"""
 
-		X = numpy.array(X, dtype='float64', order='C')
+		X = numpy.asarray(X, dtype='float64', order='C')
 
 		n, d = X.shape
 
@@ -538,7 +538,7 @@ cdef class Kmeans(Model):
 			probabilities.
 		"""
 
-		cdef numpy.ndarray X_ndarray = numpy.array(X, dtype='float64', order='C')
+		cdef numpy.ndarray X_ndarray = numpy.asarray(X, dtype='float64', order='C')
 		cdef double* X_ptr = <double*> X_ndarray.data
 
 		cdef numpy.ndarray weights_ndarray
@@ -548,7 +548,7 @@ cdef class Kmeans(Model):
 		if weights is None:
 			weights_ndarray = numpy.ones(n, dtype='float64')
 		else:
-			weights_ndarray = numpy.array(weights, dtype='float64')
+			weights_ndarray = numpy.asarray(weights, dtype='float64')
 
 		cdef double* weights_ptr = <double*> weights_ndarray.data
 
@@ -763,7 +763,7 @@ cdef class Kmeans(Model):
 			parallelism is used.
 		"""
 
-		X = numpy.array(X, dtype='float64', order='C')
+		X = numpy.asarray(X, dtype='float64', order='C')
 
 		n, d = X.shape
 

--- a/pomegranate/parallel.pyx
+++ b/pomegranate/parallel.pyx
@@ -307,7 +307,7 @@ def summarize(model, X, weights=None, y=None, n_jobs=1, backend='threading', par
 	if weights is None:
 		weights = numpy.ones(len(X), dtype='float64')
 	else:
-		weights = numpy.array(weights, dtype='float64')
+		weights = numpy.asarray(weights, dtype='float64')
 
 	starts = [n/n_jobs*i for i in range(n_jobs)]
 	ends = starts[1:] + [n]
@@ -401,7 +401,7 @@ def fit(model, X, weights=None, y=None, n_jobs=1, backend='threading', stop_thre
 	if weights is None:
 		weights = numpy.ones(len(X), dtype='float64')
 	else:
-		weights = numpy.array(weights, dtype='float64')
+		weights = numpy.asarray(weights, dtype='float64')
 
 	if isinstance(model, HiddenMarkovModel):
 		return model.fit(X, weights=weights, n_jobs=n_jobs, stop_threshold=stop_threshold,

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -216,7 +216,7 @@ cdef double pair_lse(double x, double y) nogil:
 def logsumexp(X):
 	"""Calculate the log-sum-exp of an array to add in log space."""
 
-	X = numpy.array(X, dtype='float64')
+	X = numpy.asarray(X, dtype='float64')
 	
 	cdef double* X_ptr = <double*> (<numpy.ndarray> X).data
 	cdef double x
@@ -242,8 +242,8 @@ def logsumexp(X):
 def logaddexp(X, Y):
 	"""Calculate the log-add-exp of a pair of arrays."""
 
-	X = numpy.array(X, dtype='float64')
-	Y = numpy.array(Y, dtype='float64')
+	X = numpy.asarray(X, dtype='float64')
+	Y = numpy.asarray(Y, dtype='float64')
 
 	if len(X.shape) != len(Y.shape):
 		raise ValueError("Both arrays must be of the same shape.")
@@ -452,7 +452,7 @@ def weight_set(items, weights):
 	if weights is None: # Weight everything 1 if no weights specified
 		weights = numpy.ones(items.shape[0], dtype=numpy.float64)
 	else: # Force whatever we have to be a Numpy array
-		weights = numpy.array(weights, dtype=numpy.float64)
+		weights = numpy.asarray(weights, dtype=numpy.float64)
 
 	return items, weights
 


### PR DESCRIPTION
numpy.array always makes a copy whereas numpy.asarray only makes a copy if necessary.

Compare:

```
$ /usr/bin/time -v python -c 'import numpy as np; np.array(np.ones(1000000))' 2>&1 | grep 'Maximum resident set'
        Maximum resident set size (kbytes): 41096
```

```
$ /usr/bin/time -v python -c 'import numpy as np; np.asarray(np.ones(1000000))' 2>&1 | grep 'Maximum resident set'
        Maximum resident set size (kbytes): 33168
```