### PR TITLE
Temporary fix for GH Actions and Py3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,5 +47,5 @@ jobs:
         
     - name: Test with pytest
       run: |
-      pip install -e .
-      pytest tests/
+        pip install -e .
+        pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,4 +41,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         
     - name: Test with pytest
-      run: python setup.py test
+      run: pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,6 @@ jobs:
         pip install flake8 pytest
         conda install --file requirements.txt
         pip install -r dev-requirements.txt
-        python setup.py install
         
     - name: Lint with flake8
       run: |
@@ -47,4 +46,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         
     - name: Test with pytest
-      run: pytest tests/
+      run: |
+      pip install -e .
+      pytest tests/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 wheel
 pandas
 cython >= 0.22.1
+nose
 pytest
 numpy >= 1.20.0
 scipy >= 0.17.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 wheel
 pandas
 cython >= 0.22.1
-nose
+pytest
 numpy >= 1.20.0
 scipy >= 0.17.0
 sphinx >= 4.2.0


### PR DESCRIPTION
Hopefully this works on the main repo and not just my fork.
I think the big issue is actually `nose` which is no longer supported in Python 3.10

The other thing to note is that `cibuildwheel` can actually integrate in testing, so it might make more sense to use that to both test and build for release so that you are less likely to encounter some problem that was not checked in the CI. 