### PR TITLE
Use a typed index in HiddenMarkovModel.bake

### DIFF
--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -701,6 +701,8 @@ cdef class HiddenMarkovModel(GraphModel):
         None
         """
 
+        cdef int i
+
         self.free_bake_buffers()
 
         in_edge_count = numpy.zeros(len(self.graph.nodes()),


### PR DESCRIPTION
This fixes the compilation warning `pomegranate/hmm.pyx:913:31: Index should be typed for more efficient access`