### PR TITLE
Better exception handling

### DIFF
--- a/pomegranate/hmm.pyx
+++ b/pomegranate/hmm.pyx
@@ -1330,7 +1330,7 @@ cdef class HiddenMarkovModel(GraphModel):
 
 		return numpy.array(emissions)
 
-	cpdef double log_probability(self, sequence, check_input=True):
+	cpdef double log_probability(self, sequence, check_input=True) except *:
 		"""Calculate the log probability of a single sequence.
 
 		If a path is provided, calculate the log probability of that sequence
@@ -2968,7 +2968,7 @@ cdef class HiddenMarkovModel(GraphModel):
 		free(b)
 		return log_sequence_probability * weight[0]
 
-	cpdef double _viterbi_summarize(self, numpy.ndarray sequence_ndarray, double weight):
+	cpdef double _viterbi_summarize(self, numpy.ndarray sequence_ndarray, double weight) except *:
 		"""Python wrapper for the summarization step.
 
 		This is done to ensure compatibility with joblib's multithreading
@@ -3003,7 +3003,7 @@ cdef class HiddenMarkovModel(GraphModel):
 		return log_probability * weight
 
 	cpdef double _labeled_summarize(self, numpy.ndarray sequence_ndarray,
-		numpy.ndarray label_ndarray, double weight):
+		numpy.ndarray label_ndarray, double weight) except *:
 		"""Python wrapper for the summarization step.
 
 		This is done to ensure compatibility with joblib's multithreading


### PR DESCRIPTION
Added exception handling to `HiddenMarkovModel.log_probability` so Python exceptions can be caught and are not just logged and ignored.

This problem is mentioned here https://github.com/jmschrei/pomegranate/issues/549 or https://github.com/jmschrei/pomegranate/issues/937

I am not sure how other cpdef functions which return Python objects and not native types need to be handled.