### PR TITLE
Remove redundant definition of nan from BayesianNetwork.pyx

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -47,12 +47,7 @@ from .io import DataGenerator
 #from libcpp.list cimport list as cpplist
 from libc.math cimport exp as cexp
 
-import cython
 cimport cython
-import numpy
-cimport numpy
-import random
-
 
 from collections import defaultdict
 

--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -68,7 +68,6 @@ DEF INF = float("inf")
 DEF NEGINF = float("-inf")
 
 nan = numpy.nan
-nan = numpy.nan
 
 def _check_input(X, model):
 	"""Ensure that the keys in the sample are valid keys.


### PR DESCRIPTION
The extra line was added by commit 8ffca80b304d24f1333fd95e75f96935e6ff4993.