### PR TITLE
Threading -> multiprocessing for Bayesian Network

### DIFF
--- a/pomegranate/BayesianNetwork.pyx
+++ b/pomegranate/BayesianNetwork.pyx
@@ -443,10 +443,19 @@ cdef class BayesianNetwork(GraphModel):
 			with open(fn, 'w') as outfile:
 				outfile.write(self.to_json())
 
-			with Parallel(n_jobs=n_jobs, backend='threading') as parallel:
+			with Parallel(n_jobs=n_jobs, backend='multiprocessing') as parallel:
 				f = delayed(parallelize_function)
-				logp_array = parallel(f(batch[0], BayesianNetwork, 'log_probability',
-					fn) for batch in data_generator.batches())
+				logp_array = parallel(
+					f(
+						batch[0],
+						BayesianNetwork,
+						'log_probability',
+						fn,
+						check_input=check_input,
+						n_jobs=1
+					)
+					for batch in data_generator.batches()
+				)
 
 			os.remove(fn)
 			return numpy.concatenate(logp_array)
@@ -610,10 +619,21 @@ cdef class BayesianNetwork(GraphModel):
 			with open(fn, 'w') as outfile:
 				outfile.write(self.to_json())
 
-			with Parallel(n_jobs=n_jobs, backend='threading') as parallel:
+
+			with Parallel(n_jobs=n_jobs, backend='multiprocessing') as parallel:
 				f = delayed(parallelize_function)
-				logp_array = parallel(f(batch[0], BayesianNetwork, 'predict_proba',
-					fn) for batch in data_generator.batches())
+				logp_array = parallel(
+					f(
+						batch[0],
+						self.__class__,
+						'predict_proba',
+						fn,
+						max_iterations=max_iterations,
+						check_input=check_input,
+						n_jobs=1
+					)
+					for batch in data_generator.batches()
+				)
 
 			os.remove(fn)
 			return numpy.concatenate(logp_array)


### PR DESCRIPTION
For issue #962.
Switch parallelism backend to multiprocessing, and fix the passing of kwargs for `log_probability()` and `predict_proba()`.

The following has succeeded:
```bash
python -m build
python setup.py test
```

Test environment:
> EC2 Amazon Linux (m5.2xlarge)
Python 3.8.8 (Cython)
pomegranate 0.14.8

Performance check (5,236 test instances):

`m` = `max_iterations`
`n` = `n_jobs`

| m\n | 1 | 2 | 4 |
| --- | --- | --- | --- | 
| 1 | 125s | 75s | 60s |
| 5 | 869s | 461s | 241s |