### PR TITLE
Kmeans - only do one init if init method is first-k

### DIFF
--- a/pomegranate/kmeans.pyx
+++ b/pomegranate/kmeans.pyx
@@ -221,7 +221,10 @@ cdef class Kmeans(Model):
 
 	def __init__(self, k, init='kmeans++', n_init=10):
 		self.k = k
-		self.n_init = n_init
+		if init != 'first-k':
+			self.n_init = n_init
+		else:
+			self.n_init = 1
 		self.centroid_norms = <double*> calloc(self.k, sizeof(double))
 
 		if isinstance(init, (list, numpy.ndarray)):


### PR DESCRIPTION
there doesn't seem to be much point in doing multiple different initialisations if using the same first-k starting points each time.