### PR TITLE
Improvements to max_parents

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -1624,10 +1624,10 @@ cdef class ParentGraph(object):
 		self.key_count = key_count
 		self.i = i
 		self.pseudocount = pseudocount
-		self.max_parents = max_parents
 		self.values = {}
 		self.n = X.shape[0]
 		self.d = X.shape[1]
+		self.max_parents = self.d - 1 if max_parents < 0 else max_parents
 		self.include_parents = set([parent for parent, child in include_edges
 			if child == i])
 		self.exclude_parents = set([parent for parent, child in exclude_edges


### PR DESCRIPTION
This dramatically reduces both the running time and the memory consumption when training Bayes nets. The `from_samples` function sets `max_parents` to `int(_log2(2*w_sum / _log2(w_sum)))` by default, so the improvement can be seen even when `max_parents` is not specified.

Test program:

```
from pomegranate import BayesianNetwork
from sklearn.datasets import load_digits

X = load_digits(return_X_y=True)[0][:100,:25]
BayesianNetwork().from_samples(X)
```

Before:

```
$ /usr/bin/time -v python3 test.py
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:56.42
        Maximum resident set size (kbytes): 4195444
```

After:

```
$ /usr/bin/time -v python3 test.py
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.00
        Maximum resident set size (kbytes): 129944
```

The code could be simplified and the performance further improved by changing `reversed(list(it.combinations(value, max_parents)))` to just `it.combinations(value, max_parents)`, but that currently breaks `test_constrained_parents_structure_learning` because it changes the parent subset that is returned when two parent subsets have equal scores.
