### PR TITLE
[#953]: Fixed BayesModel unpickling bug.

### DIFF
--- a/pomegranate/bayes.pyx
+++ b/pomegranate/bayes.pyx
@@ -145,8 +145,7 @@ cdef class BayesModel(Model):
 
     def __reduce__(self):
         return self.__class__, (self.distributions.tolist(),
-                                numpy.exp(self.weights),
-                                self.n)
+                                numpy.exp(self.weights))
 
     def sample(self, n=1, random_state=None):
         """Generate a sample from the model.

--- a/tests/test_bayes_classifier.py
+++ b/tests/test_bayes_classifier.py
@@ -1,6 +1,7 @@
 from __future__ import (division)
 
 from pomegranate import *
+from pomegranate.bayes import BayesModel
 from pomegranate.io import DataGenerator
 from pomegranate.io import DataFrameGenerator
 
@@ -136,6 +137,21 @@ def setup_multivariate():
 def teardown():
 	pass
 
+def test_unpickle_bayes_model():
+	"""Test that `BayesModel` can be pickled and unpickled."""
+	dists = [BernoulliDistribution(0.2), BernoulliDistribution(0.3)]
+	model = BayesModel(distributions=dists)
+	unpickled_model = pickle.loads(pickle.dumps(model))
+	np.testing.assert_almost_equal(model.weights, unpickled_model.weights)
+	# Check weights of individual distributions.
+	np.testing.assert_almost_equal(
+		model.distributions[0].parameters,
+		unpickled_model.distributions[0].parameters,
+	)
+	np.testing.assert_almost_equal(
+		model.distributions[1].parameters,
+		unpickled_model.distributions[1].parameters,
+	)
 
 @with_setup(setup_multivariate_gaussian, teardown)
 def test_bc_multivariate_gaussian_initialization():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -703,6 +703,12 @@ def test_distributions_poisson_random_sample():
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
 	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
 
+def test_beta():
+	"""Test pickling of beta distribution."""
+	d = BetaDistribution(2, 3)
+	e = pickle.loads(pickle.dumps(d))
+	assert_equal(e.name, "BetaDistribution")
+	assert_equal(e.parameters, [2, 3])
 
 def test_distributions_beta_random_sample():
 	d = BetaDistribution(1, 1)


### PR DESCRIPTION
The `NaiveBayes` class can not be unpickled because the `__reduce__` method doesn't match the `__init__` constructor, as described in issue [#953](https://github.com/jmschrei/pomegranate/issues/953). This pull request fixes this bug, with accompanying unit test. In addition, it includes a `BetaDistribution` pickling unit test (which was missing).