### PR TITLE
Remove unused variables from ParentGraph class

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1597,9 +1597,7 @@ cdef class ParentGraph(object):
 	"""
 
 	cdef int i, n, d, max_parents
-	cdef tuple parent_set
 	cdef double pseudocount
-	cdef public double all_parents_score
 	cdef dict values
 	cdef numpy.ndarray X
 	cdef numpy.ndarray weights


### PR DESCRIPTION
I just noticed that these variables aren't doing anything. It would make the code simpler and more understandable to simply remove them.