### PR TITLE
Tell Pip to install Cython, NumPy, and SciPy before running setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "numpy", "scipy", "setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        if hasattr(__builtins__, '__NUMPY_SETUP__'):
+            __builtins__.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 


### PR DESCRIPTION
[[845](https://github.com/jmschrei/pomegranate/issues/845)] Installation via pip while missing cython fails

See https://setuptools.readthedocs.io/en/latest/build_meta.html and https://github.com/pypa/setuptools/issues/1317#issuecomment-387702371