### PR TITLE
Remove reference to numpy.float from _check_nan

### DIFF
--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -473,7 +473,7 @@ def _check_nan(X):
 	"""Checks to see if a value is nan, either as a float or a string."""
 	if isinstance(X, (str, unicode, numpy.string_)):
 		return X == 'nan'
-	if isinstance(X, (float, numpy.float, numpy.float32, numpy.float64)):
+	if isinstance(X, (float, numpy.float32, numpy.float64)):
 		return isnan(X)
 	return X is None
 


### PR DESCRIPTION
`numpy.float` is just a reference to the built-in `float`:

```
$ python3 -c 'import numpy; print(numpy.float is float)'
True
```

I missed this one in pull request #869.