### PR TITLE
Defining a Cython distribution for custom distance metrics

### DIFF
--- a/pomegranate/distributions/CustomDistribution.pxd
+++ b/pomegranate/distributions/CustomDistribution.pxd
@@ -1,0 +1,13 @@
+# CustomDistribution.pxd
+# Contact: Aaron Meyer
+
+import numpy
+cimport numpy
+
+from .distributions cimport Distribution
+
+cdef class CustomDistribution(Distribution):
+	cdef public numpy.ndarray logWeights
+	cdef public numpy.ndarray weightsIn
+	cdef double* logWeights_ptr
+	cdef double* weightsIn_ptr

--- a/pomegranate/distributions/CustomDistribution.pyx
+++ b/pomegranate/distributions/CustomDistribution.pyx
@@ -14,6 +14,15 @@ from libc.math cimport sqrt as csqrt
 cdef class CustomDistribution(Distribution):
 	""" The generic distribution class. """
 
+	property parameters:
+		def __get__(self):
+			return [self.logWeights.tolist()]
+		def __set__(self, logWeights):
+			self.logWeights = numpy.array(logWeights, dtype='float64')
+			self.logWeights_ptr = <double*> self.logWeights.data
+			self.weightsIn = numpy.exp(self.logWeights)
+			self.weightsIn_ptr = <double*> self.weightsIn.data
+
 	def __init__(self, N, frozen=False):
 		self.frozen = frozen
 		self.summaries = None

--- a/pomegranate/distributions/CustomDistribution.pyx
+++ b/pomegranate/distributions/CustomDistribution.pyx
@@ -1,0 +1,46 @@
+#!python
+#cython: boundscheck=False
+#cython: cdivision=True
+# CustomDistribution.pyx
+# Contact: Aaron Meyer
+
+import numpy
+
+from ..utils cimport isnan
+
+from libc.math cimport sqrt as csqrt
+
+
+cdef class CustomDistribution(Distribution):
+	""" The generic distribution class. """
+
+	def __init__(self, N, frozen=False):
+		self.frozen = frozen
+		self.summaries = None
+		self.weightsIn = numpy.ones(N, dtype='float64')
+		self.logWeights = numpy.log(self.weights)
+		self.weightsIn_ptr = <double*> self.weightsIn.data
+		self.logWeights_ptr = <double*> self.logWeights.data
+
+	cdef void _log_probability(self, double* X, double* log_probability, int n) nogil:
+		cdef int i
+		for i in range(n):
+			if isnan(X[i]):
+				log_probability[i] = 0.
+			else:
+				log_probability[i] = self.logWeights_ptr[int(X[i])]
+
+	cdef double _summarize(self, double* X, double* weights, int n,
+		int column_idx, int d) nogil:
+		"""Calculate sufficient statistics for a minibatch.
+		For this distribution we'll just store the weights.
+		"""
+
+		cdef int i
+
+		for i in range(n):
+			self.weightsIn_ptr[i] = weights[i]
+
+	def clear_summaries(self):
+		""" Clear the summary statistics stored in the object. Not needed here. """
+		return

--- a/pomegranate/distributions/CustomDistribution.pyx
+++ b/pomegranate/distributions/CustomDistribution.pyx
@@ -18,7 +18,7 @@ cdef class CustomDistribution(Distribution):
 		self.frozen = frozen
 		self.summaries = None
 		self.weightsIn = numpy.ones(N, dtype='float64')
-		self.logWeights = numpy.log(self.weights)
+		self.logWeights = numpy.log(self.weightsIn)
 		self.weightsIn_ptr = <double*> self.weightsIn.data
 		self.logWeights_ptr = <double*> self.logWeights.data
 

--- a/pomegranate/distributions/__init__.py
+++ b/pomegranate/distributions/__init__.py
@@ -17,6 +17,7 @@ from .BetaDistribution import BetaDistribution
 from .GammaDistribution import GammaDistribution
 from .DiscreteDistribution import DiscreteDistribution
 from .PoissonDistribution import PoissonDistribution
+from .CustomDistribution import CustomDistribution
 
 from .KernelDensities import KernelDensity
 from .KernelDensities import UniformKernelDensity


### PR DESCRIPTION
@mcreixell and I needed a way to define custom distances between observations when fitting a GMM. (We're clustering data where each observation is a protein peptide, and want to be able to use the PAM250 or other distance metrics to influence the clustering.) To do so, we made a "custom distribution" which can then be inherited by a Python distance class. One then makes a new column in the data that includes the indices for each observation.

We were wondering if this might be a sufficiently general to include within pomegranate. We can write a test and description if so, but wanted to check first.