### PR TITLE
Import pygraphviz, matplotlib, and cupy only when necessary

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -56,14 +56,6 @@ import random
 
 from collections import defaultdict
 
-try:
-	import tempfile
-	import pygraphviz
-	import matplotlib.pyplot as plt
-	import matplotlib.image
-except ImportError:
-	pygraphviz = None
-
 DEF INF = float("inf")
 DEF NEGINF = float("-inf")
 
@@ -253,6 +245,14 @@ cdef class BayesianNetwork(GraphModel):
 		-------
 		None
 		"""
+
+		try:
+			import tempfile
+			import pygraphviz
+			import matplotlib.pyplot as plt
+			import matplotlib.image
+		except ImportError:
+			pygraphviz = None
 
 		if pygraphviz is not None:
 			G = pygraphviz.AGraph(directed=True)

--- a/pomegranate/FactorGraph.pyx
+++ b/pomegranate/FactorGraph.pyx
@@ -4,14 +4,6 @@
 cimport numpy
 import numpy
 
-try:
-	import pygraphviz
-	import tempfile
-	import matplotlib
-	import matplotlib.pyplot as plt
-except:
-	pygraphviz = None
-
 from .base cimport GraphModel
 from .base cimport State
 
@@ -60,6 +52,14 @@ cdef class FactorGraph(GraphModel):
 		-------
 		None
 		"""
+
+		try:
+			import pygraphviz
+			import tempfile
+			import matplotlib
+			import matplotlib.pyplot as plt
+		except:
+			pygraphviz = None
 
 		if pygraphviz is not None:
 			G = pygraphviz.AGraph(directed=True)

--- a/pomegranate/distributions/MultivariateGaussianDistribution.pyx
+++ b/pomegranate/distributions/MultivariateGaussianDistribution.pyx
@@ -7,11 +7,6 @@
 import numpy
 import scipy
 
-try:
-	import cupy
-except:
-	cupy = object
-
 from libc.stdlib cimport calloc
 from libc.stdlib cimport free
 from libc.string cimport memset
@@ -96,6 +91,8 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 
 		if _is_gpu_enabled():
 			with gil:
+				import cupy
+
 				x = ndarray_wrap_cpointer(X, n*d).reshape(n, d)
 				x1 = cupy.array(x)
 				x2 = cupy.array(self.inv_cov)
@@ -183,6 +180,8 @@ cdef class MultivariateGaussianDistribution(MultivariateDistribution):
 
 		if _is_gpu_enabled():
 			with gil:
+				import cupy
+
 				x_ndarray = ndarray_wrap_cpointer(y, n*d).reshape(n, d)
 				x_gpu = cupy.array(x_ndarray, copy=False)
 				pair_sum_ndarray = cupy.dot(x_gpu.T, x_gpu).get()

--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -49,13 +49,6 @@ cimport numpy
 from joblib import Parallel
 from joblib import delayed
 
-try:
-    import pygraphviz
-    import matplotlib.pyplot as plt
-    import matplotlib.image
-except ImportError:
-    pygraphviz = None
-
 # Define some useful constants
 DEF NEGINF = float("-inf")
 DEF INF = float("inf")
@@ -626,6 +619,12 @@ cdef class HiddenMarkovModel(GraphModel):
         None
         """
 
+        try:
+            import pygraphviz
+            import matplotlib.pyplot as plt
+            import matplotlib.image
+        except ImportError:
+            pygraphviz = None
 
         if pygraphviz is not None:
             G = pygraphviz.AGraph(directed=True)

--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -23,11 +23,6 @@ cimport numpy
 from joblib import Parallel
 from joblib import delayed
 
-try:
-	import cupy
-except:
-	cupy = object
-
 DEF NEGINF = float("-inf")
 DEF INF = float("inf")
 

--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -21,14 +21,6 @@ import numbers
 
 import heapq
 
-try:
-	import tempfile
-	import pygraphviz
-	import matplotlib.pyplot as plt
-	import matplotlib.image
-except ImportError:
-	pygraphviz = None
-
 cdef bint GPU = False
 cdef bint has_cupy = False
 
@@ -391,6 +383,11 @@ cdef double lgamma(double x) nogil:
 	return (x - 0.5) * clog(x) - x + HALF_LOG2_PI + sum / x
 
 def plot_networkx(Q, edge_label=None, filename=None):
+	import tempfile
+	import pygraphviz
+	import matplotlib.pyplot as plt
+	import matplotlib.image
+
 	G = pygraphviz.AGraph(directed=True)
 
 	for state in Q.nodes():

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,10 @@ setup(
         "scipy >= 0.17.0",
         "pyyaml"
     ],
+    extras_require={
+        "Plotting": ["pygraphviz", "matplotlib"],
+        "GPU": ["cupy"],
+    },
     test_suite = 'nose.collector',
     package_data={
         'pomegranate': ['*.pyd', '*.pxd'],


### PR DESCRIPTION
[According to Python's documentation](https://docs.python.org/3/reference/import.html#importsystem), import statements only import the named module once even if they are in a function that is called over and over. So moving the pygraphviz and matplotlib imports into the functions that use them should not cause any negative side effects, and it saves about 40 megabytes of RAM when they are not being used. 40 megabytes may not seem like much, but when you have 32 parallel processes all training Bayes nets, it adds up fast ;-)

Test program:

```
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:100,:5]
BayesianNetwork().from_samples(X, algorithm='greedy')
```

Before:

```
$ /usr/bin/time -v python test.py 2>&1 | grep 'Maximum resident set'
        Maximum resident set size (kbytes): 156624
```

After:

```
$ /usr/bin/time -v python test.py 2>&1 | grep 'Maximum resident set'
	Maximum resident set size (kbytes): 116044
```