### PR TITLE
Free old parent graphs in BayesianNetwork.discrete_greedy

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -2053,6 +2053,7 @@ def discrete_greedy(X, weights, key_count, include_edges, exclude_edges,
 		structure[best_variable] = best_parents
 		seen_variables = tuple(sorted(seen_variables + (best_variable,)))
 		unseen_variables = unseen_variables - set([best_variable])
+		parent_graphs[best_variable] = None #free memory
 
 	return tuple(structure)
 


### PR DESCRIPTION
Recently we've been getting out-of-memory errors despite using the greedy algorithm instead of the exact one. This one-line fix cuts the greedy algorithm's memory usage in half, making it much more practical.

Test program:

```
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:100,:25]
BayesianNetwork().from_samples(X, algorithm='greedy')
```

Before:

```
$ /usr/bin/time -v python test.py 2>&1 | grep 'Maximum resident set'
        Maximum resident set size (kbytes): 8116744
```

After:

```
$ /usr/bin/time -v python test.py 2>&1 | grep 'Maximum resident set'
        Maximum resident set size (kbytes): 4160728
```