### PR TITLE
Out-of-sample prediction using pseudocount

### DIFF
--- a/pomegranate/BayesClassifier.pyx
+++ b/pomegranate/BayesClassifier.pyx
@@ -99,8 +99,8 @@ cdef class BayesClassifier(BayesModel):
 		return nb
 
 	@classmethod
-	def from_samples(cls, distributions, X, y=None, weights=None,
-		inertia=0.0, pseudocount=0.0, stop_threshold=0.1, max_iterations=1e8,
+	def from_samples(cls, distributions, X, y=None, weights=None, inertia=0.0,
+		pseudocount=0.0, alpha=0.0, stop_threshold=0.1, max_iterations=1e8,
 		callbacks=[], return_history=False, keys=None, verbose=False, n_jobs=1, **kwargs):
 		"""Create a Bayes classifier directly from the given dataset.
 
@@ -145,9 +145,14 @@ cdef class BayesClassifier(BayesModel):
 			Inertia used for the training the distributions.
 
 		pseudocount : double, optional
-			A pseudocount to add to the emission of each distribution. This
-			effectively smoothes the states to prevent 0. probability symbols
-			if they don't happen to occur in the data. Default is 0.
+			A pseudocount to smooth the label, but not the distribution (see
+			`alpha`). Smoothing increases the label counts to prevent 0.
+			probability symbols if the label doesn't occur in the data. Default
+			is 0.
+
+		alpha : double, optional
+			A pseudocount to smooth the distributions, but not the label (for
+			which `pseudocount` can be used). Default is 0.
 
 		stop_threshold : double, optional, positive
 			The threshold at which EM will terminate for the improvement of
@@ -219,7 +224,7 @@ cdef class BayesClassifier(BayesModel):
 				labels = numpy.unique(y)
 
 				distributions = [distributions.from_samples(X[y == label], 
-					weights=weights, keys=keys, pseudocount=pseudocount) for label in labels]
+					weights=weights, keys=keys, pseudocount=alpha) for label in labels]
 
 				return cls(distributions)
 
@@ -232,7 +237,7 @@ cdef class BayesClassifier(BayesModel):
 
 		model = cls(distributions)
 		_, history = model.fit(X=data_generator, weights=weights, inertia=inertia, 
-			pseudocount=pseudocount, stop_threshold=stop_threshold, 
+			pseudocount=pseudocount, alpha=alpha, stop_threshold=stop_threshold,
 			max_iterations=max_iterations, callbacks=callbacks, 
 			return_history=True, verbose=verbose, n_jobs=n_jobs)
 

--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -3,8 +3,6 @@
 # NaiveBayes.pyx
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
-from typing import Optional
-
 import numpy
 cimport numpy
 
@@ -95,7 +93,7 @@ cdef class NaiveBayes(BayesModel):
 
 	@classmethod
 	def from_samples(cls, distributions, X, y=None, weights=None,
-		pseudocount=0.0, alpha: Optional[float] = None, stop_threshold=0.1,
+		pseudocount=0.0, alpha=0.0, stop_threshold=0.1,
 		max_iterations=1e8, callbacks=[], return_history=False, verbose=False,
 		n_jobs=1):
 		"""Create a naive Bayes classifier directly from the given dataset.
@@ -138,14 +136,14 @@ cdef class NaiveBayes(BayesModel):
 			Default is None.
 
 		pseudocount : double, optional, positive
-			A pseudocount to add to the emission of each distribution. This
-			effectively smoothes the states to prevent 0. probability symbols
-			if they don't happen to occur in the data. Only effects mixture
-			models defined over discrete distributions. Default is 0.
+			A pseudocount to smooth the label, but not the distribution (see
+			`alpha`). Smoothing increases the label counts to prevent 0.
+			probability symbols if the label doesn't occur in the data. Default
+			is 0.
 
-        alpha : double, optional
-            A pseudocount to smooth the distributions, but not the label (for
-            which `pseudocount` can be used).
+		alpha : double, optional, positive
+			A pseudocount to smooth the distributions, but not the label (for
+			which `pseudocount` can be used).
 
 		stop_threshold : double, optional, positive
 			The threshold at which EM will terminate for the improvement of

--- a/pomegranate/NaiveBayes.pyx
+++ b/pomegranate/NaiveBayes.pyx
@@ -3,6 +3,8 @@
 # NaiveBayes.pyx
 # Contact: Jacob Schreiber ( jmschreiber91@gmail.com )
 
+from typing import Optional
+
 import numpy
 cimport numpy
 
@@ -93,8 +95,9 @@ cdef class NaiveBayes(BayesModel):
 
 	@classmethod
 	def from_samples(cls, distributions, X, y=None, weights=None,
-		pseudocount=0.0, stop_threshold=0.1, max_iterations=1e8,
-		callbacks=[], return_history=False, verbose=False, n_jobs=1):
+		pseudocount=0.0, alpha: Optional[float] = None, stop_threshold=0.1,
+		max_iterations=1e8, callbacks=[], return_history=False, verbose=False,
+		n_jobs=1):
 		"""Create a naive Bayes classifier directly from the given dataset.
 
 		This will initialize the distributions using maximum likelihood estimates
@@ -139,6 +142,10 @@ cdef class NaiveBayes(BayesModel):
 			effectively smoothes the states to prevent 0. probability symbols
 			if they don't happen to occur in the data. Only effects mixture
 			models defined over discrete distributions. Default is 0.
+
+        alpha : double, optional
+            A pseudocount to smooth the distributions, but not the label (for
+            which `pseudocount` can be used).
 
 		stop_threshold : double, optional, positive
 			The threshold at which EM will terminate for the improvement of
@@ -209,7 +216,7 @@ cdef class NaiveBayes(BayesModel):
 				distributions = [distribution.blank() for distribution in distributions]
 
 		model = cls(distributions)
-		_, history = model.fit(data_generator, pseudocount=pseudocount,
+		_, history = model.fit(data_generator, pseudocount=pseudocount, alpha=alpha,
 			stop_threshold=stop_threshold, max_iterations=max_iterations,
 			verbose=verbose, callbacks=callbacks, return_history=True, n_jobs=n_jobs)
 

--- a/pomegranate/distributions/BernoulliDistribution.pyx
+++ b/pomegranate/distributions/BernoulliDistribution.pyx
@@ -75,27 +75,21 @@ cdef class BernoulliDistribution(Distribution):
 			self.summaries[0] += w_sum
 			self.summaries[1] += x_sum
 
-	def from_summaries(self, inertia=0.0, pseudocount: float = 0.0):
+	def from_summaries(self, inertia=0.0, pseudocount=0.0):
 		"""Update the parameters of the distribution from the summaries."""
 
 		if self.summaries[0] < 1e-8 or self.frozen:
 			return
 
-		n: int = 2
+		n = 2
 		p = (self.summaries[1] + pseudocount) / (self.summaries[0] + n * pseudocount)
 		self.p = self.p * inertia + p * (1-inertia)
 		self.logp[0] = _log(1-p)
 		self.logp[1] = _log(p)
 		self.summaries = [0.0, 0.0]
 
-	def fit(
-		self,
-		items,
-		weights=None,
-		inertia: float = 0.0,
-		column_idx: int = 0,
-		pseudocount: float = 0.0,
-	):
+	def fit(self, items, weights=None, inertia=0.0, column_idx=0,
+		pseudocount=0.0):
 		"""
 		Fit parameters of this Distribution by maximizing likelihood of samples.
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -887,9 +887,8 @@ def test_bernoulli_pseudocount():
 	"""
 	a = [0.0, 0.0, 0.0]
 	d = BernoulliDistribution.from_samples(a, pseudocount=1)
-	assert_equal(d.probability(0), 0.8)
-	assert_equal(d.probability(1), 0.2)
-
+	assert_almost_equal(d.probability(0), 0.8)
+	assert_almost_equal(d.probability(1), 0.2)
 
 
 def test_distributions_uniform_kernel_random_sample():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -879,6 +879,19 @@ def test_bernoulli():
 	assert_equal(f.name, "BernoulliDistribution")
 	assert_equal(round(f.parameters[0], 4), 0.1667)
 
+
+@with_setup(setup, teardown)
+def test_bernoulli_pseudocount():
+	"""
+	Test fitting Bernoulli distribution with non-zero pseudocount.
+	"""
+	a = [0.0, 0.0, 0.0]
+	d = BernoulliDistribution.from_samples(a, pseudocount=1)
+	assert_equal(d.probability(0), 0.8)
+	assert_equal(d.probability(1), 0.2)
+
+
+
 def test_distributions_uniform_kernel_random_sample():
 	d = BernoulliDistribution(0.2)
 
@@ -1008,6 +1021,30 @@ def test_independent():
 	assert_almost_equal(d.parameters[0][1].parameters[0], -1.5898, 4)
 	assert_almost_equal(d.parameters[0][1].parameters[1], 0.36673, 4)
 	assert_almost_equal(d.parameters[0][2].parameters[0], 1.27660, 4)
+
+
+
+@with_setup(setup, teardown)
+def test_independent_bernoulli_pseudocount():
+	"""
+	Test fitting Bernoulli distribution with non-zero pseudocount.
+	"""
+	X = numpy.array([
+		[0., 1.],
+		[0., 1.],
+		[0., 0.],
+	])
+	d = IndependentComponentsDistribution.from_samples(
+		X,
+		distributions=BernoulliDistribution,
+		pseudocount=1.,
+	)
+	params = d.parameters[0]
+	assert_equal(params[0].probability(0), 0.8)
+	assert_equal(params[0].probability(1), 0.2)
+	assert_equal(params[1].probability(0), 0.4)
+	assert_equal(params[1].probability(1), 0.6)
+
 
 
 def test_distributions_independent_random_sample():


### PR DESCRIPTION
This pull request should resolve [#835]. 
In detail:
- `pseudocount` support for the `BernoulliDistribution` was implemented.
- The parameter `alpha` was introduced to smooth only the individual distributions but not the label (like in scikit-learn), leaving the current behaviour of `pseudocount` in tact.
- Supporting tests were written.
- No failing tests when running `python3 setup.py test`.
- scikit-learn and pomegranate now give identical predictions:
```Python
from numpy import array, testing
from pomegranate import *
from sklearn.naive_bayes import BernoulliNB

X_train = array([
    [1., 0., 1., 0., 1.],
    [1., 0., 1., 0., 1.],
    [1., 0., 1., 0., 1.],
])
y_train = array([0, 0, 1])
X_test = array([[1., 0., 1., 0., 0.]])

pmodel = NaiveBayes.from_samples(
    BernoulliDistribution, 
    X_train, 
    y_train,
    alpha=1.0,
)
skmodel = BernoulliNB(alpha=1.0).fit(X_train, y_train)

testing.assert_array_almost_equal(
    skmodel.predict_proba(X_test),  
    pmodel.predict_proba(X_test),
)
```