### PR TITLE
Remove redundant initializations from constructors

### DIFF
--- a/pomegranate/base.pyx
+++ b/pomegranate/base.pyx
@@ -21,8 +21,6 @@ cdef class Model(object):
 
 	def __cinit__(self):
 		self.name = "Model"
-		self.frozen = False
-		self.d = 0
 
 	def __str__(self):
 		return self.to_json()
@@ -332,9 +330,6 @@ cdef class GraphModel(Model):
 		self.name = name or str(id(self))
 		self.states = []
 		self.edges = []
-		self.n_edges = 0
-		self.n_states = 0
-		self.d = 0
 
 	def __str__(self):
 		"""Represent this model with it's name and states."""

--- a/pomegranate/distributions/ConditionalProbabilityTable.pyx
+++ b/pomegranate/distributions/ConditionalProbabilityTable.pyx
@@ -37,7 +37,6 @@ cdef class ConditionalProbabilityTable(MultivariateDistribution):
 		"""
 
 		self.name = "ConditionalProbabilityTable"
-		self.frozen = False
 		self.m = len(parents) if parents is not None else len(table[0])-2
 		self.n = len(table)
 		self.k = len(set(row[-2] for row in table))

--- a/pomegranate/distributions/DiscreteDistribution.pyx
+++ b/pomegranate/distributions/DiscreteDistribution.pyx
@@ -57,11 +57,6 @@ cdef class DiscreteDistribution(Distribution):
 		self.log_dist = { key: _log(value) for key, value in characters.items() }
 		self.summaries =[{ key: 0 for key in characters.keys() }, 0]
 
-		self.encoded_summary = 0
-		self.encoded_keys = None
-		self.encoded_counts = NULL
-		self.encoded_log_probability = NULL
-
 	def __dealloc__(self):
 		if self.encoded_keys is not None:
 			free(self.encoded_counts)

--- a/pomegranate/distributions/JointProbabilityTable.pyx
+++ b/pomegranate/distributions/JointProbabilityTable.pyx
@@ -37,7 +37,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 		"""
 
 		self.name = "JointProbabilityTable"
-		self.frozen = False
 		self.d = len(parents) if parents is not None else len(table[0]) - 1
 		self.m = len(parents) if parents is not None else len(table[0]) - 1
 		self.n = len(table)
@@ -46,7 +45,6 @@ cdef class JointProbabilityTable(MultivariateDistribution):
 
 		self.values = <double*> malloc(self.n*sizeof(double))
 		self.counts = <double*> calloc(self.n, sizeof(double))
-		self.count = 0
 
 		self.n_columns = self.d
 

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -215,32 +215,9 @@ cdef class HiddenMarkovModel(GraphModel):
         self.start = start or State(None, name=self.name + "-start")
         self.end = end or State(None, name=self.name + "-end")
 
-        self.d = 0
-        self.n_edges = 0
-        self.n_states = 0
-        self.discrete = 0
-        self.multivariate = 0
-
         # Put start and end in the graph
         self.graph.add_node(self.start)
         self.graph.add_node(self.end)
-
-        self.in_edge_count = NULL
-        self.in_transitions = NULL
-        self.in_transition_pseudocounts = NULL
-        self.in_transition_log_probabilities = NULL
-        self.out_edge_count = NULL
-        self.out_transitions = NULL
-        self.out_transition_pseudocounts = NULL
-        self.out_transition_log_probabilities = NULL
-        self.expected_transitions = NULL
-        self.summaries = 0
-
-        self.tied_state_count = NULL
-        self.tied = NULL
-        self.tied_edge_group_size = NULL
-        self.tied_edges_starts = NULL
-        self.tied_edges_ends = NULL
 
         self.state_names = set()
         self.state_name_mapping = {}

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -226,7 +226,6 @@ cdef class Kmeans(Model):
 
 	def __init__(self, k, init='kmeans++', n_init=10):
 		self.k = k
-		self.d = 0
 		self.n_init = n_init
 		self.centroid_norms = <double*> calloc(self.k, sizeof(double))
 

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -63,7 +63,6 @@ cdef class PriorityQueue(object):
 	cdef dict entries
 
 	def __init__(self):
-		self.n = 0
 		self.pq = []
 		self.entries = {}
 


### PR DESCRIPTION
All C variables are guaranteed to be initialized to 0 before `__cinit__` is called, and all Python variables are guaranteed to be initialized to None before `__init__` is called.

See https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#initialisation-methods-cinit-and-init

I didn't change any behavior, but I did think it was strange that the JointProbabilityTable and ConditionalProbabilityTable constructors does not use their `frozen` parameters. Is that intentional?