### PR TITLE
Fix for #947: Be more flexible in ICD keymaps

### DIFF
--- a/pomegranate/utils.pyx
+++ b/pomegranate/utils.pyx
@@ -440,9 +440,15 @@ def _check_input(X, keymap=None):
 					X_ndarray[i] = keymap[0][X[i]]
 				X_ndarray = X_ndarray.reshape(-1, 1)
 			else:
-				for i in range(X.shape[0]):
-					for j in range(X.shape[1]):
-						X_ndarray[i, j] = keymap[j][X[i, j]]
+				for j in range(X.shape[1]):
+					if len(keymap[j]) == 0: 
+						# No keymap for non-discrete distributions
+						# convert the whole column to floats;
+						X_ndarray[:, j] = X[:, j].astype(numpy.float64)
+					else:
+						# else convert entries via the keymap
+						for i in range(X.shape[0]):
+							X_ndarray[i, j] = keymap[j][X[i, j]]
 
 
 	return X_ndarray

--- a/tests/test_gmm.py
+++ b/tests/test_gmm.py
@@ -90,6 +90,18 @@ def setup_multivariate_discrete():
 	gmm = GeneralMixtureModel([d1, d2], weights=np.array([0.4,0.6]))
 
 
+def setup_multivariate_mixed_discrete_other():
+	d1 = IndependentComponentsDistribution([PoissonDistribution(4.0),
+	                                        DiscreteDistribution({'A':0.5, 'B':0.5}), 
+	                                        DiscreteDistribution({'0':0.2, '1':0.2, '2':0.2, '3':0.4})])
+	d2 = IndependentComponentsDistribution([PoissonDistribution(1.0),
+	                                        DiscreteDistribution({'A':0.1, 'B':0.9}), 
+	                                        DiscreteDistribution({'0':0.1, '1':0.6, '2':0.1, '3':0.2})])
+
+
+	global gmm
+	gmm = GeneralMixtureModel([d1, d2], weights=np.array([0.4,0.6]))
+
 def teardown():
 	"""
 	Teardown the model, so delete it.
@@ -1231,6 +1243,22 @@ def test_gmm_multivariate_mixed_random_sample():
 
 	assert_array_almost_equal(gmm.sample(3, random_state=5), x)
 	assert_raises(AssertionError, assert_array_almost_equal, gmm.sample(3), x)
+
+
+@with_setup(setup_multivariate_mixed_discrete_other)
+def test_gmm_multivariate_mixed_discrete_other_fit():
+	x = numpy.array(
+		[
+			[0, 'A', '0'],
+			[5, 'A', '1'],
+			[4, 'A', '3'],
+			[5, 'B', '0']
+		], 
+		dtype=object
+	)
+	gmm.fit(x)
+	assert_array_almost_equal(gmm.weights, numpy.array([-0.28544206, -1.39304465]))
+
 
 def test_io_log_probability():
 	X = numpy.random.randn(100, 5) + 0.5


### PR DESCRIPTION
If an ICD has a mixture of ``DiscreteDistribution`` and other distribution types then the discrete distributions have a keymap for encoding, and the other distributions get an empty keymap (based on initialization of keymaps per component as empty dicts). When data is then passed in the check_array uses keymaps to encode the data, but fails for the non-``DiscreteDistribution`` columns since they have empty keymaps. If the column has data for a non-``DiscreteDistribution`` it is numeric and doesn't require encoding -- the entire column can simply be cast to ``float64``. This PR makes a minimal alteration to work by columns first, and, in the case of an empty keymap attempts to cast the entire column to ``float64``. This resolves the issues seen in #947 . A test of this is also added.

Note: running the test suite locally I have a failure for ``tests.test_naive_bayes.test_discrete_distribution``, however this test also fails on the current master, and does not seem related to these changes. All other tests passed.