### PR TITLE
Switch to pytest from unsupported nose

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,4 +47,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         
     - name: Test with pytest
-      run: python setup.py test
+      run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	python setup.py install
 
 test:
-	python setup.py test
+	python3 -m pytest
 
 bigclean: nbclean
 	rm -rf build
@@ -64,9 +64,9 @@ py2uninstall:
 	rm -rf ~/miniconda2/envs/$(PY2_ENV)/lib/python2.7/site-packages/$(PACKAGE_NAME)*
 
 py3test:
-	(source activate $(PY3_ENV) ; python setup.py test )
+	(source activate $(PY3_ENV) ; python3 -m pytest )
 py2test:
-	(source activate $(PY2_ENV) ; python setup.py test )
+	(source activate $(PY2_ENV) ; python -m pytest )
 
 ## Notebook tests
 PYTHON_NOTEBOOKS= examples/*.ipynb tutorials/*.ipynb benchmarks/*.ipynb

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ pomegranate requires:
 - joblib
 ```
 
-To run the tests, you also must have `nose` installed.
+To run the tests, you also must have `pytest` installed.
 
 ## Contributing
 
-If you would like to contribute a feature then fork the master branch (fork the release if you are fixing a bug). Be sure to run the tests before changing any code. You'll need to have [nosetests](https://github.com/nose-devs/nose) installed. The following command will run all the tests:
+If you would like to contribute a feature then fork the master branch (fork the release if you are fixing a bug). Be sure to run the tests before changing any code. You'll need to have [pytest](https://pytest.org) installed. The following command will run all the tests:
 
 ```
-python setup.py test
+python3 -m pytest
 ```
 
 Let us know what you want to do just in case we're already working on an implementation of something similar. This way we can avoid any needless duplication of effort. Also, please don't forget to add tests for any new functions.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 wheel
 pandas
 cython >= 0.22.1
-nose
+pytest
 numpy >= 1.20.0
 scipy >= 0.17.0
 sphinx >= 4.2.0

--- a/rebuildconda
+++ b/rebuildconda
@@ -24,7 +24,7 @@ conda config --add channels conda-forge
 conda config --get channels
 # wip add packages that should be in base:
 base_packages=" cython "
-pom_packages=" scipy joblib nose networkx=1.11 "
+pom_packages=" scipy joblib pytest networkx=1.11 "
 pom_nbtest_packages=" scikit-learn pandas seaborn pygraphviz pillow xlrd memory_profiler jupyter jupyter_contrib_nbextensions jupyter_nbextensions_configurator "
 echo "Don't forget to also install gnuplot-py since it isn't yet in the tools Makefile"
 conda install --yes $base_packages $pom_packages $pom_nbtest_packages

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ setup(
         "Plotting": ["pygraphviz", "matplotlib"],
         "GPU": ["cupy"],
     },
-    test_suite = 'nose.collector',
     package_data={
         'pomegranate': ['*.pyd', '*.pxd'],
         'pomegranate/distributions': ['*.pyd', '*.pxd'],

--- a/tests/assert_tools.py
+++ b/tests/assert_tools.py
@@ -1,0 +1,141 @@
+"""
+Copyright 2016 Oliver Schoenborn. BSD 3-Clause license (see __license__ at bottom of this file for details).
+
+This module is part of the nose2pytest distribution.
+
+This module's assert_ functions provide drop-in replacements for nose.tools.assert_ functions (many of which are
+pep-8-ized extractions from Python's unittest.case.TestCase methods). As such, it can be imported in a test
+suite run by pytest, to replace the nose imports with functions that rely on pytest's assertion
+introspection for error reporting.  When combined with running nose2pytest.py on your test suite, this
+module may be sufficient to decrease your test suite's third-party dependencies by 1.
+"""
+
+import pytest
+import unittest
+
+
+__all__ = [
+    'assert_almost_equal',
+    'assert_not_almost_equal',
+    'assert_dict_contains_subset',
+
+    'assert_raises_regex',
+    'assert_raises_regexp',
+    'assert_regexp_matches',
+    'assert_warns_regex',
+]
+
+
+def assert_almost_equal(a, b, places=7, msg=None):
+    """
+    Fail if the two objects are unequal as determined by their
+    difference rounded to the given number of decimal places
+    and comparing to zero.
+
+    Note that decimal places (from zero) are usually not the same
+    as significant digits (measured from the most signficant digit).
+
+    See the builtin round() function for places parameter.
+    """
+    if msg is None:
+        assert round(abs(b - a), places) == 0
+    else:
+        assert round(abs(b - a), places) == 0, msg
+
+
+def assert_not_almost_equal(a, b, places=7, msg=None):
+    """
+    Fail if the two objects are equal as determined by their
+    difference rounded to the given number of decimal places
+    and comparing to zero.
+
+    Note that decimal places (from zero) are usually not the same
+    as significant digits (measured from the most signficant digit).
+
+    See the builtin round() function for places parameter.
+    """
+    if msg is None:
+        assert round(abs(b - a), places) != 0
+    else:
+        assert round(abs(b - a), places) != 0, msg
+
+
+def assert_dict_contains_subset(subset, dictionary, msg=None):
+    """
+    Checks whether dictionary is a superset of subset. If not, the assertion message will have useful details,
+    unless msg is given, then msg is output.
+    """
+    dictionary = dictionary
+    missing_keys = sorted(list(set(subset.keys()) - set(dictionary.keys())))
+    mismatch_vals = {k: (subset[k], dictionary[k]) for k in subset if k in dictionary and subset[k] != dictionary[k]}
+    if msg is None:
+        assert missing_keys == [], 'Missing keys = {}'.format(missing_keys)
+        assert mismatch_vals == {}, 'Mismatched values (s, d) = {}'.format(mismatch_vals)
+    else:
+        assert missing_keys == [], msg
+        assert mismatch_vals == {}, msg
+
+
+# make other unittest.TestCase methods available as-is as functions; trick taken from Nose
+
+class _Dummy(unittest.TestCase):
+    def do_nothing(self):
+        pass
+
+_t = _Dummy('do_nothing')
+
+assert_raises_regex=_t.assertRaisesRegex,
+assert_raises_regexp=_t.assertRaisesRegex,
+assert_regexp_matches=_t.assertRegex,
+assert_warns_regex=_t.assertWarnsRegex,
+
+del _Dummy
+del _t
+
+
+# pytest integration: add all assert_ function to the pytest package namespace
+
+# Use similar trick as Nose to bring in bound methods from unittest.TestCase as free functions:
+
+
+def _supported_nose_name(name):
+    return name.startswith('assert_') or name in ('ok_', 'eq_')
+
+
+def pytest_configure():
+    for name, obj in globals().items():
+        if _supported_nose_name(name):
+            setattr(pytest, name, obj)
+
+
+# licensing
+
+__license__ = """
+    Copyright (c) 2016, Oliver Schoenborn
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of nose2pytest nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""

--- a/tests/test_custom_distributions.py
+++ b/tests/test_custom_distributions.py
@@ -1,20 +1,12 @@
 from __future__ import (division)
 
 from pomegranate import *
-from nose.tools import with_setup
-from nose.tools import assert_almost_equal
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
-from nose.tools import assert_less_equal
-from nose.tools import assert_raises
-from nose.tools import assert_true
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
 
 import numpy
 import scipy.stats
-
-nan = numpy.nan
+import pytest
 
 class NormalDistribution2():
 	def __init__(self, mu, std):
@@ -116,10 +108,9 @@ def build_model(d1, d2):
 	model.bake()
 	return model
 
-def setup_normal_hmm():
-	global model1
-	global model2
 
+@pytest.fixture
+def normal_hmm():
 	d1 = NormalDistribution(0, 1)
 	d2 = NormalDistribution(1, 1)
 	model1 = build_model(d1, d2)
@@ -127,24 +118,21 @@ def setup_normal_hmm():
 	d3 = NormalDistribution2(0, 1)
 	d4 = NormalDistribution2(1, 1)
 	model2 = build_model(d3, d4)
+	return model1, model2
 
-def setup_mgd_hmm():
-	global model1
-	global model2
-
+@pytest.fixture
+def mgd_hmm():
 	d1 = MultivariateGaussianDistribution(numpy.zeros(3), numpy.eye(3))
 	d2 = MultivariateGaussianDistribution(numpy.ones(3), numpy.eye(3))
 	model1 = build_model(d1, d2)
-	
 
 	d3 = MultivariateGaussianDistribution2(numpy.zeros(3), numpy.eye(3))
 	d4 = MultivariateGaussianDistribution2(numpy.ones(3), numpy.eye(3))
 	model2 = build_model(d3, d4)
+	return model1, model2
 
-def setup_icd_hmm():
-	global model1
-	global model2
-
+@pytest.fixture
+def icd_hmm():
 	d1 = IndependentComponentsDistribution([NormalDistribution(0, 1) for _ in range(5)])
 	d2 = IndependentComponentsDistribution([NormalDistribution(1, 1) for _ in range(5)])
 	model1 = build_model(d1, d2)
@@ -152,15 +140,16 @@ def setup_icd_hmm():
 	d3 = IndependentComponentsDistribution([NormalDistribution2(0, 1) for _ in range(5)])
 	d4 = IndependentComponentsDistribution([NormalDistribution2(1, 1) for _ in range(5)])
 	model2 = build_model(d3, d4)
+	return model1, model2
 
 def test_custom_normal_gmm_init():
 	d1 = NormalDistribution2(0, 1)
 	d2 = NormalDistribution2(1, 1)
 	model = GeneralMixtureModel([d1, d2])
 
-	assert_equal(d1.d, 1)
-	assert_equal(d2.d, 1)
-	assert_equal(model.d, 1)
+	assert d1.d == 1
+	assert d2.d == 1
+	assert model.d == 1
 
 def test_custom_normal_gmm_logp():
 	X = numpy.random.normal(0.5, 1, size=(20, 1))
@@ -247,9 +236,9 @@ def test_custom_mgd_gmm_init():
 	d2 = MultivariateGaussianDistribution2(numpy.ones(3), numpy.eye(3))
 	model = GeneralMixtureModel([d1, d2])
 
-	assert_equal(d1.d, 3)
-	assert_equal(d2.d, 3)
-	assert_equal(model.d, 3)
+	assert d1.d == 3
+	assert d2.d == 3
+	assert model.d == 3
 
 def test_custom_mgd_gmm_logp():
 	X = numpy.random.normal(0.5, 1, size=(20,3))
@@ -337,9 +326,9 @@ def test_custom_icd_gmm_init():
 	d2 = IndependentComponentsDistribution([NormalDistribution2(1, 1) for _ in range(5)])
 	model = GeneralMixtureModel([d1, d2])
 
-	assert_equal(d1.d, 5)
-	assert_equal(d2.d, 5)
-	assert_equal(model.d, 5)
+	assert d1.d == 5
+	assert d2.d == 5
+	assert model.d == 5
 
 def test_custom_icd_gmm_logp():
 	X = numpy.random.normal(0.5, 1, size=(20,5))
@@ -426,9 +415,9 @@ def test_custom_normal_nb_init():
 	d2 = NormalDistribution2(1, 1)
 	model = NaiveBayes([d1, d2])
 
-	assert_equal(d1.d, 1)
-	assert_equal(d2.d, 1)
-	assert_equal(model.d, 1)
+	assert d1.d == 1
+	assert d2.d == 1
+	assert model.d == 1
 
 def test_custom_normal_nb_logp():
 	X = numpy.random.normal(0.5, 1, size=(20, 1))
@@ -519,9 +508,9 @@ def test_custom_mgd_bc_init():
 	d2 = MultivariateGaussianDistribution2(numpy.ones(3), numpy.eye(3))
 	model = BayesClassifier([d1, d2])
 
-	assert_equal(d1.d, 3)
-	assert_equal(d2.d, 3)
-	assert_equal(model.d, 3)
+	assert d1.d == 3
+	assert d2.d == 3
+	assert model.d == 3
 
 def test_custom_mgd_bc_logp():
 	X = numpy.random.normal(0.5, 1, size=(20,3))
@@ -612,9 +601,9 @@ def test_custom_icd_nb_init():
 	d2 = IndependentComponentsDistribution([NormalDistribution2(1, 1) for _ in range(5)])
 	model = NaiveBayes([d1, d2])
 
-	assert_equal(d1.d, 5)
-	assert_equal(d2.d, 5)
-	assert_equal(model.d, 5)
+	assert d1.d == 5
+	assert d2.d == 5
+	assert model.d == 5
 
 def test_custom_icd_nb_logp():
 	X = numpy.random.normal(0.5, 1, size=(20,5))
@@ -700,33 +689,33 @@ def test_custom_icd_nb_from_samples():
 
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_init():
-	assert_equal(model1.d, 1)
-	assert_equal(model2.d, 1)
+def test_custom_normal_hmm_init(normal_hmm):
+	model1, model2 = normal_hmm
+	assert model1.d == 1
+	assert model2.d == 1
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_logp():
+def test_custom_normal_hmm_logp(normal_hmm):
+	model1, model2 = normal_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 1))
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_predict():
+def test_custom_normal_hmm_predict(normal_hmm):
+	model1, model2 = normal_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 1))
 	assert_array_equal(model1.predict(X), model2.predict(X))
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_predict_proba():
+def test_custom_normal_hmm_predict_proba(normal_hmm):
+	model1, model2 = normal_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 1))
 	assert_array_almost_equal(model1.predict_proba(X), model2.predict_proba(X))
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_predict_log_proba():
+def test_custom_normal_hmm_predict_log_proba(normal_hmm):
+	model1, model2 = normal_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 1))
 	assert_array_almost_equal(model1.predict_log_proba(X), model2.predict_log_proba(X))
 
-@with_setup(setup_normal_hmm)
-def test_custom_normal_hmm_fit():
+def test_custom_normal_hmm_fit(normal_hmm):
+	model1, model2 = normal_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 1))
 
 	model1.fit(X, max_iterations=5)
@@ -743,33 +732,33 @@ def test_custom_normal_hmm_from_samples():
 
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_init():
-	assert_equal(model1.d, 3)
-	assert_equal(model2.d, 3)
+def test_custom_mgd_hmm_init(mgd_hmm):
+	model1, model2 = mgd_hmm
+	assert model1.d == 3
+	assert model2.d == 3
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_logp():
+def test_custom_mgd_hmm_logp(mgd_hmm):
+	model1, model2 = mgd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 3))
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_predict():
+def test_custom_mgd_hmm_predict(mgd_hmm):
+	model1, model2 = mgd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 3))
 	assert_array_equal(model1.predict(X), model2.predict(X))
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_predict_proba():
+def test_custom_mgd_hmm_predict_proba(mgd_hmm):
+	model1, model2 = mgd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 3))
 	assert_array_almost_equal(model1.predict_proba(X), model2.predict_proba(X))
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_predict_log_proba():
+def test_custom_mgd_hmm_predict_log_proba(mgd_hmm):
+	model1, model2 = mgd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 3))
 	assert_array_almost_equal(model1.predict_log_proba(X), model2.predict_log_proba(X))
 
-@with_setup(setup_mgd_hmm)
-def test_custom_mgd_hmm_fit():
+def test_custom_mgd_hmm_fit(mgd_hmm):
+	model1, model2 = mgd_hmm
 	X = numpy.random.normal(0, 0.1, size=(2, 50, 3))
 	X[:, ::2] += 1
 
@@ -787,33 +776,33 @@ def test_custom_mgd_hmm_from_samples():
 
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_init():
-	assert_equal(model1.d, 5)
-	assert_equal(model2.d, 5)
+def test_custom_icd_hmm_init(icd_hmm):
+	model1, model2 = icd_hmm
+	assert model1.d == 5
+	assert model2.d == 5
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_logp():
+def test_custom_icd_hmm_logp(icd_hmm):
+	model1, model2 = icd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 5))
 	assert_array_almost_equal(model1.log_probability(X), model2.log_probability(X))
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_predict():
+def test_custom_icd_hmm_predict(icd_hmm):
+	model1, model2 = icd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 5))
 	assert_array_almost_equal(model1.predict(X), model2.predict(X))
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_predict_proba():
+def test_custom_icd_hmm_predict_proba(icd_hmm):
+	model1, model2 = icd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 5))
 	assert_array_almost_equal(model1.predict_proba(X), model2.predict_proba(X))
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_predict_log_proba():
+def test_custom_icd_hmm_predict_log_proba(icd_hmm):
+	model1, model2 = icd_hmm
 	X = numpy.random.normal(0.5, 1, size=(5, 20, 5))
 	assert_array_almost_equal(model1.predict_log_proba(X), model2.predict_log_proba(X))
 
-@with_setup(setup_icd_hmm)
-def test_custom_icd_hmm_fit():
+def test_custom_icd_hmm_fit(icd_hmm):
+	model1, model2 = icd_hmm
 	X = numpy.random.normal(0.5, 1, size=(3, 20, 5))
 
 	model1.fit(X, max_iterations=5)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -18,28 +18,15 @@ from pomegranate import (Distribution,
 						 BernoulliDistribution,
 						 from_json)
 
-from nose.tools import with_setup
-from nose.tools import assert_almost_equal
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
-from nose.tools import assert_less_equal
-from nose.tools import assert_true
-from nose.tools import assert_raises
+from .assert_tools import assert_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
 import pickle
 import numpy
+import pytest
 
 nan = numpy.nan
 inf = float("inf")
-
-def setup():
-	pass
-
-
-def teardown():
-	pass
-
 
 def discrete_equality(x, y, z=8):
 	'''
@@ -56,22 +43,25 @@ def discrete_equality(x, y, z=8):
 
 def test_distributions_uniform_initialization():
 	d = UniformDistribution(0, 10)
-	assert_equal(d.name, "UniformDistribution")
+	assert d.name == "UniformDistribution"
 	assert_array_equal(d.parameters, [0, 10])
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
 
 def test_distributions_uniform_blank():
 	d = UniformDistribution.blank()
-	assert_equal(d.name, "UniformDistribution")
+	assert d.name == "UniformDistribution"
 	assert_array_equal(d.parameters, [0, 0])
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
 
 def test_distributions_uniform_initialization_error():
-	assert_raises(TypeError, UniformDistribution, 0)
-	assert_raises(TypeError, UniformDistribution, [0, 10])
-	assert_raises(TypeError, UniformDistribution, 0, 10, 4, 7, 3)
+	with pytest.raises(TypeError):
+		UniformDistribution(0)
+	with pytest.raises(TypeError):
+		UniformDistribution([0, 10])
+	with pytest.raises(TypeError):
+		UniformDistribution(0, 10, 4, 7, 3)
 
 
 def test_distributions_uniform_log_probability():
@@ -79,26 +69,26 @@ def test_distributions_uniform_log_probability():
 	e = UniformDistribution(0., 10.)
 
 	assert_almost_equal(d.log_probability(5), -2.302585092)
-	assert_equal(d.log_probability(5), e.log_probability(5))
-	assert_equal(d.log_probability(5), d.log_probability(5.))
+	assert d.log_probability(5) == e.log_probability(5)
+	assert d.log_probability(5) == d.log_probability(5.)
 
 	assert_almost_equal(d.log_probability(0), -2.302585092)
-	assert_equal(d.log_probability(0), e.log_probability(0.))
+	assert d.log_probability(0) == e.log_probability(0.)
 
-	assert_equal(d.log_probability(-1), -inf)
-	assert_equal(d.log_probability(11), -inf)
+	assert d.log_probability(-1) == -inf
+	assert d.log_probability(11) == -inf
 
 
 def test_distributions_uniform_nan_log_probability():
 	d = UniformDistribution(0, 10)
 
-	assert_equal(d.log_probability(nan), 0)
+	assert d.log_probability(nan) == 0
 	assert_array_almost_equal(d.log_probability([nan, 5]), [0, -2.302585092])
 
 
 def test_distributions_uniform_underflow_log_probability():
 	d = UniformDistribution(0, 10)
-	assert_equal(d.log_probability(1e100), float("-inf"))
+	assert d.log_probability(1e100) == float("-inf")
 
 
 def test_distributions_uniform_probability():
@@ -106,20 +96,20 @@ def test_distributions_uniform_probability():
 	e = UniformDistribution(0., 10.)
 
 	assert_almost_equal(d.probability(5), 0.0999999999)
-	assert_equal(d.probability(5), e.probability(5))
-	assert_equal(d.probability(5), d.probability(5.))
+	assert d.probability(5) == e.probability(5)
+	assert d.probability(5) == d.probability(5.)
 
 	assert_almost_equal(d.probability(0), 0.0999999999)
-	assert_equal(d.probability(0), e.probability(0.))
+	assert d.probability(0) == e.probability(0.)
 
-	assert_equal(d.probability(-1), 0)
-	assert_equal(d.probability(11), 0)
+	assert d.probability(-1) == 0
+	assert d.probability(11) == 0
 
 
 def test_distributions_uniform_nan_probability():
 	d = UniformDistribution(0, 10)
 
-	assert_equal(d.probability(nan), 1)
+	assert d.probability(nan) == 1
 	assert_array_almost_equal(d.probability([nan, 5]), [1, 0.0999999999])
 
 
@@ -135,10 +125,10 @@ def test_distributions_uniform_fit():
 	d.fit([5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4])
 
 	assert_array_equal(d.parameters, [4, 6])
-	assert_not_equal(d.log_probability(4), e.log_probability(4))
+	assert d.log_probability(4) != e.log_probability(4)
 	assert_almost_equal(d.log_probability(4), -0.69314718055994529)
-	assert_equal(d.log_probability(18), -inf)
-	assert_equal(d.log_probability(1e8), -inf)
+	assert d.log_probability(18) == -inf
+	assert d.log_probability(1e8) == -inf
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
 
@@ -149,10 +139,10 @@ def test_distributions_uniform_nan_fit():
 	d.fit([5, 4, nan, 5, 4, nan, 6, 5, 6, nan, nan, 5, 4, 6, nan, 5, 4, nan])
 
 	assert_array_equal(d.parameters, [4, 6])
-	assert_not_equal(d.log_probability(4), e.log_probability(4))
+	assert d.log_probability(4) != e.log_probability(4)
 	assert_almost_equal(d.log_probability(4), -0.69314718055994529)
-	assert_equal(d.log_probability(18), -inf)
-	assert_equal(d.log_probability(1e8), -inf)
+	assert d.log_probability(18) == -inf
+	assert d.log_probability(1e8) == -inf
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
 
@@ -234,7 +224,7 @@ def test_distributions_uniform_pickle_serialization():
 	d = UniformDistribution(0, 10)
 
 	e = pickle.loads(pickle.dumps(d))
-	assert_equal(e.name, "UniformDistribution")
+	assert e.name == "UniformDistribution"
 	assert_array_equal(e.parameters, [0, 10])
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
@@ -243,7 +233,7 @@ def test_distributions_uniform_json_serialization():
 	d = UniformDistribution(0, 10)
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "UniformDistribution")
+	assert e.name == "UniformDistribution"
 	assert_array_equal(e.parameters, [0, 10])
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
@@ -251,7 +241,7 @@ def test_distributions_uniform_robust_json_serialization():
 	d = UniformDistribution(0, 10)
 
 	e = from_json(d.to_json())
-	assert_equal(e.name, "UniformDistribution")
+	assert e.name == "UniformDistribution"
 	assert_array_equal(e.parameters, [0, 10])
 	assert_array_equal(d.summaries, [inf, -inf, 0])
 
@@ -262,26 +252,30 @@ def test_distributions_uniform_random_sample():
 		4.88411189])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 def test_distributions_normal_initialization():
 	d = NormalDistribution(5, 2)
-	assert_equal(d.name, "NormalDistribution")
+	assert d.name == "NormalDistribution"
 	assert_array_equal(d.parameters, [5, 2])
 	assert_array_equal(d.summaries, [0, 0, 0])
 
 
 def test_distributions_normal_blank():
 	d = NormalDistribution.blank()
-	assert_equal(d.name, "NormalDistribution")
+	assert d.name == "NormalDistribution"
 	assert_array_equal(d.parameters, [0, 1])
 	assert_array_equal(d.summaries, [0, 0, 0])
 
 
 def test_distributions_normal_initialization_error():
-	assert_raises(TypeError, NormalDistribution, 5)
-	assert_raises(TypeError, NormalDistribution, [5, 1])
-	assert_raises(TypeError, NormalDistribution, 5, 1, 4, 7, 3)
+	with pytest.raises(TypeError):
+		NormalDistribution(5)
+	with pytest.raises(TypeError):
+		NormalDistribution([5, 1])
+	with pytest.raises(TypeError):
+		NormalDistribution(5, 1, 4, 7, 3)
 
 
 def test_distributions_normal_log_probability():
@@ -289,23 +283,23 @@ def test_distributions_normal_log_probability():
 	e = NormalDistribution(5., 2.)
 
 	assert_almost_equal(d.log_probability(5), -1.61208571)
-	assert_equal(d.log_probability(5), e.log_probability(5))
-	assert_equal(d.log_probability(5), d.log_probability(5.))
+	assert d.log_probability(5) == e.log_probability(5)
+	assert d.log_probability(5) == d.log_probability(5.)
 
 	assert_almost_equal(d.log_probability(0), -4.737085713764219)
-	assert_equal(d.log_probability(0), e.log_probability(0.))
+	assert d.log_probability(0) == e.log_probability(0.)
 
 
 def test_distributions_normal_nan_log_probability():
 	d = NormalDistribution(5, 2)
 
-	assert_equal(d.log_probability(nan), 0)
+	assert d.log_probability(nan) == 0
 	assert_array_almost_equal(d.log_probability([nan, 5]), [0, -1.61208571])
 
 
 def test_distributions_normal_underflow_log_probability():
 	d = NormalDistribution(5, 1e-10)
-	assert_almost_equal(d.log_probability(1e100), -4.9999999999999987e+219, delta=6.270570637641398e+203)
+	assert abs(d.log_probability(1e100) - (-4.9999999999999987e+219)) <= 6.270570637641398e+203
 
 
 def test_distributions_normal_probability():
@@ -313,17 +307,17 @@ def test_distributions_normal_probability():
 	e = NormalDistribution(5., 2.)
 
 	assert_almost_equal(d.probability(5), 0.19947114)
-	assert_equal(d.probability(5), e.probability(5))
-	assert_equal(d.probability(5), d.probability(5.))
+	assert d.probability(5) == e.probability(5)
+	assert d.probability(5) == d.probability(5.)
 
 	assert_almost_equal(d.probability(0), 0.0087641502)
-	assert_equal(d.probability(0), e.probability(0.))
+	assert d.probability(0) == e.probability(0.)
 
 
 def test_distributions_normal_nan_probability():
 	d = NormalDistribution(5, 2)
 
-	assert_equal(d.probability(nan), 1)
+	assert d.probability(nan) == 1
 	assert_array_almost_equal(d.probability([nan, 5]), [1, 0.199471])
 
 
@@ -339,7 +333,7 @@ def test_distributions_normal_fit():
 	d.fit([5, 4, 5, 4, 6, 5, 6, 5, 4, 6, 5, 4])
 
 	assert_array_almost_equal(d.parameters, [4.9167, 0.7592], 4)
-	assert_not_equal(d.log_probability(4), e.log_probability(4))
+	assert d.log_probability(4) != e.log_probability(4)
 	assert_almost_equal(d.log_probability(4), -1.3723678499651766)
 	assert_almost_equal(d.log_probability(18), -149.13140399454429)
 	assert_almost_equal(d.log_probability(1e8), -8674697942168743.0, -4)
@@ -353,7 +347,7 @@ def test_distributions_normal_nan_fit():
 	d.fit([5, 4, nan, 5, 4, nan, 6, 5, 6, nan, nan, 5, 4, 6, nan, 5, 4, nan])
 
 	assert_array_almost_equal(d.parameters, [4.9167, 0.7592], 4)
-	assert_not_equal(d.log_probability(4), e.log_probability(4))
+	assert d.log_probability(4) != e.log_probability(4)
 	assert_almost_equal(d.log_probability(4), -1.3723678499651766)
 	assert_almost_equal(d.log_probability(18), -149.13140399454429)
 	assert_almost_equal(d.log_probability(1e8), -8674697942168743.0, -4)
@@ -438,7 +432,7 @@ def test_distributions_normal_pickle_serialization():
 	d = NormalDistribution(5, 2)
 
 	e = pickle.loads(pickle.dumps(d))
-	assert_equal(e.name, "NormalDistribution")
+	assert e.name == "NormalDistribution"
 	assert_array_equal(e.parameters, [5, 2])
 	assert_array_equal(e.summaries, [0, 0, 0])
 
@@ -447,7 +441,7 @@ def test_distributions_normal_json_serialization():
 	d = NormalDistribution(5, 2)
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "NormalDistribution")
+	assert e.name == "NormalDistribution"
 	assert_array_equal(e.parameters, [5, 2])
 	assert_array_equal(e.summaries, [0, 0, 0])
 
@@ -455,166 +449,165 @@ def test_distributions_normal_robust_json_serialization():
 	d = NormalDistribution(5, 2)
 
 	e = from_json(d.to_json())
-	assert_equal(e.name, "NormalDistribution")
+	assert e.name == "NormalDistribution"
 	assert_array_equal(e.parameters, [5, 2])
 	assert_array_equal(e.summaries, [0, 0, 0])
 
 def test_distributions_normal_random_sample():
 	d = NormalDistribution(0, 1)
 
-	x = numpy.array([ 0.44122749, -0.33087015,  2.43077119, -0.25209213,  
+	x = numpy.array([ 0.44122749, -0.33087015,	2.43077119, -0.25209213,
 		0.10960984])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_distributions_discrete():
 	d = DiscreteDistribution({'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25})
 
-	assert_equal(d.log_probability('C'), -1.3862943611198906)
-	assert_equal(d.log_probability('A'), d.log_probability('C'))
-	assert_equal(d.log_probability('G'), d.log_probability('T'))
-	assert_equal(d.log_probability('a'), float('-inf'))
+	assert d.log_probability('C') == -1.3862943611198906
+	assert d.log_probability('A') == d.log_probability('C')
+	assert d.log_probability('G') == d.log_probability('T')
+	assert d.log_probability('a') == float('-inf')
 
 	seq = "ACGTACGTTGCATGCACGCGCTCTCGCGC"
 	d.fit(list(seq))
 
-	assert_equal(d.log_probability('C'), -0.9694005571881036)
-	assert_equal(d.log_probability('A'), -1.9810014688665833)
-	assert_equal(d.log_probability('T'), -1.575536360758419)
+	assert d.log_probability('C') == -0.9694005571881036
+	assert d.log_probability('A') == -1.9810014688665833
+	assert d.log_probability('T') == -1.575536360758419
 
 	seq = "ACGTGTG"
 	d.fit(list(seq), weights=[0., 1., 2., 3., 4., 5., 6.])
 
-	assert_equal(d.log_probability('A'), float('-inf'))
-	assert_equal(d.log_probability('C'), -3.044522437723423)
-	assert_equal(d.log_probability('G'), -0.5596157879354228)
+	assert d.log_probability('A') == float('-inf')
+	assert d.log_probability('C') == -3.044522437723423
+	assert d.log_probability('G') == -0.5596157879354228
 
 	d.summarize(list("ACG"), weights=[0., 1., 2.])
 	d.summarize(list("TGT"), weights=[3., 4., 5.])
 	d.summarize(list("G"), weights=[6.])
 	d.from_summaries()
 
-	assert_equal(d.log_probability('A'), float('-inf'))
-	assert_equal(round(d.log_probability('C'), 4), -3.0445)
-	assert_equal(round(d.log_probability('G'), 4), -0.5596)
+	assert d.log_probability('A') == float('-inf')
+	assert round(d.log_probability('C'), 4) == -3.0445
+	assert round(d.log_probability('G'), 4) == -0.5596
 
 	d = DiscreteDistribution({'A': 0.0, 'B': 1.0})
 	d.summarize(list("ABABABAB"))
 	d.summarize(list("ABAB"))
 	d.summarize(list("BABABABABABABABABA"))
 	d.from_summaries(inertia=0.75)
-	assert_equal(d.parameters[0], {'A': 0.125, 'B': 0.875})
+	assert d.parameters[0] == {'A': 0.125, 'B': 0.875}
 
 	d = DiscreteDistribution({'A': 0.0, 'B': 1.0})
 	d.summarize(list("ABABABAB"))
 	d.summarize(list("ABAB"))
 	d.summarize(list("BABABABABABABABABA"))
 	d.from_summaries(inertia=0.5)
-	assert_equal(d.parameters[0], {'A': 0.25, 'B': 0.75})
+	assert d.parameters[0] == {'A': 0.25, 'B': 0.75}
 
 	d.freeze()
 	d.fit(list('ABAABBAAAAAAAAAAAAAAAAAA'))
-	assert_equal(d.parameters[0], {'A': 0.25, 'B': 0.75})
+	assert d.parameters[0] == {'A': 0.25, 'B': 0.75}
 
 	d = DiscreteDistribution.from_samples(['A', 'B', 'A', 'A'])
-	assert_equal(d.parameters[0], {'A': 0.75, 'B': 0.25})
+	assert d.parameters[0] == {'A': 0.75, 'B': 0.25}
 
 	# Test vector input instead of flat array.
 	d = DiscreteDistribution.from_samples(numpy.array(['A', 'B', 'A', 'A']).reshape(-1,1))
-	assert_equal(d.parameters[0], {'A': 0.75, 'B': 0.25})
+	assert d.parameters[0] == {'A': 0.75, 'B': 0.25}
 
 	d = DiscreteDistribution.from_samples(['A', 'B', 'A', 'A'], pseudocount=0.5)
-	assert_equal(d.parameters[0], {'A': 0.70, 'B': 0.30})
+	assert d.parameters[0] == {'A': 0.70, 'B': 0.30}
 
 	d = DiscreteDistribution.from_samples(['A', 'B', 'A', 'A'], pseudocount=6)
-	assert_equal(d.parameters[0], {'A': 0.5625, 'B': 0.4375})
+	assert d.parameters[0] == {'A': 0.5625, 'B': 0.4375}
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "DiscreteDistribution")
-	assert_equal(e.parameters[0], {'A': 0.5625, 'B': 0.4375})
+	assert e.name == "DiscreteDistribution"
+	assert e.parameters[0] == {'A': 0.5625, 'B': 0.4375}
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "DiscreteDistribution")
-	assert_equal(f.parameters[0], {'A': 0.5625, 'B': 0.4375})
+	assert f.name == "DiscreteDistribution"
+	assert f.parameters[0] == {'A': 0.5625, 'B': 0.4375}
 
 
 def test_discrete_robust_json_serialization():
 	d = DiscreteDistribution.from_samples(['A', 'B', 'A', 'A'], pseudocount=6)
 
 	e = from_json(d.to_json())
-	assert_equal(e.name, "DiscreteDistribution")
-	assert_equal(e.parameters[0], {'A': 0.5625, 'B': 0.4375})
+	assert e.name == "DiscreteDistribution"
+	assert e.parameters[0] == {'A': 0.5625, 'B': 0.4375}
 
-@with_setup(setup, teardown)
 def test_lognormal():
 	d = LogNormalDistribution(5, 2)
-	assert_equal(round(d.log_probability(5), 4), -4.6585)
+	assert round(d.log_probability(5), 4) == -4.6585
 
 	d.fit([5.1, 5.03, 4.98, 5.05, 4.91, 5.2, 5.1, 5., 4.8, 5.21])
-	assert_equal(round(d.parameters[0], 4), 1.6167)
-	assert_equal(round(d.parameters[1], 4), 0.0237)
+	assert round(d.parameters[0], 4) == 1.6167
+	assert round(d.parameters[1], 4) == 0.0237
 
 	d.summarize([5.1, 5.03, 4.98, 5.05])
 	d.summarize([4.91, 5.2, 5.1])
 	d.summarize([5., 4.8, 5.21])
 	d.from_summaries()
 
-	assert_equal(round(d.parameters[0], 4), 1.6167)
-	assert_equal(round(d.parameters[1], 4), 0.0237)
+	assert round(d.parameters[0], 4) == 1.6167
+	assert round(d.parameters[1], 4) == 0.0237
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "LogNormalDistribution")
-	assert_equal(round(e.parameters[0], 4), 1.6167)
-	assert_equal(round(e.parameters[1], 4), 0.0237)
+	assert e.name == "LogNormalDistribution"
+	assert round(e.parameters[0], 4) == 1.6167
+	assert round(e.parameters[1], 4) == 0.0237
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "LogNormalDistribution")
-	assert_equal(round(f.parameters[0], 4), 1.6167)
-	assert_equal(round(f.parameters[1], 4), 0.0237)
+	assert f.name == "LogNormalDistribution"
+	assert round(f.parameters[0], 4) == 1.6167
+	assert round(f.parameters[1], 4) == 0.0237
 
 
 def test_distributions_lognormal_random_sample():
 	d = LogNormalDistribution(0, 1)
 
-	x = numpy.array([1.55461432,  0.71829843, 11.36764528,  0.77717313,  
+	x = numpy.array([1.55461432,  0.71829843, 11.36764528,	0.77717313,
 		1.11584263])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_gamma():
 	d = GammaDistribution(5, 2)
-	assert_equal(round(d.log_probability(4), 4), -2.1671)
+	assert round(d.log_probability(4), 4) == -2.1671
 
 	d.fit([2.3, 4.3, 2.7, 2.3, 3.1, 3.2, 3.4, 3.1, 2.9, 2.8])
-	assert_equal(round(d.parameters[0], 4), 31.8806)
-	assert_equal(round(d.parameters[1], 4), 10.5916)
+	assert round(d.parameters[0], 4) == 31.8806
+	assert round(d.parameters[1], 4) == 10.5916
 
 	d = GammaDistribution(2, 7)
-	assert_not_equal(round(d.log_probability(4), 4), -2.1671)
+	assert round(d.log_probability(4), 4) != -2.1671
 
 	d.summarize([2.3, 4.3, 2.7])
 	d.summarize([2.3, 3.1, 3.2])
 	d.summarize([3.4, 3.1, 2.9, 2.8])
 	d.from_summaries()
 
-	assert_equal(round(d.parameters[0], 4), 31.8806)
-	assert_equal(round(d.parameters[1], 4), 10.5916)
+	assert round(d.parameters[0], 4) == 31.8806
+	assert round(d.parameters[1], 4) == 10.5916
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "GammaDistribution")
-	assert_equal(round(e.parameters[0], 4), 31.8806)
-	assert_equal(round(e.parameters[1], 4), 10.5916)
+	assert e.name == "GammaDistribution"
+	assert round(e.parameters[0], 4) == 31.8806
+	assert round(e.parameters[1], 4) == 10.5916
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "GammaDistribution")
-	assert_equal(round(f.parameters[0], 4), 31.8806)
-	assert_equal(round(f.parameters[1], 4), 10.5916)
+	assert f.name == "GammaDistribution"
+	assert round(f.parameters[0], 4) == 31.8806
+	assert round(f.parameters[1], 4) == 10.5916
 
 
 def test_distributions_gamma_random_sample():
@@ -623,34 +616,34 @@ def test_distributions_gamma_random_sample():
 	x = numpy.array([0.049281, 0.042733, 0.238545, 0.773426, 0.088091])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_exponential():
 	d = ExponentialDistribution(3)
-	assert_equal(round(d.log_probability(8), 4), -22.9014)
+	assert round(d.log_probability(8), 4) == -22.9014
 
 	d.fit([2.7, 2.9, 3.8, 1.9, 2.7, 1.6, 1.3, 1.0, 1.9])
-	assert_equal(round(d.parameters[0], 4), 0.4545)
+	assert round(d.parameters[0], 4) == 0.4545
 
 	d = ExponentialDistribution(4)
-	assert_not_equal(round(d.log_probability(8), 4), -22.9014)
+	assert round(d.log_probability(8), 4) != -22.9014
 
 	d.summarize([2.7, 2.9, 3.8])
 	d.summarize([1.9, 2.7, 1.6])
 	d.summarize([1.3, 1.0, 1.9])
 	d.from_summaries()
 
-	assert_equal(round(d.parameters[0], 4), 0.4545)
+	assert round(d.parameters[0], 4) == 0.4545
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "ExponentialDistribution")
-	assert_equal(round(e.parameters[0], 4), 0.4545)
+	assert e.name == "ExponentialDistribution"
+	assert round(e.parameters[0], 4) == 0.4545
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "ExponentialDistribution")
-	assert_equal(round(f.parameters[0], 4), 0.4545)
+	assert f.name == "ExponentialDistribution"
+	assert round(f.parameters[0], 4) == 0.4545
 
 
 def test_distributions_exponential_random_sample():
@@ -659,40 +652,40 @@ def test_distributions_exponential_random_sample():
 	x = numpy.array([0.03586, 0.292267, 0.033083, 0.358359, 0.095748])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_poisson():
 	d = PoissonDistribution(5)
 
 	assert_almost_equal(d.log_probability(5), -1.7403021806115442)
 	assert_almost_equal(d.log_probability(10), -4.0100334487345126)
 	assert_almost_equal(d.log_probability(1), -3.3905620875658995)
-	assert_equal(d.log_probability(-1), float("-inf"))
+	assert d.log_probability(-1) == float("-inf")
 
 	d = PoissonDistribution(0)
 
-	assert_equal(d.log_probability(1), float("-inf"))
-	assert_equal(d.log_probability(7), float("-inf"))
+	assert d.log_probability(1) == float("-inf")
+	assert d.log_probability(7) == float("-inf")
 
 	d.fit([1, 6, 4, 9, 1])
-	assert_equal(d.parameters[0], 4.2)
+	assert d.parameters[0] == 4.2
 
 	d.fit([1, 6, 4, 9, 1], weights=[0, 0, 0, 1, 0])
-	assert_equal(d.parameters[0], 9)
+	assert d.parameters[0] == 9
 
 	d.fit([1, 6, 4, 9, 1], weights=[1, 0, 0, 1, 0])
-	assert_equal(d.parameters[0], 5)
+	assert d.parameters[0] == 5
 
 	assert_almost_equal(d.log_probability(5), -1.7403021806115442)
 	assert_almost_equal(d.log_probability(10), -4.0100334487345126)
 	assert_almost_equal(d.log_probability(1), -3.3905620875658995)
-	assert_equal(d.log_probability(-1), float("-inf"))
+	assert d.log_probability(-1) == float("-inf")
 
 	e = pickle.loads(pickle.dumps(d))
-	assert_equal(e.name, "PoissonDistribution")
-	assert_equal(e.parameters[0], 5)
+	assert e.name == "PoissonDistribution"
+	assert e.parameters[0] == 5
 
 
 def test_distributions_poisson_random_sample():
@@ -701,14 +694,15 @@ def test_distributions_poisson_random_sample():
 	x = numpy.array([0, 1, 2, 2, 0])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 def test_beta():
 	"""Test pickling of beta distribution."""
 	d = BetaDistribution(2, 3)
 	e = pickle.loads(pickle.dumps(d))
-	assert_equal(e.name, "BetaDistribution")
-	assert_equal(e.parameters, [2, 3])
+	assert e.name == "BetaDistribution"
+	assert e.parameters == [2, 3]
 
 def test_distributions_beta_random_sample():
 	d = BetaDistribution(1, 1)
@@ -716,45 +710,45 @@ def test_distributions_beta_random_sample():
 	x = numpy.array([0.612564, 0.098563, 0.735983, 0.583171, 0.69296 ])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
-@with_setup(setup, teardown)
 def test_gaussian_kernel():
 	d = GaussianKernelDensity([0, 4, 3, 5, 7, 4, 2])
-	assert_equal(round(d.log_probability(3.3), 4), -1.7042)
+	assert round(d.log_probability(3.3), 4) == -1.7042
 
 	d.fit([1, 6, 8, 3, 2, 4, 7, 2])
-	assert_equal(round(d.log_probability(1.2), 4), -2.0237)
+	assert round(d.log_probability(1.2), 4) == -2.0237
 
 	d.fit([1, 0, 108], weights=[2., 3., 278.])
-	assert_equal(round(d.log_probability(110), 4), -2.9368)
-	assert_equal(round(d.log_probability(0), 4), -5.1262)
+	assert round(d.log_probability(110), 4) == -2.9368
+	assert round(d.log_probability(0), 4) == -5.1262
 
 	d.summarize([1, 6, 8, 3])
 	d.summarize([2, 4, 7])
 	d.summarize([2])
 	d.from_summaries()
-	assert_equal(round(d.log_probability(1.2), 4), -2.0237)
+	assert round(d.log_probability(1.2), 4) == -2.0237
 
 	d.summarize([1, 0, 108], weights=[2., 3., 278.])
 	d.from_summaries()
-	assert_equal(round(d.log_probability(110), 4), -2.9368)
-	assert_equal(round(d.log_probability(0), 4), -5.1262)
+	assert round(d.log_probability(110), 4) == -2.9368
+	assert round(d.log_probability(0), 4) == -5.1262
 
 	d.freeze()
 	d.fit([1, 3, 5, 4, 6, 7, 3, 4, 2])
-	assert_equal(round(d.log_probability(110), 4), -2.9368)
-	assert_equal(round(d.log_probability(0), 4), -5.1262)
+	assert round(d.log_probability(110), 4) == -2.9368
+	assert round(d.log_probability(0), 4) == -5.1262
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "GaussianKernelDensity")
-	assert_equal(round(e.log_probability(110), 4), -2.9368)
-	assert_equal(round(e.log_probability(0), 4), -5.1262)
+	assert e.name == "GaussianKernelDensity"
+	assert round(e.log_probability(110), 4) == -2.9368
+	assert round(e.log_probability(0), 4) == -5.1262
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "GaussianKernelDensity")
-	assert_equal(round(f.log_probability(110), 4), -2.9368)
-	assert_equal(round(f.log_probability(0), 4), -5.1262)
+	assert f.name == "GaussianKernelDensity"
+	assert round(f.log_probability(110), 4) == -2.9368
+	assert round(f.log_probability(0), 4) == -5.1262
 
 
 def test_distributions_gaussian_kernel_random_sample():
@@ -763,34 +757,34 @@ def test_distributions_gaussian_kernel_random_sample():
 	x = numpy.array([5.367586, 2.574708, 2.114238, 2.170925, 4.596907])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_triangular_kernel():
 	d = TriangleKernelDensity([1, 6, 3, 4, 5, 2])
-	assert_equal(round(d.log_probability(6.5), 4), -2.4849)
+	assert round(d.log_probability(6.5), 4) == -2.4849
 
 	d = TriangleKernelDensity([1, 8, 100])
-	assert_not_equal(round(d.log_probability(6.5), 4), -2.4849)
+	assert round(d.log_probability(6.5), 4) != -2.4849
 
 	d.summarize([1, 6])
 	d.summarize([3, 4, 5])
 	d.summarize([2])
 	d.from_summaries()
-	assert_equal(round(d.log_probability(6.5), 4), -2.4849)
+	assert round(d.log_probability(6.5), 4) == -2.4849
 
 	d.freeze()
 	d.fit([1, 4, 6, 7, 3, 5, 7, 8, 3, 3, 4])
-	assert_equal(round(d.log_probability(6.5), 4), -2.4849)
+	assert round(d.log_probability(6.5), 4) == -2.4849
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "TriangleKernelDensity")
-	assert_equal(round(e.log_probability(6.5), 4), -2.4849)
+	assert e.name == "TriangleKernelDensity"
+	assert round(e.log_probability(6.5), 4) == -2.4849
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "TriangleKernelDensity")
-	assert_equal(round(f.log_probability(6.5), 4), -2.4849)
+	assert f.name == "TriangleKernelDensity"
+	assert round(f.log_probability(6.5), 4) == -2.4849
 
 
 def test_distributions_triangle_kernel_random_sample():
@@ -799,36 +793,36 @@ def test_distributions_triangle_kernel_random_sample():
 	x = numpy.array([4.118801, 2.31576 , 4.018591, 1.770455, 4.612734])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_uniform_kernel():
 	d = UniformKernelDensity([1, 3, 5, 6, 2, 2, 3, 2, 2])
 
-	assert_equal(round(d.log_probability(2.2), 4), -0.4055)
-	assert_equal(round(d.log_probability(6.2), 4), -2.1972)
-	assert_equal(d.log_probability(10), float('-inf'))
+	assert round(d.log_probability(2.2), 4) == -0.4055
+	assert round(d.log_probability(6.2), 4) == -2.1972
+	assert d.log_probability(10) == float('-inf')
 
 	d = UniformKernelDensity([1, 100, 200])
-	assert_not_equal(round(d.log_probability(2.2), 4), -0.4055)
-	assert_not_equal(round(d.log_probability(6.2), 4), -2.1972)
+	assert round(d.log_probability(2.2), 4) != -0.4055
+	assert round(d.log_probability(6.2), 4) != -2.1972
 
 	d.summarize([1, 3, 5, 6, 2])
 	d.summarize([2, 3, 2, 2])
 	d.from_summaries()
-	assert_equal(round(d.log_probability(2.2), 4), -0.4055)
-	assert_equal(round(d.log_probability(6.2), 4), -2.1972)
+	assert round(d.log_probability(2.2), 4) == -0.4055
+	assert round(d.log_probability(6.2), 4) == -2.1972
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "UniformKernelDensity")
-	assert_equal(round(e.log_probability(2.2), 4), -0.4055)
-	assert_equal(round(e.log_probability(6.2), 4), -2.1972)
+	assert e.name == "UniformKernelDensity"
+	assert round(e.log_probability(2.2), 4) == -0.4055
+	assert round(e.log_probability(6.2), 4) == -2.1972
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(e.name, "UniformKernelDensity")
-	assert_equal(round(f.log_probability(2.2), 4), -0.4055)
-	assert_equal(round(f.log_probability(6.2), 4), -2.1972)
+	assert e.name == "UniformKernelDensity"
+	assert round(f.log_probability(2.2), 4) == -0.4055
+	assert round(f.log_probability(6.2), 4) == -2.1972
 
 
 def test_distributions_uniform_kernel_random_sample():
@@ -837,57 +831,57 @@ def test_distributions_uniform_kernel_random_sample():
 	x = numpy.array([4.223488, 2.531816, 4.036836, 1.593601, 4.375442])
 
 	assert_array_almost_equal(d.sample(5, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
-@with_setup(setup, teardown)
 def test_bernoulli():
 	d = BernoulliDistribution(0.6)
-	assert_equal(d.probability(0), 0.4)
-	assert_equal(d.probability(1), 0.6)
-	assert_equal(d.parameters[0], 1-d.probability(0))
-	assert_equal(d.parameters[0], d.probability(1))
+	assert d.probability(0) == 0.4
+	assert d.probability(1) == 0.6
+	assert d.parameters[0] == 1-d.probability(0)
+	assert d.parameters[0] == d.probability(1)
 
 	d.fit([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-	assert_not_equal(d.probability(1), 1.0)
-	assert_equal(d.probability(0), 1.0)
+	assert d.probability(1) != 1.0
+	assert d.probability(0) == 1.0
 
 	a = [0.0, 0.0, 0.0]
 	b = [1.0, 1.0, 1.0]
 	c = [1.0, 1.0, 1.0]
 	d.summarize(a)
 	d.from_summaries()
-	assert_equal(d.probability(0), 1)
-	assert_equal(d.probability(1), 0)
+	assert d.probability(0) == 1
+	assert d.probability(1) == 0
 
 	d.summarize(a)
 	d.summarize(b)
 	d.from_summaries()
-	assert_equal(d.probability(0), 0.5)
-	assert_equal(d.probability(1), 0.5)
-	assert_equal(d.parameters[0], d.probability(0))
-	assert_equal(d.parameters[0], d.probability(1))
+	assert d.probability(0) == 0.5
+	assert d.probability(1) == 0.5
+	assert d.parameters[0] == d.probability(0)
+	assert d.parameters[0] == d.probability(1)
 
 	d.summarize(a)
 	d.summarize(b)
 	d.summarize(c)
 	d.from_summaries()
-	assert_equal(round(d.probability(0), 4), 0.3333)
-	assert_equal(round(d.probability(1), 4), 0.6667)
-	assert_equal(d.parameters[0], d.probability(1))
+	assert round(d.probability(0), 4) == 0.3333
+	assert round(d.probability(1), 4) == 0.6667
+	assert d.parameters[0] == d.probability(1)
 
 	d = BernoulliDistribution.from_samples([0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-	assert_equal(round(d.probability(0), 4), 0.8333)
-	assert_equal(round(d.probability(1), 4), 0.1667)
+	assert round(d.probability(0), 4) == 0.8333
+	assert round(d.probability(1), 4) == 0.1667
 	assert_almost_equal(d.parameters[0], d.probability(1))
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "BernoulliDistribution")
-	assert_equal(round(e.parameters[0], 4), 0.1667)
+	assert e.name == "BernoulliDistribution"
+	assert round(e.parameters[0], 4) == 0.1667
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(f.name, "BernoulliDistribution")
-	assert_equal(round(f.parameters[0], 4), 0.1667)
+	assert f.name == "BernoulliDistribution"
+	assert round(f.parameters[0], 4) == 0.1667
 
 def test_distributions_uniform_kernel_random_sample():
 	d = BernoulliDistribution(0.2)
@@ -896,48 +890,48 @@ def test_distributions_uniform_kernel_random_sample():
 			0, 0, 0, 0, 0])
 
 	assert_array_equal(d.sample(20, random_state=5), x)
-	assert_raises(AssertionError, assert_array_equal, d.sample(20), x)
+	with pytest.raises(AssertionError):
+		assert_array_equal(d.sample(20), x)
 
-@with_setup(setup, teardown)
 def test_independent():
 	d = IndependentComponentsDistribution(
 		[NormalDistribution(5, 2), ExponentialDistribution(2)])
 
-	assert_equal(round(d.log_probability((4, 1)), 4), -3.0439)
-	assert_equal(round(d.log_probability((100, 0.001)), 4), -1129.0459)
+	assert round(d.log_probability((4, 1)), 4) == -3.0439
+	assert round(d.log_probability((100, 0.001)), 4) == -1129.0459
 
 	d = IndependentComponentsDistribution([NormalDistribution(5, 2),
 										   ExponentialDistribution(2)],
 										  weights=[18., 1.])
 
-	assert_equal(round(d.log_probability((4, 1)), 4), -32.5744)
-	assert_equal(round(d.log_probability((100, 0.001)), 4), -20334.5764)
+	assert round(d.log_probability((4, 1)), 4) == -32.5744
+	assert round(d.log_probability((100, 0.001)), 4) == -20334.5764
 
 	d.fit([(5, 1), (5.2, 1.7), (4.7, 1.9), (4.9, 2.4), (4.5, 1.2)])
 
-	assert_equal(round(d.parameters[0][0].parameters[0], 4), 4.86)
-	assert_equal(round(d.parameters[0][0].parameters[1], 4), 0.2417)
-	assert_equal(round(d.parameters[0][1].parameters[0], 4), 0.6098)
+	assert round(d.parameters[0][0].parameters[0], 4) == 4.86
+	assert round(d.parameters[0][0].parameters[1], 4) == 0.2417
+	assert round(d.parameters[0][1].parameters[0], 4) == 0.6098
 
 	d = IndependentComponentsDistribution([NormalDistribution(5, 2),
 										   UniformDistribution(0, 10)])
 	d.fit([(0, 0), (5, 0), (3, 0), (5, -5), (7, 0),
 		   (3, 0), (4, 0), (5, 0), (2, 20)], inertia=0.5)
 
-	assert_equal(round(d.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_equal(round(d.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(d.parameters[0][0].parameters[0], 4) == 4.3889
+	assert round(d.parameters[0][0].parameters[1], 4) == 1.9655
 
-	assert_equal(d.parameters[0][1].parameters[0], -2.5)
-	assert_equal(d.parameters[0][1].parameters[1], 15)
+	assert d.parameters[0][1].parameters[0] == -2.5
+	assert d.parameters[0][1].parameters[1] == 15
 
 	d.fit([(0, 0), (5, 0), (3, 0), (5, -5), (7, 0),
 		   (3, 0), (4, 0), (5, 0), (2, 20)], inertia=0.75)
 
-	assert_not_equal(round(d.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_not_equal(round(d.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(d.parameters[0][0].parameters[0], 4) != 4.3889
+	assert round(d.parameters[0][0].parameters[1], 4) != 1.9655
 
-	assert_not_equal(d.parameters[0][1].parameters[0], -2.5)
-	assert_not_equal(d.parameters[0][1].parameters[1], 15)
+	assert d.parameters[0][1].parameters[0] != -2.5
+	assert d.parameters[0][1].parameters[1] != 15
 
 	d = IndependentComponentsDistribution([NormalDistribution(5, 2),
 										   UniformDistribution(0, 10)])
@@ -947,45 +941,45 @@ def test_independent():
 	d.summarize([(3, 0), (4, 0), (5, 0), (2, 20)])
 	d.from_summaries(inertia=0.5)
 
-	assert_equal(round(d.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_equal(round(d.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(d.parameters[0][0].parameters[0], 4) == 4.3889
+	assert round(d.parameters[0][0].parameters[1], 4) == 1.9655
 
-	assert_equal(d.parameters[0][1].parameters[0], -2.5)
-	assert_equal(d.parameters[0][1].parameters[1], 15)
+	assert d.parameters[0][1].parameters[0] == -2.5
+	assert d.parameters[0][1].parameters[1] == 15
 
 	d.freeze()
 	d.fit([(1, 7), (7, 2), (2, 4), (2, 4), (1, 4)])
 
-	assert_equal(round(d.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_equal(round(d.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(d.parameters[0][0].parameters[0], 4) == 4.3889
+	assert round(d.parameters[0][0].parameters[1], 4) == 1.9655
 
-	assert_equal(d.parameters[0][1].parameters[0], -2.5)
-	assert_equal(d.parameters[0][1].parameters[1], 15)
+	assert d.parameters[0][1].parameters[0] == -2.5
+	assert d.parameters[0][1].parameters[1] == 15
 
 	e = Distribution.from_json(d.to_json())
-	assert_equal(e.name, "IndependentComponentsDistribution")
+	assert e.name == "IndependentComponentsDistribution"
 
-	assert_equal(round(e.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_equal(round(e.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(e.parameters[0][0].parameters[0], 4) == 4.3889
+	assert round(e.parameters[0][0].parameters[1], 4) == 1.9655
 
-	assert_equal(e.parameters[0][1].parameters[0], -2.5)
-	assert_equal(e.parameters[0][1].parameters[1], 15)
+	assert e.parameters[0][1].parameters[0] == -2.5
+	assert e.parameters[0][1].parameters[1] == 15
 
 	f = pickle.loads(pickle.dumps(e))
-	assert_equal(e.name, "IndependentComponentsDistribution")
+	assert e.name == "IndependentComponentsDistribution"
 
-	assert_equal(round(f.parameters[0][0].parameters[0], 4), 4.3889)
-	assert_equal(round(f.parameters[0][0].parameters[1], 4), 1.9655)
+	assert round(f.parameters[0][0].parameters[0], 4) == 4.3889
+	assert round(f.parameters[0][0].parameters[1], 4) == 1.9655
 
-	assert_equal(f.parameters[0][1].parameters[0], -2.5)
-	assert_equal(f.parameters[0][1].parameters[1], 15)
+	assert f.parameters[0][1].parameters[0] == -2.5
+	assert f.parameters[0][1].parameters[1] == 15
 
 	X = numpy.array([[0.5, 0.2, 0.7],
-		          [0.3, 0.1, 0.9],
-		          [0.4, 0.3, 0.8],
-		          [0.3, 0.3, 0.9],
-		          [0.3, 0.2, 0.6],
-		          [0.5, 0.2, 0.8]])
+				  [0.3, 0.1, 0.9],
+				  [0.4, 0.3, 0.8],
+				  [0.3, 0.3, 0.9],
+				  [0.3, 0.2, 0.6],
+				  [0.5, 0.2, 0.8]])
 
 	d = IndependentComponentsDistribution.from_samples(X,
 		distributions=NormalDistribution)
@@ -1031,26 +1025,27 @@ def test_distributions_independent_random_sample():
 					 [9.861542, 2.067192, 0.033083, 2.644041]])
 
 	assert_array_almost_equal(d.sample(3, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
 def test_conditional():
 	phditis = DiscreteDistribution({True: 0.01, False: 0.99})
 	test_result = ConditionalProbabilityTable(
-		[[True,  True,  0.95],
+		[[True,  True,	0.95],
 		 [True,  False, 0.05],
-		 [False, True,  0.05],
+		 [False, True,	0.05],
 		 [False, False, 0.95]], [phditis])
 
 	assert discrete_equality(test_result.marginal(),
 							 DiscreteDistribution({False: 0.941, True: 0.059}))
 
 
-def setup_cpt():
+@pytest.fixture
+def cpt():
 	guest = DiscreteDistribution({'A': 1. / 3, 'B': 1. / 3, 'C': 1. / 3})
 	prize = DiscreteDistribution({'A': 1. / 3, 'B': 1. / 3, 'C': 1. / 3})
 
-	global monty
 	monty = ConditionalProbabilityTable(
 		[['A', 'A', 'A', 0.0],
 		 ['A', 'A', 'B', 0.5],
@@ -1080,9 +1075,8 @@ def setup_cpt():
 		 ['C', 'C', 'B', 0.5],
 		 ['C', 'C', 'C', 0.0]], [guest, prize])
 
-	global X
 	X = [['A', 'A', 'C'],
-	 	['A', 'A', 'B'],
+		['A', 'A', 'B'],
 		['A', 'A', 'C'],
 		['A', 'A', 'B'],
 		['A', 'A', 'A'],
@@ -1113,10 +1107,8 @@ def setup_cpt():
 		['C', 'C', 'C'],
 		['C', 'C', 'C']]
 
-
-	global X_nan
 	X_nan = [['nan', 'A', 'C'],
-	 	['A', 'A', 'nan'],
+		['A', 'A', 'nan'],
 		['A', 'nan', 'C'],
 		['A', 'A', 'B'],
 		['A', 'A', 'A'],
@@ -1146,11 +1138,12 @@ def setup_cpt():
 		['C', 'nan', 'C'],
 		['C', 'C', 'C'],
 		['C', 'C', 'C']]
+	return monty, X, X_nan
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_initialization():
-	assert_equal(monty.name, "ConditionalProbabilityTable")
+def test_distributions_cpt_initialization(cpt):
+	monty, X, X_nan = cpt
+	assert monty.name == "ConditionalProbabilityTable"
 	assert_array_equal(monty.parameters[0], [['A', 'A', 'A', 0.0],
 		 ['A', 'A', 'B', 0.5],
 		 ['A', 'A', 'C', 0.5],
@@ -1179,52 +1172,52 @@ def test_distributions_cpt_initialization():
 		 ['C', 'C', 'B', 0.5],
 		 ['C', 'C', 'C', 0.0]])
 
-	assert_equal(monty.n_columns, 3)
-	assert_equal(monty.m, 2)
+	assert monty.n_columns == 3
+	assert monty.m == 2
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_log_probability():
-	assert_equal(monty.log_probability(('A', 'B', 'C')), 0.)
-	assert_equal(monty.log_probability(('C', 'B', 'A')), 0.)
-	assert_equal(monty.log_probability(('C', 'C', 'C')), -inf)
-	assert_equal(monty.log_probability(('A', 'A', 'A')), -inf)
-	assert_equal(monty.log_probability(('B', 'A', 'C')), 0.)
-	assert_equal(monty.log_probability(('C', 'A', 'B')), 0.)
+def test_distributions_cpt_log_probability(cpt):
+	monty, X, X_nan = cpt
+	assert monty.log_probability(('A', 'B', 'C')) == 0.
+	assert monty.log_probability(('C', 'B', 'A')) == 0.
+	assert monty.log_probability(('C', 'C', 'C')) == -inf
+	assert monty.log_probability(('A', 'A', 'A')) == -inf
+	assert monty.log_probability(('B', 'A', 'C')) == 0.
+	assert monty.log_probability(('C', 'A', 'B')) == 0.
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_nan_log_probability():
-	assert_equal(monty.log_probability(('A', 'nan', 'C')), 0.)
-	assert_equal(monty.log_probability(('nan', 'nan', 'C')), 0.)
-	assert_equal(monty.log_probability(('A', 'nan', 'nan')), 0.)
-	assert_equal(monty.log_probability(('nan', 'nan', 'nan')), 0.)
-	assert_equal(monty.log_probability(('nan', 'B', 'C')), 0.)
-	assert_equal(monty.log_probability(('A', 'B', 'nan')), 0.)
+def test_distributions_cpt_nan_log_probability(cpt):
+	monty, X, X_nan = cpt
+	assert monty.log_probability(('A', 'nan', 'C')) == 0.
+	assert monty.log_probability(('nan', 'nan', 'C')) == 0.
+	assert monty.log_probability(('A', 'nan', 'nan')) == 0.
+	assert monty.log_probability(('nan', 'nan', 'nan')) == 0.
+	assert monty.log_probability(('nan', 'B', 'C')) == 0.
+	assert monty.log_probability(('A', 'B', 'nan')) == 0.
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_probability():
-	assert_equal(monty.probability(('A', 'B', 'C')), 1.)
-	assert_equal(monty.probability(('C', 'B', 'A')), 1.)
-	assert_equal(monty.probability(('C', 'C', 'C')), 0.)
-	assert_equal(monty.probability(('A', 'A', 'A')), 0.)
-	assert_equal(monty.probability(('B', 'A', 'C')), 1.)
-	assert_equal(monty.probability(('C', 'A', 'B')), 1.)
+def test_distributions_cpt_probability(cpt):
+	monty, X, X_nan = cpt
+	assert monty.probability(('A', 'B', 'C')) == 1.
+	assert monty.probability(('C', 'B', 'A')) == 1.
+	assert monty.probability(('C', 'C', 'C')) == 0.
+	assert monty.probability(('A', 'A', 'A')) == 0.
+	assert monty.probability(('B', 'A', 'C')) == 1.
+	assert monty.probability(('C', 'A', 'B')) == 1.
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_nan_probability():
-	assert_equal(monty.probability(('A', 'nan', 'C')), 1.)
-	assert_equal(monty.probability(('nan', 'nan', 'C')), 1.)
-	assert_equal(monty.probability(('A', 'nan', 'nan')), 1.)
-	assert_equal(monty.probability(('nan', 'nan', 'nan')), 1.)
-	assert_equal(monty.probability(('nan', 'B', 'C')), 1.)
-	assert_equal(monty.probability(('A', 'B', 'nan')), 1.)
+def test_distributions_cpt_nan_probability(cpt):
+	monty, X, X_nan = cpt
+	assert monty.probability(('A', 'nan', 'C')) == 1.
+	assert monty.probability(('nan', 'nan', 'C')) == 1.
+	assert monty.probability(('A', 'nan', 'nan')) == 1.
+	assert monty.probability(('nan', 'nan', 'nan')) == 1.
+	assert monty.probability(('nan', 'B', 'C')) == 1.
+	assert monty.probability(('A', 'B', 'nan')) == 1.
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_fit():
+def test_distributions_cpt_fit(cpt):
+	monty, X, X_nan = cpt
 	monty.fit(X)
 
 	assert_array_equal(monty.parameters[0],
@@ -1257,8 +1250,8 @@ def test_distributions_cpt_fit():
 		['C', 'C', 'C', 0.75]])
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_nan_fit():
+def test_distributions_cpt_nan_fit(cpt):
+	monty, X, X_nan = cpt
 	monty.fit(X_nan)
 
 	assert_array_equal(monty.parameters[0],
@@ -1291,8 +1284,8 @@ def test_distributions_cpt_nan_fit():
 		['C', 'C', 'C', 1.0]])
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_exclusive_nan_fit():
+def test_distributions_cpt_exclusive_nan_fit(cpt):
+	monty, X, X_nan = cpt
 	X = [['nan', 'nan', 'nan'],
 		 ['nan', 'nan', 'nan'],
 		 ['nan', 'nan', 'nan'],
@@ -1331,8 +1324,8 @@ def test_distributions_cpt_exclusive_nan_fit():
 		 ['C', 'C', 'C', 0.0]])
 
 
-@with_setup(setup_cpt)
-def test_distributions_cpt_weighted_fit():
+def test_distributions_cpt_weighted_fit(cpt):
+	monty, X, X_nan = cpt
 	weights = [1, 3, 2, 3, 7, 4, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 1, 2, 1, 3, 1,
 		1, 1, 2, 1, 1, 1, 3, 1, 1, 1]
 
@@ -1400,11 +1393,12 @@ def test_distributions_mgd_random_sample():
 	d = MultivariateGaussianDistribution(mu, cov)
 
 	x = numpy.array([[5.441227, 0.66913 ],
-			         [7.430771, 0.747908],
-			         [5.10961 , 2.582481]])
+					 [7.430771, 0.747908],
+					 [5.10961 , 2.582481]])
 
 	assert_array_almost_equal(d.sample(3, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 
 def test_distributions_independent_random_sample():
@@ -1418,7 +1412,8 @@ def test_distributions_independent_random_sample():
 					 [9.861542, 2.067192, 0.033083, 2.644041]])
 
 	assert_array_almost_equal(d.sample(3, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, d.sample(5), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(d.sample(5), x)
 
 def test_cpd_sampling():
 	d1 = DiscreteDistribution({"A": 0.1, "B": 0.9})
@@ -1458,12 +1453,13 @@ def test_distributions_cpt_random_sample():
 		[["A", "A", 0.1], ["A", "B", 0.9], ["B", "A", 0.7], ["B", "B", 0.3]],
 		[d1])
 
-    # Not true with actual seed
+	# Not true with actual seed
 	# x = numpy.array(['B', 'A', 'B', 'B', 'A', 'B', 'A', 'A', 'B', 'A', 'A', 
-	# 	'B', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A'])
+	#	'B', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A'])
 
 	x = numpy.array(['B', 'A', 'B', 'A', 'A', 'B', 'A', 'A', 'A', 'A', 'B', 'A', 'A',
-           'B', 'A', 'A', 'A', 'A', 'A', 'A'])
+		   'B', 'A', 'A', 'A', 'A', 'A', 'A'])
 
 	assert_array_equal(d.sample(n=20, random_state=5), x)
-	assert_raises(AssertionError, assert_array_equal, d.sample(n=10), x)
+	with pytest.raises(AssertionError):
+		assert_array_equal(d.sample(n=10), x)

--- a/tests/test_factor_graphs.py
+++ b/tests/test_factor_graphs.py
@@ -1,19 +1,5 @@
 from pomegranate import *
 
-from nose.tools import assert_equal
-
-def setup():
-    '''
-    No setup or teardown needs to be done in this case.
-    '''
-    pass
-
-
-def teardown():
-    '''
-    No setup or teardown needs to be done in this case.
-    '''
-    pass
 
 def test_json():
     d1 = DiscreteDistribution({"A": 0.1, "B": 0.9})
@@ -28,11 +14,11 @@ def test_json():
     bayes_net.bake()
     fg = bayes_net.graph
     also_fg = FactorGraph.from_json(fg.to_json())
-    assert_equal(fg.to_json(), also_fg.to_json())
-    assert_equal(len(fg.edges), len(also_fg.edges))
+    assert fg.to_json() == also_fg.to_json()
+    assert len(fg.edges) == len(also_fg.edges)
     for e1, e2 in zip(fg.edges, also_fg.edges):
-        assert_equal(e1[0], e2[0])
-        assert_equal(e1[1], e2[1])
+        assert e1[0] == e2[0]
+        assert e1[1] == e2[1]
 
 def test_robust_json():
     d1 = DiscreteDistribution({"A": 0.1, "B": 0.9})
@@ -47,8 +33,8 @@ def test_robust_json():
     bayes_net.bake()
     fg = bayes_net.graph
     also_fg = from_json(fg.to_json())
-    assert_equal(fg.to_json(), also_fg.to_json())
-    assert_equal(len(fg.edges), len(also_fg.edges))
+    assert fg.to_json() == also_fg.to_json()
+    assert len(fg.edges) == len(also_fg.edges)
     for e1, e2 in zip(fg.edges, also_fg.edges):
-        assert_equal(e1[0], e2[0])
-        assert_equal(e1[1], e2[1])
+        assert e1[0] == e2[0]
+        assert e1[1] == e2[1]

--- a/tests/test_gmm.py
+++ b/tests/test_gmm.py
@@ -2,12 +2,6 @@ from pomegranate import *
 from pomegranate.io import DataGenerator
 from pomegranate.io import DataFrameGenerator
 
-from nose.tools import with_setup
-from nose.tools import assert_true
-from nose.tools import assert_equal
-from nose.tools import assert_greater
-from nose.tools import assert_raises
-from nose.tools import assert_not_equal
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_array_almost_equal
@@ -16,91 +10,94 @@ import pandas
 import random
 import pickle
 import numpy as np
+import pytest
 
 np.random.seed(0)
 random.seed(0)
 
-nan = numpy.nan
+nan = np.nan
 
 def setup_nothing():
 	pass
 
-def setup_multivariate_gaussian():
+
+@pytest.fixture
+def multivariate_gaussian():
 	"""
 	Set up a five component Gaussian mixture model, where each component
 	is a multivariate Gaussian distribution.
 	"""
-
-	global gmm
-
+	
 	mu = np.arange(5)
 	cov = np.eye(5)
-
+	
 	mgs = [MultivariateGaussianDistribution(mu*i, cov) for i in range(5)]
 	gmm = GeneralMixtureModel(mgs)
+	return gmm
 
 
-def setup_multivariate_mixed():
+@pytest.fixture
+def multivariate_mixed():
 	d11 = NormalDistribution(1, 1)
 	d12 = ExponentialDistribution(5)
 	d13 = LogNormalDistribution(0.5, 0.78)
 	d14 = NormalDistribution(0.4, 0.8)
 	d15 = PoissonDistribution(4)
 	d1 = IndependentComponentsDistribution([d11, d12, d13, d14, d15])
-
+	
 	d21 = NormalDistribution(3, 1)
 	d22 = ExponentialDistribution(35)
 	d23 = LogNormalDistribution(1.8, 1.33)
 	d24 = NormalDistribution(0.5, 0.7)
 	d25 = PoissonDistribution(6)
 	d2 = IndependentComponentsDistribution([d21, d22, d23, d24, d25])
-
-	global gmm
+	
 	gmm = GeneralMixtureModel([d1, d2])
+	return gmm
 
 
-def setup_univariate_gaussian():
+@pytest.fixture
+def univariate_gaussian():
 	"""
 	Set up a three component univariate Gaussian model.
 	"""
 
-	global gmm
 	gmm = GeneralMixtureModel([NormalDistribution(i*3, 1) for i in range(3)])
+	return gmm
 
-
-def setup_univariate_mixed():
+@pytest.fixture
+def univariate_mixed():
 	"""Set up a four component univariate mixed model."""
 
-	global gmm
 	d1 = ExponentialDistribution(5)
 	d2 = NormalDistribution(0, 1.2)
 	d3 = LogNormalDistribution(0.3, 1.4)
 	d4 = PoissonDistribution(5)
 	gmm = GeneralMixtureModel([d1, d2, d3, d4])
+	return gmm
 
 
-def setup_multivariate_discrete():
+@pytest.fixture
+def multivariate_discrete():
 	d1 = IndependentComponentsDistribution([DiscreteDistribution({'A':0.5, 'B':0.5}), 
-	                                        DiscreteDistribution({'0':0.2, '1':0.2, '2':0.2, '3':0.4})])
+											DiscreteDistribution({'0':0.2, '1':0.2, '2':0.2, '3':0.4})])
 	d2 = IndependentComponentsDistribution([DiscreteDistribution({'A':0.1, 'B':0.9}), 
-	                                        DiscreteDistribution({'0':0.1, '1':0.6, '2':0.1, '3':0.2})])
+											DiscreteDistribution({'0':0.1, '1':0.6, '2':0.1, '3':0.2})])
 
-
-	global gmm
 	gmm = GeneralMixtureModel([d1, d2], weights=np.array([0.4,0.6]))
+	return gmm
 
 
-def setup_multivariate_mixed_discrete_other():
+@pytest.fixture
+def multivariate_mixed_discrete_other():
 	d1 = IndependentComponentsDistribution([PoissonDistribution(4.0),
-	                                        DiscreteDistribution({'A':0.5, 'B':0.5}), 
-	                                        DiscreteDistribution({'0':0.2, '1':0.2, '2':0.2, '3':0.4})])
+											DiscreteDistribution({'A':0.5, 'B':0.5}), 
+											DiscreteDistribution({'0':0.2, '1':0.2, '2':0.2, '3':0.4})])
 	d2 = IndependentComponentsDistribution([PoissonDistribution(1.0),
-	                                        DiscreteDistribution({'A':0.1, 'B':0.9}), 
-	                                        DiscreteDistribution({'0':0.1, '1':0.6, '2':0.1, '3':0.2})])
-
-
-	global gmm
+											DiscreteDistribution({'A':0.1, 'B':0.9}), 
+											DiscreteDistribution({'0':0.1, '1':0.6, '2':0.1, '3':0.2})])
 	gmm = GeneralMixtureModel([d1, d2], weights=np.array([0.4,0.6]))
+	return gmm
 
 def teardown():
 	"""
@@ -110,8 +107,8 @@ def teardown():
 	pass
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_log_probability():
+def test_gmm_multivariate_gaussian_log_probability(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
 					[1.8, 2.1, 3.1, 5.2, 6.5],
 					[0.9, 2.2, 3.2, 5.0, 5.8],
@@ -128,8 +125,8 @@ def test_gmm_multivariate_gaussian_log_probability():
 	assert_array_almost_equal(logp, logp_t)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_log_probability():
+def test_gmm_multivariate_mixed_log_probability(multivariate_mixed):
+	gmm = multivariate_mixed
 	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
 					[1.8, 2.1, 3.1, 5.2, 6.5],
 					[0.9, 2.2, 3.2, 5.0, 5.8],
@@ -146,8 +143,8 @@ def test_gmm_multivariate_mixed_log_probability():
 	assert_array_almost_equal(logp, logp_t)
 
 
-@with_setup(setup_univariate_gaussian, teardown)
-def test_gmm_univariate_gaussian_log_probability():
+def test_gmm_univariate_gaussian_log_probability(univariate_gaussian):
+	gmm = univariate_gaussian
 	X = np.array([[1.1], [2.7], [3.0], [4.8], [6.2]])
 	logp = [-2.35925975, -2.03120691, -1.99557605, -2.39638244, -2.03147258]
 	assert_array_almost_equal(gmm.log_probability(X), logp)
@@ -197,8 +194,8 @@ def test_gmm_univariate_gaussian_log_probability():
 	assert_array_almost_equal(gmm.log_probability(X, batch_size=2), logp)
 
 
-@with_setup(setup_univariate_mixed, teardown)
-def test_gmm_mixed_log_probability():
+def test_gmm_mixed_log_probability(univariate_mixed):
+	gmm = univariate_mixed
 	X = np.array([[1.1], [2.7], [3.0], [4.8], [6.2]])
 	logp = [-2.01561437061559, -2.7951359521294536, -2.8314639809821918,
 			-2.9108132001193265, -3.1959940375620945]
@@ -256,8 +253,8 @@ def test_gmm_mixed_log_probability():
 	assert_array_almost_equal(gmm.log_probability(X, batch_size=2), logp)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_json():
+def test_gmm_multivariate_gaussian_json(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	gmm_2 = GeneralMixtureModel.from_json(gmm.to_json())
 
 	X = np.array([[1.1, 2.7, 3.0, 4.8, 6.2]])
@@ -285,8 +282,8 @@ def test_gmm_multivariate_gaussian_json():
 	assert_almost_equal(gmm_2.log_probability(X).sum(), -10.7922, 4)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_json():
+def test_gmm_multivariate_mixed_json(multivariate_mixed):
+	gmm = multivariate_mixed
 	gmm2 = GeneralMixtureModel.from_json(gmm.to_json())
 
 	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
@@ -307,8 +304,8 @@ def test_gmm_multivariate_mixed_json():
 	assert_array_almost_equal(logp1, logp2)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_robust_from_json():
+def test_gmm_multivariate_gaussian_robust_from_json(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	gmm_2 = from_json(gmm.to_json())
 
 	X = np.array([[1.1, 2.7, 3.0, 4.8, 6.2]])
@@ -336,8 +333,8 @@ def test_gmm_multivariate_gaussian_robust_from_json():
 	assert_almost_equal(gmm_2.log_probability(X).sum(), -10.7922, 4)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_robust_from_json():
+def test_gmm_multivariate_mixed_robust_from_json(multivariate_mixed):
+	gmm = multivariate_mixed
 	gmm2 = from_json(gmm.to_json())
 
 	X = numpy.array([[1.1, 2.7, 3.0, 4.8, 6.2],
@@ -358,22 +355,22 @@ def test_gmm_multivariate_mixed_robust_from_json():
 	assert_array_almost_equal(logp1, logp2)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_predict_log_proba():
+def test_gmm_multivariate_gaussian_predict_log_proba(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	posterior = np.array([[-2.10001234e+01, -1.23402948e-04, -9.00012340e+00, -4.80001234e+01, -1.17000123e+02],
-                          [-2.30009115e+01, -9.11466556e-04, -7.00091147e+00, -4.40009115e+01, -1.11000911e+02]])
+						  [-2.30009115e+01, -9.11466556e-04, -7.00091147e+00, -4.40009115e+01, -1.11000911e+02]])
 
 	X = np.array([[2., 5., 7., 3., 2.],
-		          [1., 2., 5., 2., 5.]])
+				  [1., 2., 5., 2., 5.]])
 
 	assert_almost_equal(gmm.predict_log_proba(X), posterior, 4)
 	assert_almost_equal(numpy.exp(gmm.predict_log_proba(X)), gmm.predict_proba(X), 4)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_predict():
+def test_gmm_multivariate_gaussian_predict(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	X = np.array([[2., 5., 7., 3., 2.],
-		          [1., 2., 5., 2., 5.],
+				  [1., 2., 5., 2., 5.],
 				  [2., 1., 8., 2., 1.],
 				  [4., 3., 8., 1., 2.]])
 
@@ -389,13 +386,13 @@ def test_gmm_multivariate_gaussian_fit():
 	gmm = GeneralMixtureModel([d1, d2])
 
 	X = np.array([[0.1,  0.7],
-		          [1.8,  2.1],
-		          [-0.9, -1.2],
-		          [-0.0,  0.2],
-		          [1.4,  2.9],
-		          [1.8,  2.5],
-		          [1.4,  3.1],
-		          [1.0,  1.0]])
+				  [1.8,  2.1],
+				  [-0.9, -1.2],
+				  [-0.0,  0.2],
+				  [1.4,  2.9],
+				  [1.8,  2.5],
+				  [1.4,  3.1],
+				  [1.0,  1.0]])
 
 	_, history = gmm.fit(X, return_history=True)
 	total_improvement = history.total_improvement[-1]
@@ -403,8 +400,8 @@ def test_gmm_multivariate_gaussian_fit():
 	assert_almost_equal(total_improvement, 15.242416, 4)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_fit_iterations():
+def test_gmm_multivariate_gaussian_fit_iterations(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	numpy.random.seed(0)
 	X = numpy.concatenate([numpy.random.normal(i, 1, size=(100, 5)) for i in range(2)])
 
@@ -422,12 +419,12 @@ def test_gmm_multivariate_gaussian_fit_iterations():
 	logp2 = gmm2.log_probability(X).sum()
 	logp3 = gmm3.log_probability(X).sum()
 
-	assert_greater(logp1, logp2)
-	assert_equal(logp2, logp3)
+	assert logp1 > logp2
+	assert logp2 == logp3
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_fit_iterations():
+def test_gmm_multivariate_mixed_fit_iterations(multivariate_mixed):
+	gmm = multivariate_mixed
 	numpy.random.seed(0)
 	X = numpy.concatenate([numpy.random.normal(i, 1, size=(100, 5)) for i in range(2)])
 	X = numpy.abs(X)
@@ -443,16 +440,20 @@ def test_gmm_multivariate_mixed_fit_iterations():
 	logp2 = gmm2.log_probability(X).sum()
 	logp3 = gmm3.log_probability(X).sum()
 
-	assert_raises(AssertionError, assert_equal, logp1, logp2)
-	assert_equal(logp2, logp2)
-	assert_greater(logp1, logp2)
+	with pytest.raises(AssertionError):
+		assert logp1 == logp2
+	assert logp2 == logp2
+	assert logp1 > logp2
 
 
 def test_gmm_initialization():
-	assert_raises(ValueError, GeneralMixtureModel, [])
+	with pytest.raises(ValueError):
+		GeneralMixtureModel([])
 
-	assert_raises(TypeError, GeneralMixtureModel, [NormalDistribution(5, 2), MultivariateGaussianDistribution([5, 2], [[1, 0], [0, 1]])])
-	assert_raises(TypeError, GeneralMixtureModel, [NormalDistribution(5, 2), NormalDistribution])
+	with pytest.raises(TypeError):
+		GeneralMixtureModel([NormalDistribution(5, 2), MultivariateGaussianDistribution([5, 2], [[1, 0], [0, 1]])])
+	with pytest.raises(TypeError):
+		GeneralMixtureModel([NormalDistribution(5, 2), NormalDistribution])
 
 	X = numpy.concatenate((numpy.random.randn(300, 5) + 0.5, numpy.random.randn(200, 5)))
 
@@ -460,97 +461,72 @@ def test_gmm_initialization():
 
 	gmm1 = GeneralMixtureModel.from_samples(MGD, 2, X, init='first-k')
 	gmm2 = GeneralMixtureModel.from_samples(MGD, 2, X, init='first-k', max_iterations=1)
-	assert_greater(gmm1.log_probability(X).sum(), gmm2.log_probability(X).sum())
+	assert gmm1.log_probability(X).sum() > gmm2.log_probability(X).sum()
 
-	assert_equal(gmm1.d, 5)
-	assert_equal(gmm2.d, 5)
+	assert gmm1.d == 5
+	assert gmm2.d == 5
 
 
 def test_gmm_multivariate_discrete_initialization():
 	d1 = IndependentComponentsDistribution([DiscreteDistribution({'A' : 0.5, 'B' : 0.5}), 
-                                            DiscreteDistribution({'0' : 0.2, '1' : 0.2, '2' : 0.2, '3' : 0.4})])
+											DiscreteDistribution({'0' : 0.2, '1' : 0.2, '2' : 0.2, '3' : 0.4})])
 	d2 = IndependentComponentsDistribution([DiscreteDistribution({'A' : 0.1, 'B' : 0.9}), 
-                                            DiscreteDistribution({'0' : 0.1, '1' : 0.6, '2' : 0.1, '3' : 0.2})])
+											DiscreteDistribution({'0' : 0.1, '1' : 0.6, '2' : 0.1, '3' : 0.2})])
 
 	GeneralMixtureModel([d1, d2], weights=np.array([0.4,0.6]))
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_dimension():
+def test_gmm_dimension(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	gmm1 = GeneralMixtureModel([NormalDistribution(0, 1), UniformDistribution(0, 10)])
 
-	assert_equal(gmm.d, 5)
-	assert_equal(gmm1.d, 1)
+	assert gmm.d == 5
+	assert gmm1.d == 1
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_json():
+def test_gmm_json(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	univariate = GeneralMixtureModel([NormalDistribution(5, 2), UniformDistribution(0, 10)])
 
 	j_univ = univariate.to_json()
 	j_multi = gmm.to_json()
 
 	new_univ = univariate.from_json(j_univ)
-	assert_true(isinstance(new_univ.distributions[0], NormalDistribution))
-	assert_true(isinstance(new_univ.distributions[1], UniformDistribution))
-	assert_true(isinstance(new_univ, GeneralMixtureModel))
+	assert isinstance(new_univ.distributions[0], NormalDistribution)
+	assert isinstance(new_univ.distributions[1], UniformDistribution)
+	assert isinstance(new_univ, GeneralMixtureModel)
 	assert_array_equal(univariate.weights, new_univ.weights)
 
 	new_multi = gmm.from_json(j_multi)
 	for i in range(5):
-		assert_true(isinstance(new_multi.distributions[i], MultivariateGaussianDistribution))
+		assert isinstance(new_multi.distributions[i], MultivariateGaussianDistribution)
 
-	assert_true(isinstance(new_multi, GeneralMixtureModel))
+	assert isinstance(new_multi, GeneralMixtureModel)
 	assert_array_almost_equal(gmm.weights, new_multi.weights)
 
 
 def test_gmm_univariate_pickling():
 	univariate = GeneralMixtureModel(
 		[NormalDistribution(5, 2), UniformDistribution(0, 10)],
-        weights=np.array([1.0, 2.0]))
+		weights=np.array([1.0, 2.0]))
 
 	j_univ = pickle.dumps(univariate)
 
 	new_univ = pickle.loads(j_univ)
-	assert_true(isinstance(new_univ.distributions[0], NormalDistribution))
-	assert_true(isinstance(new_univ.distributions[1], UniformDistribution))
-	assert_true(isinstance(new_univ, GeneralMixtureModel))
+	assert isinstance(new_univ.distributions[0], NormalDistribution)
+	assert isinstance(new_univ.distributions[1], UniformDistribution)
+	assert isinstance(new_univ, GeneralMixtureModel)
 	assert_array_equal(univariate.weights, new_univ.weights)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_pickling():
+def test_gmm_multivariate_gaussian_pickling(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	gmm2 = pickle.loads(pickle.dumps(gmm))
 
 	for d in gmm2.distributions:
-		assert_true(isinstance(d, MultivariateGaussianDistribution))
+		assert isinstance(d, MultivariateGaussianDistribution)
 
-	assert_true(isinstance(gmm2, GeneralMixtureModel))
+	assert isinstance(gmm2, GeneralMixtureModel)
 	assert_array_almost_equal(gmm.weights, gmm2.weights)
-
-
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_gaussian_pickling():
-	gmm2 = pickle.loads(pickle.dumps(gmm))
-	d1 = gmm2.distributions[0]
-	d2 = gmm2.distributions[1]
-
-	assert_true(isinstance(d1, IndependentComponentsDistribution))
-	assert_true(isinstance(d2, IndependentComponentsDistribution))
-
-	assert_true(isinstance(d1.distributions[0], NormalDistribution))
-	assert_true(isinstance(d1.distributions[1], ExponentialDistribution))
-	assert_true(isinstance(d1.distributions[2], LogNormalDistribution))
-	assert_true(isinstance(d1.distributions[3], NormalDistribution))
-	assert_true(isinstance(d1.distributions[4], PoissonDistribution))
-
-	assert_true(isinstance(d2.distributions[0], NormalDistribution))
-	assert_true(isinstance(d2.distributions[1], ExponentialDistribution))
-	assert_true(isinstance(d2.distributions[2], LogNormalDistribution))
-	assert_true(isinstance(d2.distributions[3], NormalDistribution))
-	assert_true(isinstance(d2.distributions[4], PoissonDistribution))
-
-	assert_true(isinstance(gmm2, GeneralMixtureModel))
-	assert_array_equal(gmm.weights, gmm2.weights)
 
 
 def test_gmm_multivariate_gaussian_ooc():
@@ -567,7 +543,7 @@ def test_gmm_multivariate_gaussian_ooc():
 
 	assert_almost_equal(gmm.log_probability(X).sum(), gmm2.log_probability(X).sum())
 	assert_almost_equal(gmm.log_probability(X).sum(), gmm3.log_probability(X).sum(), -2)
-	assert_not_equal(gmm.log_probability(X).sum(), gmm4.log_probability(X).sum())
+	assert gmm.log_probability(X).sum() != gmm4.log_probability(X).sum()
 
 
 def test_gmm_multivariate_mixed_ooc():
@@ -585,7 +561,7 @@ def test_gmm_multivariate_mixed_ooc():
 		batch_size=500, batches_per_epoch=2)
 
 	assert_almost_equal(gmm.log_probability(X).sum(), gmm2.log_probability(X).sum())
-	assert_not_equal(gmm.log_probability(X).sum(), gmm4.log_probability(X).sum())
+	assert gmm.log_probability(X).sum() != gmm4.log_probability(X).sum()
 
 
 def test_gmm_multivariate_gaussian_minibatch():
@@ -600,10 +576,10 @@ def test_gmm_multivariate_gaussian_minibatch():
 	gmm4 = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution,
 		3, X, init='first-k', max_iterations=5, batch_size=3000, batches_per_epoch=1)
 
-	assert_not_equal(gmm.log_probability(X).sum(), gmm2.log_probability(X).sum())
-	assert_not_equal(gmm2.log_probability(X).sum(), gmm3.log_probability(X).sum())
-	assert_raises(AssertionError, assert_array_almost_equal, gmm3.log_probability(X),
-		gmm.log_probability(X))
+	assert gmm.log_probability(X).sum() != gmm2.log_probability(X).sum()
+	assert gmm2.log_probability(X).sum() != gmm3.log_probability(X).sum()
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(gmm3.log_probability(X), gmm.log_probability(X))
 
 	assert_array_equal(gmm.log_probability(X), gmm4.log_probability(X))
 
@@ -622,10 +598,10 @@ def test_gmm_multivariate_mixed_minibatch():
 	gmm4 = GeneralMixtureModel.from_samples(d, 3, X, init='first-k', max_iterations=5,
 		batch_size=3000, batches_per_epoch=1)
 
-	assert_not_equal(gmm.log_probability(X).sum(), gmm2.log_probability(X).sum())
-	assert_not_equal(gmm2.log_probability(X).sum(), gmm3.log_probability(X).sum())
-	assert_raises(AssertionError, assert_array_almost_equal, gmm3.log_probability(X),
-		gmm.log_probability(X))
+	assert gmm.log_probability(X).sum() != gmm2.log_probability(X).sum()
+	assert gmm2.log_probability(X).sum() != gmm3.log_probability(X).sum()
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(gmm3.log_probability(X), gmm.log_probability(X))
 
 	assert_array_equal(gmm.log_probability(X), gmm4.log_probability(X))
 
@@ -643,13 +619,13 @@ def test_gmm_multivariate_gaussian_nan_from_samples():
 
 	mu1t = [-0.036813615311095164, 0.05802948506749107, 0.09725454186262805]
 	cov1t = [[ 1.02529437, -0.11391075,  0.03146951],
- 		  	[-0.11391075,  1.03553592, -0.07852064],
- 		 	[ 0.03146951, -0.07852064,  0.83874547]]
+			[-0.11391075,  1.03553592, -0.07852064],
+			[ 0.03146951, -0.07852064,	0.83874547]]
 
 	mu2t = [8.088079704231793, 7.927924504375215, 8.000474719123183]
 	cov2t = [[ 0.95559825, -0.02582016,  0.07491681],
- 			[-0.02582016,  0.99427793,  0.03304442],
- 			[ 0.07491681,  0.03304442,  1.15403456]]
+			[-0.02582016,  0.99427793,	0.03304442],
+			[ 0.07491681,  0.03304442,	1.15403456]]
 
 	for init in 'first-k', 'random', 'kmeans++':
 		model = GeneralMixtureModel.from_samples(MultivariateGaussianDistribution, 2,
@@ -717,17 +693,17 @@ def test_gmm_multivariate_gaussian_nan_fit():
 	mu1t = [-0.003165176330948316, 0.07462401273020161, 0.04001352280548061]
 	cov1t = [[ 0.98556769, -0.10062447,  0.08213565],
 				[-0.10062447,  1.06955989, -0.03085883],
-				[ 0.08213565, -0.03085883,  0.89728992]]
+				[ 0.08213565, -0.03085883,	0.89728992]]
 
 	mu2t = [2.601485766170187, 2.48231424824341, 2.52771758325412]
 	cov2t = [[ 0.94263451, -0.00361101, -0.02668448],
-	 		[-0.00361101,  1.06339061, -0.00408865],
+			[-0.00361101,  1.06339061, -0.00408865],
 			 [-0.02668448, -0.00408865,  1.14789789]]
 
 	mu3t = [5.950490843670593, 5.9572969419328725, 6.025950220056731]
-	cov3t = [[ 1.03991941, -0.0232587,  -0.02457755],
+	cov3t = [[ 1.03991941, -0.0232587,	-0.02457755],
 				[-0.0232587,   1.01047466, -0.04948464],
-				[-0.02457755, -0.04948464,  0.85671553]]
+				[-0.02457755, -0.04948464,	0.85671553]]
 
 	mu1 = model.distributions[0].parameters[0]
 	cov1 = model.distributions[0].parameters[1]
@@ -746,8 +722,8 @@ def test_gmm_multivariate_gaussian_nan_fit():
 	assert_array_almost_equal(cov3, cov3t)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_nan_fit():
+def test_gmm_multivariate_mixed_nan_fit(multivariate_mixed):
+	gmm = multivariate_mixed
 
 	numpy.random.seed(1)
 	X = numpy.concatenate([numpy.random.normal(0, 1, size=(300, 5)),
@@ -770,8 +746,8 @@ def test_gmm_multivariate_mixed_nan_fit():
 		assert_almost_equal(d2.parameters[0], p2[i], 4)
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_nan_log_probability():
+def test_gmm_multivariate_gaussian_nan_log_probability(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	numpy.random.seed(1)
 
 	X = numpy.concatenate([numpy.random.normal(0, 1, size=(5, 5)),
@@ -784,8 +760,8 @@ def test_gmm_multivariate_gaussian_nan_log_probability():
 
 	logp_t = [ -7.73923053e+00,  -7.81725880e+00,  -4.55182482e+00,  -2.45359578e+01,
 			   -8.01289941e+00,  -1.08630517e+01,  -3.10356303e+00,  -3.06193233e+01,
- 			   -5.46424483e+00,  -1.84952128e+01,  -3.15420910e+01,  -1.01635415e+01,
-  			    1.66533454e-16,  -2.70671185e+00,  -5.69860159e+00]
+			   -5.46424483e+00,  -1.84952128e+01,  -3.15420910e+01,  -1.01635415e+01,
+				1.66533454e-16,  -2.70671185e+00,  -5.69860159e+00]
 
 	logp = gmm.log_probability(X)
 	logp2 = gmm.log_probability(X, n_jobs=2)
@@ -796,25 +772,25 @@ def test_gmm_multivariate_gaussian_nan_log_probability():
 	assert_array_almost_equal(logp4, logp_t)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_nan_log_probability():
-	X = numpy.array([[ 1.014,   nan, 1.076, 1.012,   nan],
-		 [ 0.745,   nan,   nan,   nan, 1.226],
-		 [ 0.012,   nan,   nan, 0.010, 0.006],
-		 [   nan,   nan, 0.979, 1.031,   nan],
-		 [ 0.006, 0.003,   nan, 0.006,   nan],
-		 [   nan,   nan,   nan,   nan, 1.041],
+def test_gmm_multivariate_mixed_nan_log_probability(multivariate_mixed):
+	gmm = multivariate_mixed
+	X = numpy.array([[ 1.014,	nan, 1.076, 1.012,	 nan],
+		 [ 0.745,	nan,   nan,   nan, 1.226],
+		 [ 0.012,	nan,   nan, 0.010, 0.006],
+		 [	 nan,	nan, 0.979, 1.031,	 nan],
+		 [ 0.006, 0.003,   nan, 0.006,	 nan],
+		 [	 nan,	nan,   nan,   nan, 1.041],
 		 [ 1.176, 1.040, 1.098, 1.224, 1.186],
-		 [   nan, 0.004,   nan,   nan, 0.005],
-		 [   nan,   nan,   nan, 0.025,   nan],
-		 [ 0.0116,  nan, 0.022, 0.006,   nan]])
+		 [	 nan, 0.004,   nan,   nan, 0.005],
+		 [	 nan,	nan,   nan, 0.025,	 nan],
+		 [ 0.0116,	nan, 0.022, 0.006,	 nan]])
 
 	logp = gmm.log_probability(X)
 	logp2 = gmm.log_probability(X, n_jobs=2)
 	logp4 = gmm.log_probability(X, n_jobs=4)
 
 	logp_t = [ -3.447266,  -4.038374,  -6.900469,  -2.282948,  -1.216055,
-        -3.080241,  -9.789394,  -2.4831  ,  -0.799054, -13.052867]
+		-3.080241,	-9.789394,	-2.4831  ,	-0.799054, -13.052867]
 
 	assert_array_almost_equal(logp, logp_t)
 	assert_array_almost_equal(logp2, logp_t)
@@ -836,15 +812,15 @@ def test_gmm_multivariate_gaussian_nan_fit_predict():
 			X_nan, init=init, n_init=1)
 
 		for d in model.distributions:
-			assert_equal(numpy.isnan(d.parameters[0]).sum(), 0)
-			assert_equal(numpy.isnan(d.parameters[1]).sum(), 0)
+			assert numpy.isnan(d.parameters[0]).sum() == 0
+			assert numpy.isnan(d.parameters[1]).sum() == 0
 
 		y_hat = model.predict(X)
-		assert_equal(y_hat.sum(), 300)
+		assert y_hat.sum() == 300
 
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_nan_predict():
+def test_gmm_multivariate_gaussian_nan_predict(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	numpy.random.seed(0)
 	X = numpy.concatenate([numpy.random.normal(0, 1, size=(5, 5)),
 						   numpy.random.normal(2, 1, size=(5, 5))])
@@ -858,31 +834,31 @@ def test_gmm_multivariate_gaussian_nan_predict():
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_nan_predict():
-	X = [[ 1.014,   nan, 1.076, 1.012,   nan],
-		 [ 0.745,   nan,   nan,   nan, 1.226],
-		 [ 0.012,   nan,   nan, 0.010, 0.006],
-		 [   nan,   nan, 0.979, 1.031,   nan],
-		 [ 0.006, 0.003,   nan, 0.006,   nan],
-		 [   nan,   nan,   nan,   nan, 1.041],
+def test_gmm_multivariate_mixed_nan_predict(multivariate_mixed):
+	gmm = multivariate_mixed
+	X = [[ 1.014,	nan, 1.076, 1.012,	 nan],
+		 [ 0.745,	nan,   nan,   nan, 1.226],
+		 [ 0.012,	nan,   nan, 0.010, 0.006],
+		 [	 nan,	nan, 0.979, 1.031,	 nan],
+		 [ 0.006, 0.003,   nan, 0.006,	 nan],
+		 [	 nan,	nan,   nan,   nan, 1.041],
 		 [ 1.176, 1.040, 1.098, 1.224, 1.186],
-		 [   nan, 0.004,   nan,   nan, 0.005],
-		 [   nan,   nan,   nan, 0.025,   nan],
-		 [ 0.0116,  nan, 0.022, 0.006,   nan]]
+		 [	 nan, 0.004,   nan,   nan, 0.005],
+		 [	 nan,	nan,   nan, 0.025,	 nan],
+		 [ 0.0116,	nan, 0.022, 0.006,	 nan]]
 
 	y_hat = gmm.predict(X)
 	y = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_multivariate_discrete)
-def test_gmm_multivariate_discrete_predict_proba():
+def test_gmm_multivariate_discrete_predict_proba(multivariate_discrete):
+	gmm = multivariate_discrete
 	probs = gmm.predict_proba(numpy.array([['A', '0'], ['B', '1']]))
 	assert_almost_equal(probs, [[0.86956522, 0.13043478], [0.10989011, 0.89010989]])
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_gaussian_nan_predict_proba():
+def test_gmm_multivariate_gaussian_nan_predict_proba(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	numpy.random.seed(0)
 	X = numpy.concatenate([numpy.random.normal(0, 1, size=(5, 5)),
 						   numpy.random.normal(2, 1, size=(5, 5))])
@@ -892,44 +868,44 @@ def test_gmm_multivariate_gaussian_nan_predict_proba():
 	X[i, j] = numpy.nan
 
 	y_hat = gmm.predict_proba(X)
-	y = [[  9.90174494e-01, 9.82550625e-03, 2.20378830e-10, 1.11726590e-23, 1.28030945e-42],
-		 [  2.53691739e-01, 7.46308013e-01, 2.47068952e-07, 9.20463413e-21, 3.85907464e-41],
-		 [  9.97082301e-01, 2.91769906e-03, 1.18573581e-16, 6.69226809e-41, 5.24561818e-76],
-		 [  9.94236788e-01, 5.76321240e-03, 7.55111628e-11, 2.23629671e-24, 1.49699183e-43],
-		 [  9.56664759e-01, 4.33351517e-02, 8.91201785e-08, 8.32083585e-18, 3.52706158e-32],
-		 [  9.98269488e-01, 1.73051193e-03, 3.37590087e-13, 7.41127732e-30, 1.83098477e-53],
-		 [  1.75007605e-01, 8.24992395e-01, 3.63922167e-13, 1.50221681e-38, 5.80259513e-77],
-		 [  8.76384248e-01, 1.23615751e-01, 7.21849843e-10, 1.74507352e-25, 1.74652336e-48],
-		 [  2.12508922e-03, 9.45913785e-01, 5.19607732e-02, 3.52248634e-07, 2.94694950e-16],
-		 [  8.63688760e-03, 9.91106040e-01, 2.57071963e-04, 1.50716583e-13, 1.99728068e-28]]
+	y = [[	9.90174494e-01, 9.82550625e-03, 2.20378830e-10, 1.11726590e-23, 1.28030945e-42],
+		 [	2.53691739e-01, 7.46308013e-01, 2.47068952e-07, 9.20463413e-21, 3.85907464e-41],
+		 [	9.97082301e-01, 2.91769906e-03, 1.18573581e-16, 6.69226809e-41, 5.24561818e-76],
+		 [	9.94236788e-01, 5.76321240e-03, 7.55111628e-11, 2.23629671e-24, 1.49699183e-43],
+		 [	9.56664759e-01, 4.33351517e-02, 8.91201785e-08, 8.32083585e-18, 3.52706158e-32],
+		 [	9.98269488e-01, 1.73051193e-03, 3.37590087e-13, 7.41127732e-30, 1.83098477e-53],
+		 [	1.75007605e-01, 8.24992395e-01, 3.63922167e-13, 1.50221681e-38, 5.80259513e-77],
+		 [	8.76384248e-01, 1.23615751e-01, 7.21849843e-10, 1.74507352e-25, 1.74652336e-48],
+		 [	2.12508922e-03, 9.45913785e-01, 5.19607732e-02, 3.52248634e-07, 2.94694950e-16],
+		 [	8.63688760e-03, 9.91106040e-01, 2.57071963e-04, 1.50716583e-13, 1.99728068e-28]]
 
 	assert_array_almost_equal(y, y_hat, 2)
 
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_nan_predict_proba():
-	X = [[ 1.014,   nan, 1.076, 1.012,   nan],
-		 [ 0.745,   nan,   nan,   nan, 1.226],
-		 [ 0.012,   nan,   nan, 0.010, 0.006],
-		 [   nan,   nan, 0.979, 1.031,   nan],
-		 [ 0.006, 0.003,   nan, 0.006,   nan],
-		 [   nan,   nan,   nan,   nan, 1.041],
+def test_gmm_multivariate_mixed_nan_predict_proba(multivariate_mixed):
+	gmm = multivariate_mixed
+	X = [[ 1.014,	nan, 1.076, 1.012,	 nan],
+		 [ 0.745,	nan,   nan,   nan, 1.226],
+		 [ 0.012,	nan,   nan, 0.010, 0.006],
+		 [	 nan,	nan, 0.979, 1.031,	 nan],
+		 [ 0.006, 0.003,   nan, 0.006,	 nan],
+		 [	 nan,	nan,   nan,   nan, 1.041],
 		 [ 1.176, 1.040, 1.098, 1.224, 1.186],
-		 [   nan, 0.004,   nan,   nan, 0.005],
-		 [   nan,   nan,   nan, 0.025,   nan],
-		 [ 0.0116,  nan, 0.022, 0.006,   nan]]
+		 [	 nan, 0.004,   nan,   nan, 0.005],
+		 [	 nan,	nan,   nan, 0.025,	 nan],
+		 [ 0.0116,	nan, 0.022, 0.006,	 nan]]
 
 	y_hat = gmm.predict_proba(X)
-	y = [[  9.54354263e-01,   4.56457374e-02],
-		 [  9.82240224e-01,   1.77597761e-02],
-		 [  9.97442611e-01,   2.55738927e-03],
-		 [  7.48577347e-01,   2.51422653e-01],
-		 [  8.93432925e-01,   1.06567075e-01],
-		 [  8.28908436e-01,   1.71091564e-01],
-		 [  1.00000000e+00,   2.78899961e-15],
-		 [  5.42909820e-01,   4.57090180e-01],
-		 [  4.96708777e-01,   5.03291223e-01],
-		 [  1.31011533e-01,   8.68988467e-01]]
+	y = [[	9.54354263e-01,   4.56457374e-02],
+		 [	9.82240224e-01,   1.77597761e-02],
+		 [	9.97442611e-01,   2.55738927e-03],
+		 [	7.48577347e-01,   2.51422653e-01],
+		 [	8.93432925e-01,   1.06567075e-01],
+		 [	8.28908436e-01,   1.71091564e-01],
+		 [	1.00000000e+00,   2.78899961e-15],
+		 [	5.42909820e-01,   4.57090180e-01],
+		 [	4.96708777e-01,   5.03291223e-01],
+		 [	1.31011533e-01,   8.68988467e-01]]
 
 	assert_array_almost_equal(y, y_hat)
 
@@ -1098,8 +1074,10 @@ def test_gmm_multivariate_gaussian_minibatch_nan_from_samples():
 	cov4 = model4.distributions[0].parameters[1]
 
 	assert_array_almost_equal(cov1, cov2)
-	assert_raises(AssertionError, assert_array_almost_equal, cov1, cov3)
-	assert_raises(AssertionError, assert_array_almost_equal, cov1, cov4)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(cov1, cov3)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(cov1, cov4)
 
 
 def test_gmm_multivariate_mixed_minibatch_nan_from_samples():
@@ -1127,8 +1105,10 @@ def test_gmm_multivariate_mixed_minibatch_nan_from_samples():
 	p4 = model4.distributions[0].distributions[0].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
-	assert_raises(AssertionError, assert_almost_equal, p1, p4)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p4)
 
 	p1 = model1.distributions[0].distributions[1].parameters[0]
 	p2 = model2.distributions[0].distributions[1].parameters[0]
@@ -1136,8 +1116,10 @@ def test_gmm_multivariate_mixed_minibatch_nan_from_samples():
 	p4 = model4.distributions[0].distributions[1].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
-	assert_raises(AssertionError, assert_almost_equal, p1, p4)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p4)
 
 	p1 = model1.distributions[0].distributions[2].parameters[0]
 	p2 = model2.distributions[0].distributions[2].parameters[0]
@@ -1145,8 +1127,10 @@ def test_gmm_multivariate_mixed_minibatch_nan_from_samples():
 	p4 = model4.distributions[0].distributions[2].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
-	assert_raises(AssertionError, assert_almost_equal, p1, p4)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p4)
 
 def test_gmm_multivariate_gaussian_minibatch_nan_fit():
 	X = numpy.concatenate([numpy.random.normal(i*3, 0.5, size=(100, 3)) for i in range(2)])
@@ -1176,7 +1160,8 @@ def test_gmm_multivariate_gaussian_minibatch_nan_fit():
 	cov3 = model3.distributions[0].parameters[1]
 
 	assert_array_almost_equal(cov1, cov2)
-	assert_raises(AssertionError, assert_array_equal, cov1, cov3)
+	with pytest.raises(AssertionError):
+		assert_array_equal(cov1, cov3)
 
 
 def test_gmm_multivariate_mixed_minibatch_nan_fit():
@@ -1210,43 +1195,48 @@ def test_gmm_multivariate_mixed_minibatch_nan_fit():
 	p3 = model3.distributions[0].distributions[0].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
 
 	p1 = model1.distributions[0].distributions[1].parameters[0]
 	p2 = model2.distributions[0].distributions[1].parameters[0]
 	p3 = model3.distributions[0].distributions[1].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
 
 	p1 = model1.distributions[0].distributions[2].parameters[0]
 	p2 = model2.distributions[0].distributions[2].parameters[0]
 	p3 = model3.distributions[0].distributions[2].parameters[0]
 
 	assert_almost_equal(p1, p2)
-	assert_raises(AssertionError, assert_almost_equal, p1, p3)
+	with pytest.raises(AssertionError):
+		assert_almost_equal(p1, p3)
 
-@with_setup(setup_multivariate_mixed, teardown)
-def test_gmm_multivariate_mixed_random_sample():
-	x = numpy.array([[ 4.61023781e+00,  2.68284944e-02,  5.15017758e+01,  1.62716647e+00, 5.00000000e+00],
-					 [ 1.97078941e+00,  1.02011059e-02,  1.53902626e+00, -2.20447410e-01, 4.00000000e+00],
-					 [-2.37630710e-01,  2.01296137e-02,  8.15899779e-02, -1.76634150e+00, 1.00000000e+01]])
+def test_gmm_multivariate_mixed_random_sample(multivariate_mixed):
+	gmm = multivariate_gaussian
+	x = numpy.array([[ 4.61023781e+00,	2.68284944e-02,  5.15017758e+01,  1.62716647e+00, 5.00000000e+00],
+					 [ 1.97078941e+00,	1.02011059e-02,  1.53902626e+00, -2.20447410e-01, 4.00000000e+00],
+					 [-2.37630710e-01,	2.01296137e-02,  8.15899779e-02, -1.76634150e+00, 1.00000000e+01]])
 
 	assert_array_almost_equal(gmm.sample(3, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, gmm.sample(3), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(gmm.sample(3), x)
 
-@with_setup(setup_multivariate_gaussian, teardown)
-def test_gmm_multivariate_mixed_random_sample():
+def test_gmm_multivariate_mixed_random_sample(multivariate_gaussian):
+	gmm = multivariate_gaussian
 	x = numpy.array([[-0.937128,  3.919795,  7.066424, 11.901844, 16.691532],
-			         [ 1.875753,  0.915462,  2.591164,  3.173006,  4.656439],
-			         [ 0.307347,  3.411364,  7.450107, 11.520762, 16.511734]])
+					 [ 1.875753,  0.915462,  2.591164,	3.173006,  4.656439],
+					 [ 0.307347,  3.411364,  7.450107, 11.520762, 16.511734]])
 
 	assert_array_almost_equal(gmm.sample(3, random_state=5), x)
-	assert_raises(AssertionError, assert_array_almost_equal, gmm.sample(3), x)
+	with pytest.raises(AssertionError):
+		assert_array_almost_equal(gmm.sample(3), x)
 
 
-@with_setup(setup_multivariate_mixed_discrete_other)
-def test_gmm_multivariate_mixed_discrete_other_fit():
+def test_gmm_multivariate_mixed_discrete_other_fit(multivariate_mixed_discrete_other):
+	gmm = multivariate_mixed_discrete_other
 	x = numpy.array(
 		[
 			[0, 'A', '0'],

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -1,23 +1,15 @@
 from __future__ import (division)
 
 from pomegranate import *
-from pomegranate.parallel import log_probability
 from pomegranate.io import SequenceGenerator
 
-from nose.tools import with_setup
-from nose.tools import assert_almost_equal
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
-from nose.tools import assert_less_equal
-from nose.tools import assert_raises
-from nose.tools import assert_greater
+from .assert_tools import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
-from numpy.testing import assert_array_equal
 
 import pickle
 import random
 import numpy
-import time
+import pytest
 
 numpy.random.seed(0)
 random.seed(0)
@@ -92,61 +84,60 @@ def sparse_model(d1, d2, d3, i_d):
     return model
 
 
-def setup():
-    global model
-
+@pytest.fixture
+def model():
     i_d = DiscreteDistribution({ 'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25 })
     d1 = DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 })
     d2 = DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 })
     d3 = DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 })
 
-    model = sparse_model(d1, d2, d3, i_d)
+    return sparse_model(d1, d2, d3, i_d)
 
 
-def setup_multivariate_discrete_sparse():
-    global model
-
+@pytest.fixture
+def multivariate_discrete_sparse():
     i1 = DiscreteDistribution({'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25})
     i2 = DiscreteDistribution({'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25})
     i_d = IndependentComponentsDistribution([i1, i2])
-
+    
     d11 = DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 })
     d12 = DiscreteDistribution({ "A": 0.92, 'C': 0.02, 'G': 0.02, 'T': 0.03 })
-
+    
     d21 = DiscreteDistribution({ "A": 0.005, 'C': 0.96, 'G': 0.005, 'T': 0.003 })
     d22 = DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 })
-
+    
     d31 = DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 })
     d32 = DiscreteDistribution({ "A": 0.05, 'C': 0.03, 'G': 0.02, 'T': 0.90 })
-
+    
     d1 = IndependentComponentsDistribution([d11, d12])
     d2 = IndependentComponentsDistribution([d21, d22])
     d3 = IndependentComponentsDistribution([d31, d32])
-
+    
     model = sparse_model(d1, d2, d3, i_d)
+    return model
 
 
-def setup_multivariate_gaussian_sparse():
-    global model
-
+@pytest.fixture
+def multivariate_gaussian_sparse():
     i1 = UniformDistribution(-20, 20)
     i2 = UniformDistribution(-20, 20)
     i_d = IndependentComponentsDistribution([i1, i2])
-
+    
     d11 = NormalDistribution(5, 1)
     d12 = NormalDistribution(7, 1)
-
+    
     d21 = NormalDistribution(13, 1)
     d22 = NormalDistribution(17, 1)
-
+    
     d31 = NormalDistribution(-2, 1)
     d32 = NormalDistribution(-5, 1)
-
+    
     d1 = IndependentComponentsDistribution([d11, d12])
     d2 = IndependentComponentsDistribution([d21, d22])
     d3 = IndependentComponentsDistribution([d31, d32])
-
+    
     model = sparse_model(d1, d2, d3, i_d)
+    return model
 
 
 def dense_model(d1, d2, d3, d4):
@@ -185,42 +176,41 @@ def dense_model(d1, d2, d3, d4):
     return model
 
 
-def setup_univariate_discrete_dense():
-    global model
-
+@pytest.fixture
+def univariate_discrete_dense():
     d1 = DiscreteDistribution({'A': 0.90, 'B': 0.02, 'C': 0.03, 'D': 0.05})
     d2 = DiscreteDistribution({'A': 0.02, 'B': 0.90, 'C': 0.03, 'D': 0.05})
     d3 = DiscreteDistribution({'A': 0.03, 'B': 0.02, 'C': 0.90, 'D': 0.05})
     d4 = DiscreteDistribution({'A': 0.05, 'B': 0.02, 'C': 0.03, 'D': 0.90})
 
     model = dense_model(d1, d2, d3, d4)
+    return model
 
 
-def setup_univariate_gaussian_dense():
-    global model
-
+@pytest.fixture
+def univariate_gaussian_dense():
     d1 = NormalDistribution(5, 1)
     d2 = NormalDistribution(1, 1)
     d3 = NormalDistribution(13, 2)
     d4 = NormalDistribution(16, 0.5)
 
     model = dense_model(d1, d2, d3, d4)
+    return model
 
 
-def setup_univariate_poisson_dense():
-    global model
-
+@pytest.fixture
+def univariate_poisson_dense():
     d1 = PoissonDistribution(12.1)
     d2 = PoissonDistribution(8.7)
     d3 = PoissonDistribution(1)
     d4 = PoissonDistribution(5)
 
     model = dense_model(d1, d2, d3, d4)
+    return model
 
 
-def setup_multivariate_mixed_dense():
-    global model
-
+@pytest.fixture
+def multivariate_mixed_dense():
     d11 = NormalDistribution(1, 1)
     d12 = ExponentialDistribution(5)
     d13 = LogNormalDistribution(0.5, 0.78)
@@ -250,11 +240,11 @@ def setup_multivariate_mixed_dense():
     d4 = IndependentComponentsDistribution([d41, d42, d43, d44, d45])
 
     model = dense_model(d1, d2, d3, d4)
+    return model
 
 
-def setup_multivariate_gaussian_dense():
-    global model
-
+@pytest.fixture
+def multivariate_gaussian_dense():
     random_state = numpy.random.RandomState(0)
     mu = random_state.normal(0, 1, size=(4, 5))
     d1 = MultivariateGaussianDistribution(mu[0], numpy.eye(5))
@@ -263,11 +253,11 @@ def setup_multivariate_gaussian_dense():
     d4 = MultivariateGaussianDistribution(mu[3], numpy.eye(5))
 
     model = dense_model(d1, d2, d3, d4)
+    return model
 
 
-def setup_general_mixture_gaussian():
-    global model
-
+@pytest.fixture
+def general_mixture_gaussian():
     # should be able to pass list of weights
     gmm1 = GeneralMixtureModel([NormalDistribution(5, 2), NormalDistribution(1, 2)], weights=[0.33, 0.67])
     gmm2 = GeneralMixtureModel([NormalDistribution(3, 2), NormalDistribution(-1, 2)], weights=numpy.array([0.67, 0.33]))
@@ -282,19 +272,11 @@ def setup_general_mixture_gaussian():
     model.add_transition(s2, s2, 0.8)
     model.add_transition(s2, s1, 0.2)
     model.bake()
+    return model
 
 
-def teardown():
-    '''
-    Remove the model at the end of the unit testing. Since it is stored in a
-    global variance, simply delete it.
-    '''
-
-    pass
-
-
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_forward():
+def test_hmm_univariate_discrete_dense_forward(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.forward(['A', 'B', 'D', 'D', 'C'])
     logp = numpy.array([[-inf, -inf, -inf, -inf, 0., -inf],
                 [-2.40794561, -5.11599581, -5.11599581, -3.91202301, -inf, -4.40631933],
@@ -306,8 +288,8 @@ def test_hmm_univariate_discrete_dense_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_forward():
+def test_hmm_univariate_gaussian_dense_forward(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.forward([3, 5, 8, 19, 13])
     logp = numpy.array([[-inf, -inf, -inf, -inf, 0.0, -inf],
         [-5.221523626198319, -4.122911337530209, -15.72152362619832, -339.14208208451845, -inf, -6.137807473983832],
@@ -319,8 +301,8 @@ def test_hmm_univariate_gaussian_dense_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_forward():
+def test_hmm_univariate_poisson_dense_forward(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.forward([5, 8, 2, 4, 7, 8, 2])
     logp = numpy.array([[-inf, -inf, -inf, -inf, 0.0, -inf],
         [-6.724049572762615, -3.874849418805291, -7.396929655216146, -2.6565929124856993, -inf, -4.680333421931903],
@@ -334,8 +316,8 @@ def test_hmm_univariate_poisson_dense_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_forward():
+def test_hmm_multivariate_mixed_dense_forward(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.forward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]])
     logp = numpy.array([[ -inf,  -inf,  -inf,  -inf,  0.,  -inf],
          [ -14.73222089,  -46.16604623,  -29.00420739,  -62.64844211, -inf, -17.03480535],
@@ -345,8 +327,8 @@ def test_hmm_multivariate_mixed_dense_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_forward():
+def test_hmm_multivariate_gaussian_dense_forward(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.forward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
     logp = numpy.array([[-inf, -inf, -inf, -inf, 0.0, -inf],
         [-17.388625105797296, -25.109952452723487, -20.33305760532214, -28.085443290422877, -inf, -19.639474084287432],
@@ -356,8 +338,8 @@ def test_hmm_multivariate_gaussian_dense_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_forward():
+def test_hmm_univariate_discrete_dense_nan_forward(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.forward(['A', nan, 'D', nan, 'C'])
     logp = numpy.array([[       -inf,        -inf,        -inf,        -inf,  0.,                -inf],
          [-2.40794561, -5.11599581, -5.11599581, -3.91202301,        -inf, -4.40631933],
@@ -369,8 +351,8 @@ def test_hmm_univariate_discrete_dense_nan_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_forward():
+def test_hmm_univariate_gaussian_dense_nan_forward(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.forward([3, 5, 8, nan, 13])
     logp = numpy.array([[         -inf,          -inf, -inf, -inf, 0., -inf],
          [  -5.22152363,   -4.12291134,  -15.72152363, -339.14208208, -inf, -6.13780747],
@@ -382,8 +364,8 @@ def test_hmm_univariate_gaussian_dense_nan_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_forward():
+def test_hmm_univariate_poisson_dense_nan_forward(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.forward([5, 8, 2, nan, 7, nan, 2])
     logp = numpy.array([[        -inf,         -inf, -inf, -inf, 0., -inf],
          [ -6.72404957,  -3.87484942,  -7.39692966,  -2.65659291, -inf, -4.68033342],
@@ -397,8 +379,8 @@ def test_hmm_univariate_poisson_dense_nan_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_forward():
+def test_hmm_multivariate_mixed_dense_nan_forward(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.forward([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]])
     logp = numpy.array([[-inf, -inf, -inf, -inf, 0.0, -inf],
         [-8.64586382, -11.86321233, -20.72307256, -49.92199169, -inf, -10.90916394],
@@ -408,8 +390,8 @@ def test_hmm_multivariate_mixed_dense_nan_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_forward():
+def test_hmm_multivariate_gaussian_dense_nan_forward(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.forward([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]])
     logp = numpy.array([[        -inf,         -inf,        -inf, -inf,   0.,  -inf],
          [-15.34182759, -21.05906503, -16.62794596, -24.70263887, -inf, -17.39777437],
@@ -419,8 +401,8 @@ def test_hmm_multivariate_gaussian_dense_nan_forward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_backward():
+def test_hmm_univariate_discrete_dense_backward(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.backward(['A', 'B', 'D', 'D', 'C'])
     logp = numpy.array([[-9.86805902419294, -10.666561769922483, -11.09973677168472, -10.617074536069564, -11.092510372852566, -inf],
         [-9.120551817416588, -9.07513780778706, -9.061129343592423, -8.517934491110973, -8.143527673240188, -inf],
@@ -432,8 +414,8 @@ def test_hmm_univariate_discrete_dense_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_backward():
+def test_hmm_univariate_gaussian_dense_backward(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.backward([3, 5, 8, 19, 13])
     logp = numpy.array([[-24.010022764471987, -24.820878919065986, -25.359784144328874, -24.666641886986977, -24.907606167690343, -inf],
         [-20.47495458748052, -21.390489786220005, -22.08295469697486, -21.390527588974052, -22.081667004696868, -inf],
@@ -445,8 +427,8 @@ def test_hmm_univariate_gaussian_dense_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_backward():
+def test_hmm_univariate_poisson_dense_backward(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.backward([5, 8, 2, 4, 7, 8, 2])
     logp = numpy.array([[-21.691907586187032, -21.73799328948721, -21.138366991878907, -21.083291604178275, -21.044274521213687, -inf],
         [-18.8959690490499, -19.147279755417475, -18.96895836891973, -18.554384880883024, -18.344028493972242, -inf],
@@ -460,8 +442,8 @@ def test_hmm_univariate_poisson_dense_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_backward():
+def test_hmm_multivariate_mixed_dense_backward(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.backward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]])
     logp = numpy.array([[-95.62390845, -96.54019907, -97.23334619, -96.54019916, -97.23334625, -inf],
         [-82.50112549, -83.41741621, -84.11056338, -83.41741622, -84.11056339, -inf],
@@ -471,8 +453,8 @@ def test_hmm_multivariate_mixed_dense_backward():
 
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_backward():
+def test_hmm_multivariate_gaussian_dense_backward(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.backward([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
     logp = numpy.array([[-68.2539137567533, -69.16076639610863, -69.84868309756291, -69.16857768159394, -69.85376066028503, -inf],
         [-52.47579136451719, -53.392079325925124, -54.08522496164164, -53.392081629466915, -54.08522649261687, -inf],
@@ -481,8 +463,8 @@ def test_hmm_multivariate_gaussian_dense_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_backward():
+def test_hmm_univariate_discrete_dense_nan_backward(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.backward(['A', nan, 'D', nan, 'C'])
     logp = numpy.array([[-6.2351892, -7.03937052, -7.53995041, -7.0284468, -7.53208902, -inf],
         [-5.47529921, -5.28136881, -5.22459211, -5.34120086, -5.21037792, -inf],
@@ -494,8 +476,8 @@ def test_hmm_univariate_discrete_dense_nan_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_backward():
+def test_hmm_univariate_gaussian_dense_nan_backward(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.backward([3, 5, 8, nan, 13])
     logp = numpy.array([[-16.72877261, -17.53965174, -18.0785865, -17.38544424, -17.62647294, -inf],
         [-13.19368605, -14.10946925, -14.80215433, -14.10948639, -14.80126502, -inf],
@@ -507,8 +489,8 @@ def test_hmm_univariate_gaussian_dense_nan_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_backward():
+def test_hmm_univariate_poisson_dense_nan_backward(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.backward([5, 8, 2, nan, 7, nan, 2])
     logp = numpy.array([[-16.63348003, -16.67956771, -16.0798998, -16.02482554, -15.98581404, -inf],
         [-13.83793763, -14.08893409, -13.91233676, -13.49588981, -13.28439885, -inf],
@@ -522,8 +504,8 @@ def test_hmm_univariate_poisson_dense_nan_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_backward():
+def test_hmm_multivariate_mixed_dense_nan_backward(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.backward([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]])
     logp = numpy.array([[-58.07503525, -58.9897255, -59.68021202, -58.98706625, -59.66964241, -inf],
         [-51.03967719, -51.95596417, -52.64910927, -51.95596729, -52.64911135, -inf],
@@ -533,8 +515,8 @@ def test_hmm_multivariate_mixed_dense_nan_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_backward():
+def test_hmm_multivariate_gaussian_dense_nan_backward(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.backward([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]])
     logp = numpy.array([[-50.72705835, -51.59493939, -52.26201549, -51.63477927, -52.28702405, -inf],
         [-37.00027105, -37.91654779, -38.60968708, -37.91655924, -38.60969427, -inf],
@@ -544,8 +526,8 @@ def test_hmm_multivariate_gaussian_dense_nan_backward():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_predict_log_proba():
+def test_hmm_univariate_discrete_dense_predict_log_proba(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict_log_proba(['A', 'B', 'D', 'D', 'C'])
     logp = numpy.array([[-0.43598705, -3.09862324, -3.08461478, -1.33744712],
         [-2.75011524, -0.18557067, -3.32315748, -2.66771698],
@@ -556,8 +538,8 @@ def test_hmm_univariate_discrete_dense_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_predict_log_proba():
+def test_hmm_univariate_gaussian_dense_predict_log_proba(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict_log_proba([3, 5, 8, 19, 13])
     logp = numpy.array([[-0.78887205, -0.60579496, -12.89687216, -335.62500351],
         [-0.00062775, -8.15629975, -7.98472576, -241.94669106],
@@ -568,8 +550,8 @@ def test_hmm_univariate_gaussian_dense_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_predict_log_proba():
+def test_hmm_univariate_poisson_dense_predict_log_proba(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict_log_proba([5, 8, 2, 4, 7, 8, 2])
     logp = numpy.array([[-4.5757441, -1.97785465, -5.3216135, -0.16670327],
         [-2.12263997, -0.57356459, -10.23962484, -1.14968683],
@@ -582,8 +564,8 @@ def test_hmm_univariate_poisson_dense_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict_log_proba():
+def test_hmm_multivariate_mixed_dense_predict_log_proba(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict_log_proba([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]])
     logp = numpy.array([[-1.3e-07, -32.35011618, -15.88142452, -48.83251208],
         [-0.0, -125.38948844, -20.25379271, -140.90667878],
@@ -591,8 +573,8 @@ def test_hmm_multivariate_mixed_dense_predict_log_proba():
 
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict_log_proba_from_json():
+def test_hmm_multivariate_mixed_dense_predict_log_proba_from_json(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     logp = numpy.array([[-1.3e-07, -32.35011618, -15.88142452, -48.83251208],
         [-0.0, -125.38948844, -20.25379271, -140.90667878],
         [-3.29e-06, -178.10391312, -12.6258323, -138.86820172]])
@@ -602,8 +584,8 @@ def test_hmm_multivariate_mixed_dense_predict_log_proba_from_json():
     f = hmm_json.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict_log_proba_from_yaml():
+def test_hmm_multivariate_mixed_dense_predict_log_proba_from_yaml(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     logp = numpy.array([[-1.3e-07, -32.35011618, -15.88142452, -48.83251208],
         [-0.0, -125.38948844, -20.25379271, -140.90667878],
         [-3.29e-06, -178.10391312, -12.6258323, -138.86820172]])
@@ -613,8 +595,8 @@ def test_hmm_multivariate_mixed_dense_predict_log_proba_from_yaml():
     f = hmm_yaml.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_robust_from_json():
+def test_hmm_multivariate_mixed_dense_robust_from_json(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     logp = numpy.array([[-1.3e-07, -32.35011618, -15.88142452, -48.83251208],
         [-0.0, -125.38948844, -20.25379271, -140.90667878],
         [-3.29e-06, -178.10391312, -12.6258323, -138.86820172]])
@@ -624,8 +606,8 @@ def test_hmm_multivariate_mixed_dense_robust_from_json():
     f = hmm_json.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict_log_proba():
+def test_hmm_multivariate_gaussian_dense_predict_log_proba(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict_log_proba([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
     logp = numpy.array([[-0.01065581, -8.64827112, -4.56452191, -11.62376426],
         [-3.5e-07, -21.03621875, -14.85696805, -21.01998258],
@@ -634,8 +616,8 @@ def test_hmm_multivariate_gaussian_dense_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_json():
+def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_json(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     logp = numpy.array([[-0.01065581, -8.64827112, -4.56452191, -11.62376426],
         [-3.5e-07, -21.03621875, -14.85696805, -21.01998258],
         [-18.86968176, -0.07127267, -3.75635416, -3.09173086]])
@@ -645,8 +627,8 @@ def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_json():
     f = hmm_json.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_yaml():
+def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_yaml(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     logp = numpy.array([[-0.01065581, -8.64827112, -4.56452191, -11.62376426],
         [-3.5e-07, -21.03621875, -14.85696805, -21.01998258],
         [-18.86968176, -0.07127267, -3.75635416, -3.09173086]])
@@ -656,8 +638,8 @@ def test_hmm_multivariate_gaussian_dense_predict_log_proba_from_yaml():
     f = hmm_yaml.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_robust_from_json():
+def test_hmm_multivariate_gaussian_dense_robust_from_json(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     logp = numpy.array([[-0.01065581, -8.64827112, -4.56452191, -11.62376426],
         [-3.5e-07, -21.03621875, -14.85696805, -21.01998258],
         [-18.86968176, -0.07127267, -3.75635416, -3.09173086]])
@@ -667,8 +649,8 @@ def test_hmm_multivariate_gaussian_dense_robust_from_json():
     f = hmm_json.predict_log_proba(s)
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_predict_log_proba():
+def test_hmm_univariate_discrete_dense_nan_predict_log_proba(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict_log_proba(['A', nan, 'D', nan, 'C'])
     logp = numpy.array([[-0.35115579, -2.8652756, -2.8084989, -1.72113484],
         [-1.05957958, -2.32005107, -1.66860008, -1.0034317],
@@ -679,8 +661,8 @@ def test_hmm_univariate_discrete_dense_nan_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_predict_log_proba():
+def test_hmm_univariate_gaussian_dense_nan_predict_log_proba(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict_log_proba([3, 5, 8, nan, 13])
     logp = numpy.array([[-0.78873673, -0.60590764, -12.89720502, -335.62509553],
         [-0.00042349, -8.53359013, -8.39210104, -242.13279062],
@@ -691,8 +673,8 @@ def test_hmm_univariate_gaussian_dense_nan_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_predict_log_proba():
+def test_hmm_univariate_poisson_dense_nan_predict_log_proba(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict_log_proba([5, 8, 2, nan, 7, nan, 2])
     logp = numpy.array([[-4.57617316, -1.97796947, -5.32345238, -0.16666868],
         [-2.12417036, -0.56894186, -10.24308433, -1.15738144],
@@ -705,8 +687,8 @@ def test_hmm_univariate_poisson_dense_nan_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_predict_log_proba():
+def test_hmm_multivariate_mixed_dense_nan_predict_log_proba(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict_log_proba([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]])
     logp = numpy.array([[-0.0158986, -4.14953409, -13.70253942, -42.20831658],
         [-4.8e-07, -124.2732402, -14.55816895, -115.82582217],
@@ -715,8 +697,8 @@ def test_hmm_multivariate_mixed_dense_nan_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_predict_log_proba():
+def test_hmm_multivariate_gaussian_dense_nan_predict_log_proba(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict_log_proba([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]])
     logp = numpy.array([[-0.05507459, -6.68858877, -2.95060899, -10.33217406],
         [-2.76e-06, -16.54254089, -12.82407236, -19.35159412],
@@ -725,8 +707,8 @@ def test_hmm_multivariate_gaussian_dense_nan_predict_log_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_predict_proba():
+def test_hmm_univariate_discrete_dense_predict_proba(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict_proba(['A', 'B', 'D', 'D', 'C'])
     logp = numpy.array([[0.6466261, 0.04511127, 0.04574765, 0.26251498],
         [0.06392049, 0.83063013, 0.03603886, 0.06941051],
@@ -737,8 +719,8 @@ def test_hmm_univariate_discrete_dense_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_predict_proba():
+def test_hmm_univariate_gaussian_dense_predict_proba(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict_proba([3, 5, 8, 19, 13])
     logp = numpy.array([[0.454357, 0.54564049, 2.51e-06, 0.0],
         [0.99937245, 0.00028692, 0.00034063, 0.0],
@@ -749,8 +731,8 @@ def test_hmm_univariate_gaussian_dense_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_predict_proba():
+def test_hmm_univariate_poisson_dense_predict_proba(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict_proba([5, 8, 2, 4, 7, 8, 2])
     logp = numpy.array([[0.01029863, 0.13836576, 0.00488487, 0.84645074],
         [0.11971517, 0.56351316, 3.573e-05, 0.31673595],
@@ -763,8 +745,8 @@ def test_hmm_univariate_poisson_dense_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict_proba():
+def test_hmm_multivariate_mixed_dense_predict_proba(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict_proba([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]])
     logp = numpy.array([[0.99999987, 0.0, 1.3e-07, 0.0],
         [1.0, 0.0, 0.0, 0.0],
@@ -772,8 +754,8 @@ def test_hmm_multivariate_mixed_dense_predict_proba():
 
     assert_array_almost_equal(f, logp)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict_proba():
+def test_hmm_multivariate_gaussian_dense_predict_proba(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict_proba([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
     logp = numpy.array([[0.98940076, 0.00017543, 0.01041486, 8.95e-06],
         [0.99999965, 0.0, 3.5e-07, 0.0],
@@ -782,8 +764,8 @@ def test_hmm_multivariate_gaussian_dense_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_predict_proba():
+def test_hmm_univariate_discrete_dense_nan_predict_proba(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict_proba(['A', nan, 'D', nan, 'C'])
     logp = numpy.array([[0.70387409, 0.05696743, 0.06029543, 0.17886305],
         [0.3466015, 0.09826857, 0.18851078, 0.36661915],
@@ -794,8 +776,8 @@ def test_hmm_univariate_discrete_dense_nan_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_predict_proba():
+def test_hmm_univariate_gaussian_dense_nan_predict_proba(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict_proba([3, 5, 8, nan, 13])
     logp = numpy.array([[0.45441848, 0.54557901, 2.51e-06, 0.0],
         [0.9995766, 0.00019675, 0.00022665, 0.0],
@@ -806,8 +788,8 @@ def test_hmm_univariate_gaussian_dense_nan_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_predict_proba():
+def test_hmm_univariate_poisson_dense_nan_predict_proba(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict_proba([5, 8, 2, nan, 7, nan, 2])
     logp = numpy.array([[0.01029422, 0.13834988, 0.00487589, 0.84648002],
         [0.1195321, 0.56612416, 3.56e-05, 0.31430814],
@@ -820,8 +802,8 @@ def test_hmm_univariate_poisson_dense_nan_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_predict_proba():
+def test_hmm_multivariate_mixed_dense_nan_predict_proba(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict_proba([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]])
     logp = numpy.array([[0.98422712, 0.01577176, 1.12e-06, 0.0],
         [0.99999952, 0.0, 4.8e-07, 0.0],
@@ -830,8 +812,8 @@ def test_hmm_multivariate_mixed_dense_nan_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_predict_proba():
+def test_hmm_multivariate_gaussian_dense_nan_predict_proba(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict_proba([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]])
     logp = numpy.array([[0.94641455, 0.00124504, 0.05230784, 3.257e-05],
         [0.99999724, 7e-08, 2.7e-06, 0.0],
@@ -840,119 +822,119 @@ def test_hmm_multivariate_gaussian_dense_nan_predict_proba():
     assert_array_almost_equal(f, logp)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_predict():
+def test_hmm_univariate_discrete_dense_predict(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict(['A', 'B', 'D', 'D', 'C'])
     path = [0, 1, 3, 3, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_predict():
+def test_hmm_univariate_gaussian_dense_predict(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict([3, 5, 8, 19, 13])
     path = [1, 0, 2, 2, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_predict():
+def test_hmm_univariate_poisson_dense_predict(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict([5, 8, 2, 4, 7, 8, 2])
     path = [3, 1, 2, 3, 3, 1, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict():
+def test_hmm_multivariate_mixed_dense_predict(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]])
     path = [0, 0, 0]
 
     assert_array_almost_equal(f, path)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict():
+def test_hmm_multivariate_gaussian_dense_predict(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]])
     path = [0, 0, 1]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_predict():
+def test_hmm_univariate_discrete_dense_nan_predict(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict(['A', nan, 'D', nan, 'C'])
     path = [0, 3, 3, 1, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_predict():
+def test_hmm_univariate_gaussian_dense_nan_predict(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict([3, 5, 8, nan, 13])
     path = [1, 0, 0, 2, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_predict():
+def test_hmm_univariate_poisson_dense_nan_predict(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict([5, 8, 2, nan, 7, nan, 2])
     path = [3, 1, 2, 3, 3, 3, 2]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_predict():
+def test_hmm_multivariate_mixed_dense_nan_predict(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]])
     path = [0, 0, 0]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_predict():
+def test_hmm_multivariate_gaussian_dense_nan_predict(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]])
     path = [0, 0, 1]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_predict_viterbi():
+def test_hmm_univariate_discrete_dense_predict_viterbi(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict(['A', 'B', 'D', 'D', 'C'], algorithm='viterbi')
     path = [4, 0, 1, 3, 3, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_predict_viterbi():
+def test_hmm_univariate_gaussian_dense_predict_viterbi(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict([3, 5, 8, 19, 13], algorithm='viterbi')
     path = [4, 1, 0, 2, 2, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_predict_viterbi():
+def test_hmm_univariate_poisson_dense_predict_viterbi(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict([5, 8, 2, 4, 7, 8, 2], algorithm='viterbi')
     path = [4, 3, 1, 2, 3, 3, 1, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_predict_viterbi():
+def test_hmm_multivariate_mixed_dense_predict_viterbi(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [4, 6, 2, 0, 1]],
         algorithm='viterbi')
     path = [4, 0, 0, 0, 5]
 
     assert_array_almost_equal(f, path)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_predict_viterbi():
+def test_hmm_multivariate_gaussian_dense_predict_viterbi(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict([[0, 1, 5, 2, 3], [2, 4, 1, 5, 6], [-4, 6, -2, 0, 1]],
         algorithm='viterbi')
     path = [4, 0, 0, 1, 5]
@@ -960,32 +942,32 @@ def test_hmm_multivariate_gaussian_dense_predict_viterbi():
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_discrete_dense)
-def test_hmm_univariate_discrete_dense_nan_predict_viterbi():
+def test_hmm_univariate_discrete_dense_nan_predict_viterbi(univariate_discrete_dense):
+    model = univariate_discrete_dense
     f = model.predict(['A', nan, 'D', nan, 'C'], algorithm='viterbi')
     path = [4, 0, 0, 3, 1, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_univariate_gaussian_dense_nan_predict_viterbi():
+def test_hmm_univariate_gaussian_dense_nan_predict_viterbi(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     f = model.predict([3, 5, 8, nan, 13], algorithm='viterbi')
     path = [4, 1, 0, 0, 0, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_univariate_poisson_dense)
-def test_hmm_univariate_poisson_dense_nan_predict_viterbi():
+def test_hmm_univariate_poisson_dense_nan_predict_viterbi(univariate_poisson_dense):
+    model = univariate_poisson_dense
     f = model.predict([5, 8, 2, nan, 7, nan, 2], algorithm='viterbi')
     path = [4, 3, 1, 2, 3, 3, 1, 2, 5]
 
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_mixed_dense)
-def test_hmm_multivariate_mixed_dense_nan_predict_viterbi():
+def test_hmm_multivariate_mixed_dense_nan_predict_viterbi(multivariate_mixed_dense):
+    model = multivariate_mixed_dense
     f = model.predict([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [4, nan, 2, nan, 1]],
         algorithm='viterbi')
     path = [4, 0, 0, 0, 5]
@@ -993,8 +975,8 @@ def test_hmm_multivariate_mixed_dense_nan_predict_viterbi():
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_multivariate_gaussian_dense_nan_predict_viterbi():
+def test_hmm_multivariate_gaussian_dense_nan_predict_viterbi(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     f = model.predict([[0, nan, 5, nan, 3], [nan, 4, 1, 5, 6], [-4, nan, -2, nan, 1]],
         algorithm='viterbi')
     path = [4, 0, 0, 1, 5]
@@ -1002,8 +984,7 @@ def test_hmm_multivariate_gaussian_dense_nan_predict_viterbi():
     assert_array_almost_equal(f, path)
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit():
+def test_hmm_viterbi_fit(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1015,11 +996,10 @@ def test_hmm_viterbi_fit():
                                use_pseudocount=True)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.2834)
+    assert round(total_improvement, 4) == 83.2834
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_no_pseudocount():
+def test_hmm_viterbi_fit_no_pseudocount(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1031,11 +1011,10 @@ def test_hmm_viterbi_fit_no_pseudocount():
                                      use_pseudocount=False)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 84.9318)
+    assert round(total_improvement, 4) == 84.9318
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_w_pseudocount():
+def test_hmm_viterbi_fit_w_pseudocount(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1047,11 +1026,10 @@ def test_hmm_viterbi_fit_w_pseudocount():
                                      transition_pseudocount=1.)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 79.4713)
+    assert round(total_improvement, 4) == 79.4713
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_w_pseudocount_priors():
+def test_hmm_viterbi_fit_w_pseudocount_priors(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1064,11 +1042,10 @@ def test_hmm_viterbi_fit_w_pseudocount_priors():
                                      use_pseudocount=True)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 81.7439)
+    assert round(total_improvement, 4) == 81.7439
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_w_inertia():
+def test_hmm_viterbi_fit_w_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1080,11 +1057,10 @@ def test_hmm_viterbi_fit_w_inertia():
                                      edge_inertia=0.193)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 84.9318)
+    assert round(total_improvement, 4) == 84.9318
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_w_inertia2():
+def test_hmm_viterbi_fit_w_inertia2(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1096,11 +1072,10 @@ def test_hmm_viterbi_fit_w_inertia2():
                                      edge_inertia=0.82)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 84.9318)
+    assert round(total_improvement, 4) == 84.9318
 
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_w_pseudocount_inertia():
+def test_hmm_viterbi_fit_w_pseudocount_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1113,10 +1088,9 @@ def test_hmm_viterbi_fit_w_pseudocount_inertia():
                                      use_pseudocount=True)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.2834)
+    assert round(total_improvement, 4) == 83.2834
 
-@with_setup(setup, teardown)
-def test_hmm_viterbi_fit_one_check_input():
+def test_hmm_viterbi_fit_one_check_input(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
     'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
     'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1129,10 +1103,9 @@ def test_hmm_viterbi_fit_one_check_input():
                                multiple_check_input=False)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.2834)
+    assert round(total_improvement, 4) == 83.2834
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit():
+def test_hmm_bw_fit(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1145,11 +1118,11 @@ def test_hmm_bw_fit():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.1132)
+    assert round(total_improvement, 4) == 83.1132
 
 
-@with_setup(setup_multivariate_discrete_sparse, teardown)
-def test_hmm_bw_multivariate_discrete_fit():
+def test_hmm_bw_multivariate_discrete_fit(multivariate_discrete_sparse):
+    model = multivariate_discrete_sparse
     seqs = [[['A', 'A'], ['A', 'C'], ['C', 'T']], [['A', 'A'], ['C', 'C'], ['T', 'T']],
             [['A', 'A'], ['A', 'C'], ['C', 'C'], ['T', 'T']], [['A', 'A'], ['C', 'C']]]
 
@@ -1161,11 +1134,11 @@ def test_hmm_bw_multivariate_discrete_fit():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 13.3622)
+    assert round(total_improvement, 4) == 13.3622
 
 
-@with_setup(setup_multivariate_discrete_sparse, teardown)
-def test_hmm_bw_multivariate_discrete_fit_json_yaml():
+def test_hmm_bw_multivariate_discrete_fit_json_yaml(multivariate_discrete_sparse):
+    model = multivariate_discrete_sparse
     seqs = [[['A', 'A'], ['A', 'C'], ['C', 'T']], [['A', 'A'], ['C', 'C'], ['T', 'T']],
             [['A', 'A'], ['A', 'C'], ['C', 'C'], ['T', 'T']], [['A', 'A'], ['C', 'C']]]
 
@@ -1178,10 +1151,10 @@ def test_hmm_bw_multivariate_discrete_fit_json_yaml():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 13.3622)
+    assert round(total_improvement, 4) == 13.3622
 
-@with_setup(setup_multivariate_discrete_sparse, teardown)
-def test_hmm_bw_multivariate_discrete_fit_robust_from_json():
+def test_hmm_bw_multivariate_discrete_fit_robust_from_json(multivariate_discrete_sparse):
+    model = multivariate_discrete_sparse
     seqs = [[['A', 'A'], ['A', 'C'], ['C', 'T']], [['A', 'A'], ['C', 'C'], ['T', 'T']],
             [['A', 'A'], ['A', 'C'], ['C', 'C'], ['T', 'T']], [['A', 'A'], ['C', 'C']]]
 
@@ -1194,10 +1167,10 @@ def test_hmm_bw_multivariate_discrete_fit_robust_from_json():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 13.3622)
+    assert round(total_improvement, 4) == 13.3622
 
-@with_setup(setup_multivariate_discrete_sparse, teardown)
-def test_hmm_bw_multivariate_discrete_fit_from_yaml():
+def test_hmm_bw_multivariate_discrete_fit_from_yaml(multivariate_discrete_sparse):
+    model = multivariate_discrete_sparse
     seqs = [[['A', 'A'], ['A', 'C'], ['C', 'T']], [['A', 'A'], ['C', 'C'], ['T', 'T']],
             [['A', 'A'], ['A', 'C'], ['C', 'C'], ['T', 'T']], [['A', 'A'], ['C', 'C']]]
 
@@ -1210,11 +1183,11 @@ def test_hmm_bw_multivariate_discrete_fit_from_yaml():
                               max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 13.3622)
+    assert round(total_improvement, 4) == 13.3622
 
 
-@with_setup(setup_multivariate_gaussian_sparse, teardown)
-def test_hmm_bw_multivariate_gaussian_fit():
+def test_hmm_bw_multivariate_gaussian_fit(multivariate_gaussian_sparse):
+    model = multivariate_gaussian_sparse
     seqs = [[[5, 8], [8, 10], [13, 17], [-3, -4]], [[6, 7], [13, 16], [12, 11], [-6, -7]],
             [[4, 6], [13, 15], [-4, -7]], [[6, 5], [14, 18], [-7, -5]]]
 
@@ -1226,10 +1199,10 @@ def test_hmm_bw_multivariate_gaussian_fit():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 24.7013)
+    assert round(total_improvement, 4) == 24.7013
 
-@with_setup(setup_multivariate_gaussian_sparse, teardown)
-def test_hmm_bw_multivariate_gaussian_from_json():
+def test_hmm_bw_multivariate_gaussian_from_json(multivariate_gaussian_sparse):
+    model = multivariate_gaussian_sparse
     seqs = [[[5, 8], [8, 10], [13, 17], [-3, -4]], [[6, 7], [13, 16], [12, 11], [-6, -7]],
             [[4, 6], [13, 15], [-4, -7]], [[6, 5], [14, 18], [-7, -5]]]
 
@@ -1242,10 +1215,10 @@ def test_hmm_bw_multivariate_gaussian_from_json():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 24.7013)
+    assert round(total_improvement, 4) == 24.7013
 
-@with_setup(setup_multivariate_gaussian_sparse, teardown)
-def test_hmm_bw_multivariate_gaussian_robust_from_json():
+def test_hmm_bw_multivariate_gaussian_robust_from_json(multivariate_gaussian_sparse):
+    model = multivariate_gaussian_sparse
     seqs = [[[5, 8], [8, 10], [13, 17], [-3, -4]], [[6, 7], [13, 16], [12, 11], [-6, -7]],
             [[4, 6], [13, 15], [-4, -7]], [[6, 5], [14, 18], [-7, -5]]]
 
@@ -1258,10 +1231,10 @@ def test_hmm_bw_multivariate_gaussian_robust_from_json():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 24.7013)
+    assert round(total_improvement, 4) == 24.7013
 
-@with_setup(setup_multivariate_gaussian_sparse, teardown)
-def test_hmm_bw_multivariate_gaussian_from_yaml(): 
+def test_hmm_bw_multivariate_gaussian_from_yaml(multivariate_gaussian_sparse):
+    model = multivariate_gaussian_sparse
     seqs = [[[5, 8], [8, 10], [13, 17], [-3, -4]], [[6, 7], [13, 16], [12, 11], [-6, -7]],
             [[4, 6], [13, 15], [-4, -7]], [[6, 5], [14, 18], [-7, -5]]]
             
@@ -1274,10 +1247,9 @@ def test_hmm_bw_multivariate_gaussian_from_yaml():
                               max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 24.7013)
+    assert round(total_improvement, 4) == 24.7013
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_json():
+def test_hmm_bw_fit_json(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1291,14 +1263,13 @@ def test_hmm_bw_fit_json():
 
     total_improvement = history.total_improvement[-1]
 
-    assert_equal(round(total_improvement, 4), 83.1132)
+    assert round(total_improvement, 4) == 83.1132
     assert_almost_equal(sum(model.log_probability(seq) for seq in seqs), -42.2341, 4)
 
     hmm = HiddenMarkovModel.from_json(model.to_json())
     assert_almost_equal(sum(model.log_probability(seq) for seq in seqs), -42.2341, 4)
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_robust_from_json():
+def test_hmm_bw_fit_robust_from_json(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1312,14 +1283,13 @@ def test_hmm_bw_fit_robust_from_json():
 
     total_improvement = history.total_improvement[-1]
 
-    assert_equal(round(total_improvement, 4), 83.1132)
+    assert round(total_improvement, 4) == 83.1132
     assert_almost_equal(sum(model.log_probability(seq) for seq in seqs), -42.2341, 4)
 
     hmm = from_json(model.to_json())
     assert_almost_equal(sum(model.log_probability(seq) for seq in seqs), -42.2341, 4)
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_no_pseudocount():
+def test_hmm_bw_fit_no_pseudocount(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1332,11 +1302,10 @@ def test_hmm_bw_fit_no_pseudocount():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 85.681)
+    assert round(total_improvement, 4) == 85.681
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount():
+def test_hmm_bw_fit_w_pseudocount(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1349,11 +1318,10 @@ def test_hmm_bw_fit_w_pseudocount():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 84.9408)
+    assert round(total_improvement, 4) == 84.9408
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount_priors():
+def test_hmm_bw_fit_w_pseudocount_priors(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1367,11 +1335,10 @@ def test_hmm_bw_fit_w_pseudocount_priors():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 81.2265)
+    assert round(total_improvement, 4) == 81.2265
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_inertia():
+def test_hmm_bw_fit_w_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1384,11 +1351,10 @@ def test_hmm_bw_fit_w_inertia():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 85.0528)
+    assert round(total_improvement, 4) == 85.0528
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_inertia2():
+def test_hmm_bw_fit_w_inertia2(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1401,11 +1367,10 @@ def test_hmm_bw_fit_w_inertia2():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 72.5134)
+    assert round(total_improvement, 4) == 72.5134
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount_inertia():
+def test_hmm_bw_fit_w_pseudocount_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1419,11 +1384,10 @@ def test_hmm_bw_fit_w_pseudocount_inertia():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.0764)
+    assert round(total_improvement, 4) == 83.0764
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_frozen_distributions():
+def test_hmm_bw_fit_w_frozen_distributions(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1436,11 +1400,10 @@ def test_hmm_bw_fit_w_frozen_distributions():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 64.474)
+    assert round(total_improvement, 4) == 64.474
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_frozen_edges():
+def test_hmm_bw_fit_w_frozen_edges(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1453,11 +1416,10 @@ def test_hmm_bw_fit_w_frozen_edges():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 44.0208)
+    assert round(total_improvement, 4) == 44.0208
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_edge_a_distribution_inertia():
+def test_hmm_bw_fit_w_edge_a_distribution_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1471,11 +1433,10 @@ def test_hmm_bw_fit_w_edge_a_distribution_inertia():
                                      max_iterations=5)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 81.5447)
+    assert round(total_improvement, 4) == 81.5447
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_parallel():
+def test_hmm_bw_fit_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1489,11 +1450,10 @@ def test_hmm_bw_fit_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.1132)
+    assert round(total_improvement, 4) == 83.1132
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_no_pseudocount_parallel():
+def test_hmm_bw_fit_no_pseudocount_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1507,11 +1467,10 @@ def test_hmm_bw_fit_no_pseudocount_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 85.681)
+    assert round(total_improvement, 4) == 85.681
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount_parallel():
+def test_hmm_bw_fit_w_pseudocount_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1525,11 +1484,10 @@ def test_hmm_bw_fit_w_pseudocount_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 84.9408)
+    assert round(total_improvement, 4) == 84.9408
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount_priors_parallel():
+def test_hmm_bw_fit_w_pseudocount_priors_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1544,11 +1502,10 @@ def test_hmm_bw_fit_w_pseudocount_priors_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 81.2265)
+    assert round(total_improvement, 4) == 81.2265
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_inertia_parallel():
+def test_hmm_bw_fit_w_inertia_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1562,11 +1519,10 @@ def test_hmm_bw_fit_w_inertia_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 85.0528)
+    assert round(total_improvement, 4) == 85.0528
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_inertia2_parallel():
+def test_hmm_bw_fit_w_inertia2_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1580,11 +1536,10 @@ def test_hmm_bw_fit_w_inertia2_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 72.5134)
+    assert round(total_improvement, 4) == 72.5134
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_pseudocount_inertia_parallel():
+def test_hmm_bw_fit_w_pseudocount_inertia_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1599,11 +1554,10 @@ def test_hmm_bw_fit_w_pseudocount_inertia_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.0764)
+    assert round(total_improvement, 4) == 83.0764
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_frozen_distributions_parallel():
+def test_hmm_bw_fit_w_frozen_distributions_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1617,11 +1571,10 @@ def test_hmm_bw_fit_w_frozen_distributions_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 64.474)
+    assert round(total_improvement, 4) == 64.474
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_frozen_edges_parallel():
+def test_hmm_bw_fit_w_frozen_edges_parallel(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1635,11 +1588,10 @@ def test_hmm_bw_fit_w_frozen_edges_parallel():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 44.0208)
+    assert round(total_improvement, 4) == 44.0208
 
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_w_edge_a_distribution_inertia():
+def test_hmm_bw_fit_w_edge_a_distribution_inertia(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1654,10 +1606,9 @@ def test_hmm_bw_fit_w_edge_a_distribution_inertia():
                                      n_jobs=2)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 81.5447)
+    assert round(total_improvement, 4) == 81.5447
 
-@with_setup(setup, teardown)
-def test_hmm_bw_fit_one_check_input():
+def test_hmm_bw_fit_one_check_input(model):
     seqs = [list(x) for x in ['ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT',
         'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT',
         'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT']]
@@ -1671,11 +1622,11 @@ def test_hmm_bw_fit_one_check_input():
                                      multiple_check_input=False)
 
     total_improvement = history.total_improvement[-1]
-    assert_equal(round(total_improvement, 4), 83.1132)
+    assert round(total_improvement, 4) == 83.1132
 
 def test_hmm_initialization():
     hmmd1 = HiddenMarkovModel()
-    assert_equal(hmmd1.d, 0)
+    assert hmmd1.d == 0
 
 
 def test_hmm_univariate_initialization():
@@ -1691,10 +1642,10 @@ def test_hmm_univariate_initialization():
     hmmd1.add_transition(s3d1, s1d1, 0.5)
     hmmd1.add_transition(s3d1, s2d1, 0.5)
 
-    assert_equal(hmmd1.d, 0)
+    assert hmmd1.d == 0
 
     hmmd1.bake()
-    assert_equal(hmmd1.d, 1)
+    assert hmmd1.d == 1
 
 
 def test_hmm_multivariate_initialization():
@@ -1703,7 +1654,7 @@ def test_hmm_multivariate_initialization():
     s3d3 = State(IndependentComponentsDistribution([UniformDistribution(0, 10), UniformDistribution(0, 10), UniformDistribution(0, 10)]))
 
     hmmd3 = HiddenMarkovModel()
-    assert_equal(hmmd3.d, 0)
+    assert hmmd3.d == 0
 
     hmmd3.add_transition(hmmd3.start, s1d3, 0.5)
     hmmd3.add_transition(hmmd3.start, s2d3, 0.5)
@@ -1711,10 +1662,10 @@ def test_hmm_multivariate_initialization():
     hmmd3.add_transition(s2d3, s3d3, 1)
     hmmd3.add_transition(s3d3, s1d3, 0.5)
     hmmd3.add_transition(s3d3, s2d3, 0.5)
-    assert_equal(hmmd3.d, 0)
+    assert hmmd3.d == 0
 
     hmmd3.bake()
-    assert_equal(hmmd3.d, 3)
+    assert hmmd3.d == 3
 
 
 def test_hmm_initialization_error():
@@ -1729,11 +1680,12 @@ def test_hmm_initialization_error():
     hmmb.add_transition(sbd3, sbd1, 0.5)
     hmmb.add_transition(sbd3, sbd3, 0.5)
 
-    assert_raises(ValueError, hmmb.bake)
+    with pytest.raises(ValueError):
+        hmmb.bake()
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_pickle_univariate():
+def test_hmm_pickle_univariate(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     model2 = pickle.loads(pickle.dumps(model))
 
     random_state = numpy.random.RandomState(0)
@@ -1746,8 +1698,8 @@ def test_hmm_pickle_univariate():
         assert_almost_equal(logp1, logp2)
 
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_json_univariate():
+def test_hmm_json_univariate(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     model2 = HiddenMarkovModel.from_json(model.to_json())
 
     random_state = numpy.random.RandomState(0)
@@ -1759,8 +1711,8 @@ def test_hmm_json_univariate():
 
         assert_almost_equal(logp1, logp2)
 
-@with_setup(setup_univariate_gaussian_dense)
-def test_hmm_robust_from_json_univariate():
+def test_hmm_robust_from_json_univariate(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     model2 = from_json(model.to_json())
 
     random_state = numpy.random.RandomState(0)
@@ -1772,8 +1724,8 @@ def test_hmm_robust_from_json_univariate():
 
         assert_almost_equal(logp1, logp2)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_pickle_multivariate():
+def test_hmm_pickle_multivariate(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     model2 = pickle.loads(pickle.dumps(model))
 
     random_state = numpy.random.RandomState(0)
@@ -1786,8 +1738,8 @@ def test_hmm_pickle_multivariate():
         assert_almost_equal(logp1, logp2)
 
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_json_multivariate():
+def test_hmm_json_multivariate(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     model2 = HiddenMarkovModel.from_json(model.to_json())
 
     random_state = numpy.random.RandomState(0)
@@ -1799,8 +1751,8 @@ def test_hmm_json_multivariate():
 
         assert_almost_equal(logp1, logp2)
 
-@with_setup(setup_multivariate_gaussian_dense)
-def test_hmm_robust_from_json_multivariate():
+def test_hmm_robust_from_json_multivariate(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     model2 = from_json(model.to_json())
 
     random_state = numpy.random.RandomState(0)
@@ -1812,19 +1764,19 @@ def test_hmm_robust_from_json_multivariate():
 
         assert_almost_equal(logp1, logp2)
 
-@with_setup(setup_univariate_discrete_dense, teardown)
-def test_hmm_univariate_discrete_from_samples():
+def test_hmm_univariate_discrete_from_samples(univariate_discrete_dense):
+    model = univariate_discrete_dense
     X = [model.sample(random_state=0) for i in range(25)]
     model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25)
 
     logp1 = sum(map(model.log_probability, X))
     logp2 = sum(map(model2.log_probability, X))
 
-    assert_greater(logp2, logp1)
+    assert logp2 > logp1
 
 
-@with_setup(setup_univariate_discrete_dense, teardown)
-def test_hmm_univariate_discrete_from_samples_with_labels():
+def test_hmm_univariate_discrete_from_samples_with_labels(univariate_discrete_dense):
+    model = univariate_discrete_dense
     X, y = zip(*model.sample(25, path=True, random_state=0))
     y = [[state.name for state in seq if not state.is_silent()] for seq in y]
 
@@ -1834,10 +1786,10 @@ def test_hmm_univariate_discrete_from_samples_with_labels():
     logp1 = sum(map(model.log_probability, X))
     logp2 = sum(map(model2.log_probability, X))
 
-    assert_greater(logp2, logp1)
+    assert logp2 > logp1
 
-@with_setup(setup_univariate_discrete_dense, teardown)
-def test_hmm_univariate_discrete_from_samples_one_check_input():
+def test_hmm_univariate_discrete_from_samples_one_check_input(univariate_discrete_dense):
+    model = univariate_discrete_dense
     X = [model.sample(random_state=0) for i in range(25)]
     model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, 
                                             max_iterations=25,
@@ -1846,53 +1798,53 @@ def test_hmm_univariate_discrete_from_samples_one_check_input():
     logp1 = sum(map(model.log_probability, X))
     logp2 = sum(map(model2.log_probability, X))
 
-    assert_greater(logp2, logp1)
+    assert logp2 > logp1
 
-@with_setup(setup_univariate_gaussian_dense, teardown)
-def test_hmm_univariate_gaussian_from_samples():
+def test_hmm_univariate_gaussian_from_samples(univariate_gaussian_dense):
+    model = univariate_gaussian_dense
     X = model.sample(n=25, random_state=0)
     model2 = HiddenMarkovModel.from_samples(NormalDistribution, 4, X, max_iterations=25)
 
     logp1 = sum(map(model.log_probability, X))
     logp2 = sum(map(model2.log_probability, X))
 
-    assert_greater(logp2, logp1)
+    assert logp2 > logp1
 
 
-@with_setup(setup_multivariate_gaussian_dense, teardown)
-def test_hmm_multivariate_gaussian_from_samples():
+def test_hmm_multivariate_gaussian_from_samples(multivariate_gaussian_dense):
+    model = multivariate_gaussian_dense
     X = model.sample(n=25, random_state=0)
     model2 = HiddenMarkovModel.from_samples(MultivariateGaussianDistribution, 4, X, max_iterations=25)
 
     logp1 = sum(map(model.log_probability, X))
     logp2 = sum(map(model2.log_probability, X))
 
-    assert_greater(logp2, logp1)
+    assert logp2 > logp1
 
-@with_setup(setup_univariate_discrete_dense, teardown)
-def test_hmm_univariate_discrete_from_samples_end_state():
+def test_hmm_univariate_discrete_from_samples_end_state(univariate_discrete_dense):
+    model = univariate_discrete_dense
     X = model.sample(n=25, random_state=0)
     model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, end_state=True)
 
     #We get non-zero end probabilities for each state
-    assert_greater(model2.dense_transition_matrix()[0][model2.end_index],0)
-    assert_greater(model2.dense_transition_matrix()[1][model2.end_index],0)
-    assert_greater(model2.dense_transition_matrix()[2][model2.end_index],0)
-    assert_greater(model2.dense_transition_matrix()[3][model2.end_index],0)
+    assert model2.dense_transition_matrix()[0][model2.end_index] >0
+    assert model2.dense_transition_matrix()[1][model2.end_index] >0
+    assert model2.dense_transition_matrix()[2][model2.end_index] >0
+    assert model2.dense_transition_matrix()[3][model2.end_index] >0
 
-@with_setup(setup_univariate_discrete_dense, teardown)
-def test_hmm_univariate_discrete_from_samples_no_end_state():
+def test_hmm_univariate_discrete_from_samples_no_end_state(univariate_discrete_dense):
+    model = univariate_discrete_dense
     X = [model.sample(random_state=0) for i in range(25)]
     model2 = HiddenMarkovModel.from_samples(DiscreteDistribution, 4, X, max_iterations=25, end_state=False)
 
     #We don't have end probabilities for each state
-    assert_equal(model2.dense_transition_matrix()[0][model2.end_index],0)
-    assert_equal(model2.dense_transition_matrix()[1][model2.end_index],0)
-    assert_equal(model2.dense_transition_matrix()[2][model2.end_index],0)
-    assert_equal(model2.dense_transition_matrix()[3][model2.end_index],0)
+    assert model2.dense_transition_matrix()[0][model2.end_index] ==0
+    assert model2.dense_transition_matrix()[1][model2.end_index] ==0
+    assert model2.dense_transition_matrix()[2][model2.end_index] ==0
+    assert model2.dense_transition_matrix()[3][model2.end_index] ==0
 
-@with_setup(setup_general_mixture_gaussian, teardown)
-def test_hmm_json_general_mixture_gaussian():
+def test_hmm_json_general_mixture_gaussian(general_mixture_gaussian):
+    model = general_mixture_gaussian
     model2 = HiddenMarkovModel.from_json(model.to_json())
     random_state = numpy.random.RandomState(0)
     for i in range(10):
@@ -1903,8 +1855,8 @@ def test_hmm_json_general_mixture_gaussian():
 
         assert_almost_equal(logp1, logp2)
 
-@with_setup(setup_general_mixture_gaussian, teardown)
-def test_hmm_robust_from_json_general_mixture_gaussian():
+def test_hmm_robust_from_json_general_mixture_gaussian(general_mixture_gaussian):
+    model = general_mixture_gaussian
     model2 = from_json(model.to_json())
     random_state = numpy.random.RandomState(0)
     for i in range(10):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,17 +3,13 @@ from pomegranate.io import DataGenerator
 from pomegranate.io import SequenceGenerator
 from pomegranate.io import DataFrameGenerator
 
-from nose.tools import with_setup
-from nose.tools import assert_true
-from nose.tools import assert_equal
-from nose.tools import assert_raises
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_equal
-from numpy.testing import assert_array_almost_equal
 
 import random
 import numpy
 import pandas
+import pytest
 
 numpy.random.seed(0)
 random.seed(0)
@@ -30,7 +26,9 @@ def test_io_datagenerator_classes_fail():
 	X = numpy.random.randn(500, 13)
 	data = DataGenerator(X)
 
-	assert_raises(ValueError, lambda data: data.classes, data)
+	with pytest.raises(ValueError):
+		d = lambda data: data.classes
+		d(data)
 
 def test_io_datagenerator_classes():
 	X = numpy.random.randn(500, 13)
@@ -146,7 +144,7 @@ def test_io_datagenerator_wy_unlabeled():
 	X_ = numpy.concatenate([batch[0] for batch in data.unlabeled_batches()])
 	w_ = numpy.concatenate([batch[1] for batch in data.unlabeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X[y == -1], X_)
 	assert_almost_equal(w[y == -1], w_)
 
@@ -160,7 +158,7 @@ def test_io_datagenerator_wy_labeled():
 	y_ = numpy.concatenate([batch[1] for batch in data.labeled_batches()])
 	w_ = numpy.concatenate([batch[2] for batch in data.labeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X[y != -1], X_)
 	assert_almost_equal(y[y != -1], y_)
 	assert_almost_equal(w[y != -1], w_)
@@ -278,8 +276,8 @@ def test_io_seqgenerator_wy_unlabeled():
 	X_ = numpy.concatenate([batch[0] for batch in data.unlabeled_batches()])
 	w_ = numpy.concatenate([batch[1] for batch in data.unlabeled_batches()])
 
-	assert_true(len(X) > len(X_))
-	assert_true(len(w) > len(w_))
+	assert len(X) > len(X_)
+	assert len(w) > len(w_)
 
 	i = 0
 	for j in range(500):
@@ -301,8 +299,8 @@ def test_io_seqgenerator_wy_symbol_unlabeled():
 	X_ = numpy.concatenate([batch[0] for batch in data.unlabeled_batches()])
 	w_ = numpy.concatenate([batch[1] for batch in data.unlabeled_batches()])
 
-	assert_true(len(X) > len(X_))
-	assert_true(len(w) > len(w_))
+	assert len(X) > len(X_)
+	assert len(w) > len(w_)
 
 	i = 0
 	for j in range(500):
@@ -325,9 +323,9 @@ def test_io_seqgenerator_wy_labeled():
 	w_ = numpy.concatenate([batch[1] for batch in data.labeled_batches()])
 	y_ = numpy.concatenate([batch[2] for batch in data.labeled_batches()])
 
-	assert_true(len(X) > len(X_))
-	assert_true(len(w) > len(w_))
-	assert_true(len(y) > len(y_))
+	assert len(X) > len(X_)
+	assert len(w) > len(w_)
+	assert len(y) > len(y_)
 
 	i = 0
 	for j in range(500):
@@ -351,9 +349,9 @@ def test_io_seqgenerator_wy_symbol_labeled():
 	w_ = numpy.concatenate([batch[1] for batch in data.labeled_batches()])
 	y_ = numpy.concatenate([batch[2] for batch in data.labeled_batches()])
 
-	assert_true(len(X) > len(X_))
-	assert_true(len(w) > len(w_))
-	assert_true(len(y) > len(y_))
+	assert len(X) > len(X_)
+	assert len(w) > len(w_)
+	assert len(y) > len(y_)
 
 	i = 0
 	for j in range(500):
@@ -373,7 +371,9 @@ def test_io_dfgenerator_classes_fail():
 	X = pandas.DataFrame(numpy.random.randn(500, 13))
 	data = DataFrameGenerator(X)
 
-	assert_raises(ValueError, lambda data: data.classes, data)
+	with pytest.raises(ValueError):
+		d = lambda data: data.classes
+		d(data)
 
 def test_io_dfgenerator_numpy_classes():
 	X = pandas.DataFrame(numpy.random.randn(500, 13))
@@ -627,7 +627,7 @@ def test_io_dfgenerator_wy_unlabeled():
 	X_ = numpy.concatenate([batch[0] for batch in data.unlabeled_batches()])
 	w_ = numpy.concatenate([batch[1] for batch in data.unlabeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X.loc[y == -1], X_)
 	assert_almost_equal(w[y == -1], w_)
 
@@ -644,7 +644,7 @@ def test_io_dfgenerator_wy_str_unlabeled():
 	X_ = numpy.concatenate([batch[0] for batch in data.unlabeled_batches()])
 	w_ = numpy.concatenate([batch[1] for batch in data.unlabeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X2.loc[y == -1], X_)
 	assert_almost_equal(w[y == -1], w_)
 
@@ -658,7 +658,7 @@ def test_io_dfgenerator_wy_labeled():
 	y_ = numpy.concatenate([batch[1] for batch in data.labeled_batches()])
 	w_ = numpy.concatenate([batch[2] for batch in data.labeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X.loc[y != -1], X_)
 	assert_almost_equal(y[y != -1], y_)
 	assert_almost_equal(w[y != -1], w_)
@@ -677,7 +677,7 @@ def test_io_dfgenerator_wy_str_labeled():
 	y_ = numpy.concatenate([batch[1] for batch in data.labeled_batches()])
 	w_ = numpy.concatenate([batch[2] for batch in data.labeled_batches()])
 
-	assert_true(X.shape[0] > X_.shape[0])
+	assert X.shape[0] > X_.shape[0]
 	assert_almost_equal(X2.loc[y != -1], X_)
 	assert_almost_equal(y[y != -1], y_)
 	assert_almost_equal(w[y != -1], w_)

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -1,125 +1,112 @@
 from pomegranate import *
-from nose.tools import with_setup
-from nose.tools import assert_true
-from nose.tools import assert_equal
-from nose.tools import assert_greater_equal
-from nose.tools import assert_greater
-from nose.tools import assert_raises
-from nose.tools import assert_not_equal
-from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
-import random
-import pickle
-import numpy as np
+
+import pytest
 
 numpy.random.seed(0)
 
-def setup_three_dimensions():
-	global X
-	X = numpy.array([[-0.13174492,  0.51895916, -1.13141796],
-		 [ 7.92260379,  7.86325294,  7.9884075 ],
-         [-0.63378039, -0.96394236, -1.34125012],
-         [ 8.16216236,  8.04655182,  6.68825619],
-         [-0.69595565, -0.19004012,  0.40768949],
-         [ 7.76271281,  8.94969945,  7.03687617],
-         [-1.92481462, -1.03905815, -0.44048926],
-         [ 7.90926091,  7.21944418,  7.15989354],
-         [-0.97493454, -0.04714556, -0.38607725],
-         [ 9.65781658,  7.04832845,  6.47613347]])
+@pytest.fixture
+def three_dimensions():
+	X = numpy.array([[-0.13174492,	0.51895916, -1.13141796],
+		 [ 7.92260379,	7.86325294,  7.9884075 ],
+		 [-0.63378039, -0.96394236, -1.34125012],
+		 [ 8.16216236,	8.04655182,  6.68825619],
+		 [-0.69595565, -0.19004012,  0.40768949],
+		 [ 7.76271281,	8.94969945,  7.03687617],
+		 [-1.92481462, -1.03905815, -0.44048926],
+		 [ 7.90926091,	7.21944418,  7.15989354],
+		 [-0.97493454, -0.04714556, -0.38607725],
+		 [ 9.65781658,	7.04832845,  6.47613347]])
 
 	idxs = numpy.array([29, 19, 26, 11,  8, 27, 21,  7, 14, 13])
 	i, j = idxs // 3, idxs % 3
 
-	global X_nan
 	X_nan = X.copy()
 	X_nan[i, j] = numpy.nan
 
 
-	global centroids
 	centroids = numpy.array([[0, 0, 0],
 							 [8, 8, 8]])
 
-	global model
 	model = Kmeans(2, centroids)
+	return X, X_nan, centroids, model
 
 
-def setup_five_dimensions():
-	global X
-	X = numpy.array([[-0.04320239,  2.25402395, -0.3075753 ,  0.01710706,  2.88816037],
-	      [ 3.6483074 ,  5.03958367,  3.14457941,  4.94180558,  4.32880698],
-	      [ 7.48485345,  8.54100011,  7.90936486,  8.12260819,  6.6466098 ],
-	      [ 12.15394848,  10.52091121,  13.55495735,  10.48190106, 10.94417476],
-          [ 1.21068778,  0.77311369, -0.31479566, -0.51865649,  0.4408653 ],
-          [-0.62796182, -0.34947675, -1.09050772, -0.34591408,  0.78866514],
-          [ 0.5661847 ,  0.30785453,  0.38823634,  1.99717206, -0.99415221],
-          [ 0.10871016,  2.06244903, -0.19580087, -0.22100353, -0.43777027],
-	      [ 3.06987578,  4.8633418 ,  4.23645519,  4.20563589,  3.40046883],
-          [ 3.0471144 ,  3.43070459,  3.88690894,  3.61962816,  3.52399965],
-          [ 3.3020318 ,  5.16491752,  3.85249134,  2.7075964 ,  4.03831846],
-          [ 3.55266908,  2.69803949,  4.13340743,  5.72527752,  4.9840009 ],
-	      [ 7.27689336,  8.99614296,  7.10109146,  7.81354687,  7.27320546],
-          [ 9.55443921,  7.70358635,  8.9762396 ,  7.8054752 ,  7.95933534],
-          [ 7.55150108,  9.09523173,  8.38379803,  8.18932292,  7.70853   ],
-          [ 9.59329137,  8.26811547,  9.82226673,  8.35257773,  8.21768809],
-          [ 11.77294852,  12.33135372,  13.02160394,  12.05536766, 11.96375761],
-          [ 11.08768408,  13.15689157,  12.59002102,  11.16137415, 9.84335332],
-          [ 11.41978669,  11.45646564,  11.77622614,  11.96590564, 12.33083825],
-          [ 12.13323296,  11.89683824,  12.18373541,  13.21432431, 11.79987739]])
+@pytest.fixture
+def five_dimensions():
+	X = numpy.array([[-0.04320239,	2.25402395, -0.3075753 ,  0.01710706,  2.88816037],
+		  [ 3.6483074 ,  5.03958367,  3.14457941,  4.94180558,	4.32880698],
+		  [ 7.48485345,  8.54100011,  7.90936486,  8.12260819,	6.6466098 ],
+		  [ 12.15394848,  10.52091121,	13.55495735,  10.48190106, 10.94417476],
+		  [ 1.21068778,  0.77311369, -0.31479566, -0.51865649,	0.4408653 ],
+		  [-0.62796182, -0.34947675, -1.09050772, -0.34591408,	0.78866514],
+		  [ 0.5661847 ,  0.30785453,  0.38823634,  1.99717206, -0.99415221],
+		  [ 0.10871016,  2.06244903, -0.19580087, -0.22100353, -0.43777027],
+		  [ 3.06987578,  4.8633418 ,  4.23645519,  4.20563589,	3.40046883],
+		  [ 3.0471144 ,  3.43070459,  3.88690894,  3.61962816,	3.52399965],
+		  [ 3.3020318 ,  5.16491752,  3.85249134,  2.7075964 ,	4.03831846],
+		  [ 3.55266908,  2.69803949,  4.13340743,  5.72527752,	4.9840009 ],
+		  [ 7.27689336,  8.99614296,  7.10109146,  7.81354687,	7.27320546],
+		  [ 9.55443921,  7.70358635,  8.9762396 ,  7.8054752 ,	7.95933534],
+		  [ 7.55150108,  9.09523173,  8.38379803,  8.18932292,	7.70853   ],
+		  [ 9.59329137,  8.26811547,  9.82226673,  8.35257773,	8.21768809],
+		  [ 11.77294852,  12.33135372,	13.02160394,  12.05536766, 11.96375761],
+		  [ 11.08768408,  13.15689157,	12.59002102,  11.16137415, 9.84335332],
+		  [ 11.41978669,  11.45646564,	11.77622614,  11.96590564, 12.33083825],
+		  [ 12.13323296,  11.89683824,	12.18373541,  13.21432431, 11.79987739]])
 
 	idxs = numpy.array([77, 26, 61, 46, 18, 30, 94, 96, 45, 67,  4, 20, 23, 73, 37, 21, 58,
-       99, 51,  7, 69, 53, 81, 85, 95,  9, 98, 24, 28, 38])
+	   99, 51,	7, 69, 53, 81, 85, 95,	9, 98, 24, 28, 38])
 	i, j = idxs // 5, idxs % 5
 
-	global X_nan
 	X_nan = X.copy()
 	X_nan[i, j] = numpy.nan
 
-	global centroids
 	centroids = numpy.array([[0, 0, 0, 0, 0],
 							 [4, 4, 4, 4, 4],
 							 [8, 8, 8, 8, 8],
 							 [12, 12, 12, 12, 12]])
 
-	global model
 	model = Kmeans(4, centroids)
+	return X, X_nan, centroids, model
 
 
 def test_kmeans_init():
 	centroids = [[2, 3], [5, 7]]
 	model = Kmeans(2, centroids)
-	assert_equal(model.d, 2)
-	assert_equal(model.k, 2)
+	assert model.d == 2
+	assert model.k == 2
 	assert_array_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_from_samples():
+def test_kmeans_from_samples(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model = Kmeans.from_samples(2, X, init='first-k')
 	centroids = [[-0.872246, -0.344245, -0.578309],
-      			 [ 8.282911,  7.825455,  7.069913]]
+				 [ 8.282911,  7.825455,  7.069913]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_from_samples_parallel():
+def test_kmeans_from_samples_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model = Kmeans.from_samples(2, X, init='first-k', n_jobs=2)
 	centroids = [[-0.872246, -0.344245, -0.578309],
-      			 [ 8.282911,  7.825455,  7.069913]]
+				 [ 8.282911,  7.825455,  7.069913]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_predict():
+def test_kmeans_predict(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
 	y_hat = model.predict(X)
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_predict_parallel():
+def test_kmeans_predict_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
 	y_hat = model.predict(X, n_jobs=2)
 	assert_array_equal(y, y_hat)
@@ -128,15 +115,15 @@ def test_kmeans_predict_parallel():
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_predict_large():
+def test_kmeans_predict_large(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	y = [0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 	y_hat = model.predict(X)
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_predict_large_parallel():
+def test_kmeans_predict_large_parallel(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	y = [0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
 	y_hat = model.predict(X, n_jobs=2)
 	assert_array_equal(y, y_hat)
@@ -145,42 +132,42 @@ def test_kmeans_predict_large_parallel():
 	assert_array_equal(y, y_hat)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_fit():
+def test_kmeans_fit(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model.fit(X)
 
 	centroids = [[-0.872246, -0.344245, -0.578309],
-       			 [ 8.282911,  7.825455,  7.069913]]
+				 [ 8.282911,  7.825455,  7.069913]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_fit_parallel():
+def test_kmeans_fit_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model.fit(X, n_jobs=2)
 
 	centroids = [[-0.872246, -0.344245, -0.578309],
-       			 [ 8.282911,  7.825455,  7.069913]]
+				 [ 8.282911,  7.825455,  7.069913]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 	model.fit(X, n_jobs=4)
 
 	centroids = [[-0.872246, -0.344245, -0.578309],
-       			 [ 8.282911,  7.825455,  7.069913]]
+				 [ 8.282911,  7.825455,  7.069913]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_multiple_init():
+def test_kmeans_multiple_init(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model1 = Kmeans.from_samples(4, X, init='kmeans++', n_init=1)
 	model2 = Kmeans.from_samples(4, X, init='kmeans++', n_init=25)
 
 	dist1 = model1.distance(X).min(axis=1).sum()
 	dist2 = model2.distance(X).min(axis=1).sum()
 
-	assert_greater_equal(dist1, dist2)
+	assert dist1 >= dist2
 
 	model1 = Kmeans.from_samples(4, X, init='first-k', n_init=1)
 	model2 = Kmeans.from_samples(4, X, init='first-k', n_init=5)
@@ -188,11 +175,11 @@ def test_kmeans_multiple_init():
 	dist1 = model1.distance(X).min(axis=1).sum()
 	dist2 = model2.distance(X).min(axis=1).sum()
 
-	assert_equal(dist1, dist2)
+	assert dist1 == dist2
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_ooc_from_samples():
+def test_kmeans_ooc_from_samples(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	numpy.random.seed(0)
 
 	model1 = Kmeans.from_samples(5, X, init='first-k', batch_size=20)
@@ -201,8 +188,8 @@ def test_kmeans_ooc_from_samples():
 	assert_array_equal(model1.centroids, model2.centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_ooc_fit():
+def test_kmeans_ooc_fit(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	centroids_copy = numpy.copy(centroids)
 	model1 = Kmeans(2, centroids_copy, n_init=1)
 	model1.fit(X)
@@ -219,18 +206,19 @@ def test_kmeans_ooc_fit():
 	assert_array_almost_equal(model1.centroids, model3.centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_minibatch_from_samples():
+def test_kmeans_minibatch_from_samples(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model1 = Kmeans.from_samples(4, X, init='first-k', batch_size=10)
 	model2 = Kmeans.from_samples(4, X, init='first-k', batch_size=None)
 	model3 = Kmeans.from_samples(4, X, init='first-k', batch_size=10, batches_per_epoch=1)
 
 	assert_array_almost_equal(model1.centroids, model2.centroids)
-	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+	with pytest.raises(AssertionError):
+		assert_array_equal(model1.centroids, model3.centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_minibatch_fit():
+def test_kmeans_minibatch_fit(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	centroids_copy = numpy.copy(centroids)
 	model1 = Kmeans(4, centroids_copy)
 	model1.fit(X, batch_size=10)
@@ -244,105 +232,106 @@ def test_kmeans_minibatch_fit():
 	model3.fit(X, batch_size=5, batches_per_epoch=1)
 
 	assert_array_almost_equal(model1.centroids, model2.centroids)
-	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+	with pytest.raises(AssertionError):
+		assert_array_equal(model1.centroids, model3.centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_from_samples():
+def test_kmeans_nan_from_samples(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model = Kmeans.from_samples(2, X_nan, init='first-k')
 	centroids = [[-0.872246,  0.235907, -0.785954],
-      			 [ 7.94916 ,  7.825455,  7.395059]]
+				 [ 7.94916 ,  7.825455,  7.395059]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_from_samples_parallel():
+def test_kmeans_nan_from_samples_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model = Kmeans.from_samples(2, X_nan, init='first-k', n_jobs=2)
 	centroids = [[-0.872246,  0.235907, -0.785954],
-      			 [ 7.94916 ,  7.825455,  7.395059]]
+				 [ 7.94916 ,  7.825455,  7.395059]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_fit():
+def test_kmeans_nan_fit(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model.fit(X_nan)
 
 	centroids = [[-0.872246,  0.235907, -0.785954],
-      			 [ 7.94916 ,  7.825455,  7.395059]]
+				 [ 7.94916 ,  7.825455,  7.395059]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_fit_parallel():
+def test_kmeans_nan_fit_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	model.fit(X_nan, n_jobs=2)
 
 	centroids = [[-0.872246,  0.235907, -0.785954],
-      			 [ 7.94916 ,  7.825455,  7.395059]]
+				 [ 7.94916 ,  7.825455,  7.395059]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_nan_fit_large():
+def test_kmeans_nan_fit_large(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model.fit(X_nan)
 
-	centroids = [[ -0.187485,   1.541443,  -0.331161,   1.00714 ,  -0.214419],
-		         [  3.393221,   4.200322,   4.027316,   4.25569 ,   3.986697],
-		         [  8.292196,   8.401983,   7.798085,   8.023552,   7.461508],
-		         [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
+	centroids = [[ -0.187485,	1.541443,  -0.331161,	1.00714 ,  -0.214419],
+				 [	3.393221,	4.200322,	4.027316,	4.25569 ,	3.986697],
+				 [	8.292196,	8.401983,	7.798085,	8.023552,	7.461508],
+				 [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_nan_fit_large_parallel():
+def test_kmeans_nan_fit_large_parallel(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model.fit(X_nan, n_jobs=2)
 
-	centroids = [[ -0.187485,   1.541443,  -0.331161,   1.00714 ,  -0.214419],
-		         [  3.393221,   4.200322,   4.027316,   4.25569 ,   3.986697],
-		         [  8.292196,   8.401983,   7.798085,   8.023552,   7.461508],
-		         [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
+	centroids = [[ -0.187485,	1.541443,  -0.331161,	1.00714 ,  -0.214419],
+				 [	3.393221,	4.200322,	4.027316,	4.25569 ,	3.986697],
+				 [	8.292196,	8.401983,	7.798085,	8.023552,	7.461508],
+				 [ 11.782228,  11.711423,  12.625309,  11.727549,  10.917095]]
 
 	assert_array_almost_equal(model.centroids, centroids)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_predict():
+def test_kmeans_nan_predict(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
 	y_hat = model.predict(X_nan)
 
 	assert_array_almost_equal(y, y_hat)
 
 
-@with_setup(setup_three_dimensions)
-def test_kmeans_nan_predict_parallel():
+def test_kmeans_nan_predict_parallel(three_dimensions):
+	X, X_nan, centroids, model = three_dimensions
 	y = numpy.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
 	y_hat = model.predict(X_nan, n_jobs=2)
 
 	assert_array_almost_equal(y, y_hat)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_nan_large_predict():
+def test_kmeans_nan_large_predict(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	y = numpy.array([0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
 	y_hat = model.predict(X_nan)
 
 	assert_array_almost_equal(y, y_hat)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_nan_large_predict_parallel():
+def test_kmeans_nan_large_predict_parallel(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	y = numpy.array([0, 1, 2, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
 	y_hat = model.predict(X_nan, n_jobs=2)
 
 	assert_array_almost_equal(y, y_hat)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_nan_multiple_init():
+def test_kmeans_nan_multiple_init(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	numpy.random.seed(0)
 	model1 = Kmeans.from_samples(4, X_nan, init='kmeans++', n_init=1)
 	
@@ -352,7 +341,7 @@ def test_kmeans_nan_multiple_init():
 	dist1 = model1.distance(X).min(axis=1).sum()
 	dist2 = model2.distance(X).min(axis=1).sum()
 
-	assert_greater_equal(dist1, dist2)
+	assert dist1 >= dist2
 
 	model1 = Kmeans.from_samples(4, X_nan, init='first-k', n_init=1)
 	model2 = Kmeans.from_samples(4, X_nan, init='first-k', n_init=5)
@@ -360,19 +349,19 @@ def test_kmeans_nan_multiple_init():
 	dist1 = model1.distance(X).min(axis=1).sum()
 	dist2 = model2.distance(X).min(axis=1).sum()
 
-	assert_equal(dist1, dist2)
+	assert dist1 == dist2
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_ooc_nan_from_samples():
+def test_kmeans_ooc_nan_from_samples(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model1 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=20)
 	model2 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=None)
 
 	assert_array_almost_equal(model1.centroids, model2.centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_ooc_nan_fit():
+def test_kmeans_ooc_nan_fit(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	centroids_copy = numpy.copy(centroids)
 	model1 = Kmeans(4, centroids_copy, n_init=1)
 	model1.fit(X_nan)
@@ -389,8 +378,8 @@ def test_kmeans_ooc_nan_fit():
 	assert_array_almost_equal(model1.centroids, model3.centroids, 4)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_minibatch_nan_from_samples():
+def test_kmeans_minibatch_nan_from_samples(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	model1 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=10)
 	model2 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=None)
 	model3 = Kmeans.from_samples(4, X_nan, init='first-k', batch_size=10, batches_per_epoch=1)
@@ -398,11 +387,12 @@ def test_kmeans_minibatch_nan_from_samples():
 
 	assert_array_almost_equal(model1.centroids, model2.centroids)
 	assert_array_almost_equal(model1.centroids, model4.centroids)
-	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+	with pytest.raises(AssertionError):
+		assert_array_equal(model1.centroids, model3.centroids)
 
 
-@with_setup(setup_five_dimensions)
-def test_kmeans_minibatch_nan_fit():
+def test_kmeans_minibatch_nan_fit(five_dimensions):
+	X, X_nan, centroids, model = five_dimensions
 	centroids_copy = numpy.copy(centroids)
 	model1 = Kmeans(4, centroids_copy, n_init=1)
 	model1.fit(X, batch_size=10)
@@ -421,4 +411,5 @@ def test_kmeans_minibatch_nan_fit():
 
 	assert_array_almost_equal(model1.centroids, model2.centroids)
 	assert_array_almost_equal(model1.centroids, model4.centroids)
-	assert_raises(AssertionError, assert_array_equal, model1.centroids, model3.centroids)
+	with pytest.raises(AssertionError):
+		assert_array_equal(model1.centroids, model3.centroids)

--- a/tests/test_markov_chain.py
+++ b/tests/test_markov_chain.py
@@ -1,78 +1,67 @@
 from __future__ import (division)
 
 from pomegranate import *
-from nose.tools import with_setup
-from nose.tools import assert_almost_equal
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
-from nose.tools import assert_less_equal
-from nose.tools import assert_raises
-import random
+from .assert_tools import assert_almost_equal
+
 import pickle
-import numpy as np
+import pytest
 
+
+@pytest.fixture
 def setup():
-	global data
-	global weights
-	global zeroth_dist
-	global first_dist
-	global second_dist
+    data = [ list('AAACBDAA'), list('DBBCBABD'), list('CBDCCDCBC'),	 list('DDDDC'),
+    		 list('DADBBCBBBACBC'), list('CBDBAC'), list('CACDDDBCAABA'), list('BBABDAADCABCCAD'),
+    		 list('DCBBBADBBCBC'), list('DCADDAAA'), list('AABBBCC'), list('CABBADACDBBDCC'),
+    		 list('AADDCDDDB'), list('CCDBDCDDDABDAC'), list('DDADB'), list('BCDACDBBBBAC'),
+    		 list('ADCBCCCB'), list('BDDBCA'), list('ACCDCBADCBBBB'), list('ACCBABCBA'),
+    		 list('DAABCCBBD'), list('CCAADACBDCDBABC'), list('BCDCACBBAD'), list('CBBBCDCA'),
+    		 list('CBDADACAADBCC'), list('DCDABCC'), list('AAAABCBC'), list('BDDDDACBBCABA'),
+    		 list('CCBDCBDCBADBBDB'), list('CBDAA'), list('CCDAAAB'), list('ABDBAC'),
+    		 list('DBCCDCC'), list('CCDCBB'), list('ACDBCDD'), list('CACCACCDBBDABB'),
+    		 list('DCDDAB'), list('ADDDCDACACA'), list('AAACACADB'), list('BDBBDDBACDCCAAA') ]
 
-	data = [ list('AAACBDAA'), list('DBBCBABD'), list('CBDCCDCBC'),	 list('DDDDC'),
-			 list('DADBBCBBBACBC'), list('CBDBAC'), list('CACDDDBCAABA'), list('BBABDAADCABCCAD'),
-			 list('DCBBBADBBCBC'), list('DCADDAAA'), list('AABBBCC'), list('CABBADACDBBDCC'),
-			 list('AADDCDDDB'), list('CCDBDCDDDABDAC'), list('DDADB'), list('BCDACDBBBBAC'),
-			 list('ADCBCCCB'), list('BDDBCA'), list('ACCDCBADCBBBB'), list('ACCBABCBA'),
-			 list('DAABCCBBD'), list('CCAADACBDCDBABC'), list('BCDCACBBAD'), list('CBBBCDCA'),
-			 list('CBDADACAADBCC'), list('DCDABCC'), list('AAAABCBC'), list('BDDDDACBBCABA'),
-			 list('CCBDCBDCBADBBDB'), list('CBDAA'), list('CCDAAAB'), list('ABDBAC'),
-			 list('DBCCDCC'), list('CCDCBB'), list('ACDBCDD'), list('CACCACCDBBDABB'),
-			 list('DCDDAB'), list('ADDDCDACACA'), list('AAACACADB'), list('BDBBDDBACDCCAAA') ]
+    weights = [ 8, 7, 1, 2, 8, 1, 9, 2, 6, 2, 5, 6, 10, 10, 8, 4, 10, 10, 2, 9,
+    			6, 2, 9, 9, 3, 1, 10, 6, 9, 1, 2, 9, 2, 1, 4, 1, 2, 7, 9, 4]
 
-	weights = [ 8, 7, 1, 2, 8, 1, 9, 2, 6, 2, 5, 6, 10, 10, 8, 4, 10, 10, 2, 9,
-				6, 2, 9, 9, 3, 1, 10, 6, 9, 1, 2, 9, 2, 1, 4, 1, 2, 7, 9, 4]
+    zeroth_dist = DiscreteDistribution( { 'A': 0.1, 'B': 0.2, 'C': 0.3, 'D': 0.4 } )
 
-	zeroth_dist = DiscreteDistribution( { 'A': 0.1, 'B': 0.2, 'C': 0.3, 'D': 0.4 } )
+    first_dist = ConditionalProbabilityTable(
+    	[[ 'A', 'A', 0.8 ], [ 'A', 'B', 0.05 ], [ 'A', 'C', 0.05 ], [ 'A', 'D', 0.1 ],
+    	 [ 'B', 'A', 0.1 ], [ 'B', 'B', 0.2 ], [ 'B', 'C', 0.6 ], [ 'B', 'D', 0.1 ],
+    	 [ 'C', 'A', 0.15 ], [ 'C', 'B', 0.1 ], [ 'C', 'C', 0.25 ], [ 'C', 'D', 0.5 ],
+    	 [ 'D', 'A', 0.25 ], [ 'D', 'B', 0.25 ], [ 'D', 'C', 0.4 ], [ 'D', 'D', 0.1 ]],
+    	 [ zeroth_dist ] )
 
-	first_dist = ConditionalProbabilityTable(
-		[[ 'A', 'A', 0.8 ], [ 'A', 'B', 0.05 ], [ 'A', 'C', 0.05 ], [ 'A', 'D', 0.1 ],
-		 [ 'B', 'A', 0.1 ], [ 'B', 'B', 0.2 ], [ 'B', 'C', 0.6 ], [ 'B', 'D', 0.1 ],
-		 [ 'C', 'A', 0.15 ], [ 'C', 'B', 0.1 ], [ 'C', 'C', 0.25 ], [ 'C', 'D', 0.5 ],
-		 [ 'D', 'A', 0.25 ], [ 'D', 'B', 0.25 ], [ 'D', 'C', 0.4 ], [ 'D', 'D', 0.1 ]],
-		 [ zeroth_dist ] )
+    second_dist = ConditionalProbabilityTable(
+    	[[ 'A', 'A', 'A', 0.05 ], [ 'A', 'A', 'B', 0.25 ], [ 'A', 'A', 'C', 0.15 ], [ 'A', 'A', 'D', 0.55 ],
+    	 [ 'A', 'B', 'A', 0.05 ], [ 'A', 'B', 'B', 0.05 ], [ 'A', 'B', 'C', 0.85 ], [ 'A', 'B', 'D', 0.05 ],
+    	 [ 'A', 'C', 'A', 0.7 ], [ 'A', 'C', 'B', 0.1 ], [ 'A', 'C', 'C', 0.1 ], [ 'A', 'C', 'D', 0.1 ],
+    	 [ 'A', 'D', 'A', 0.2 ], [ 'A', 'D', 'B', 0.4 ], [ 'A', 'D', 'C', 0.35 ], [ 'A', 'D', 'D', 0.05 ],
+    	 [ 'B', 'A', 'A', 0.3 ], [ 'B', 'A', 'B', 0.05 ], [ 'B', 'A', 'C', 0.15 ], [ 'B', 'A', 'D', 0.5 ],
+    	 [ 'B', 'B', 'A', 0.8 ], [ 'B', 'B', 'B', 0.1 ], [ 'B', 'B', 'C', 0.1 ], [ 'B', 'B', 'D', 0.0 ],
+    	 [ 'B', 'C', 'A', 0.1 ], [ 'B', 'C', 'B', 0.35 ], [ 'B', 'C', 'C', 0.3 ], [ 'B', 'C', 'D', 0.25 ],
+    	 [ 'B', 'D', 'A', 0.3 ], [ 'B', 'D', 'B', 0.1 ], [ 'B', 'D', 'C', 0.2 ], [ 'B', 'D', 'D', 0.4 ],
+    	 [ 'C', 'A', 'A', 0.2 ], [ 'C', 'A', 'B', 0.3 ], [ 'C', 'A', 'C', 0.3 ], [ 'C', 'A', 'D', 0.2 ],
+    	 [ 'C', 'B', 'A', 0.35 ], [ 'C', 'B', 'B', 0.45 ], [ 'C', 'B', 'C', 0.0 ], [ 'C', 'B', 'D', 0.2 ],
+    	 [ 'C', 'C', 'A', 0.25 ], [ 'C', 'C', 'B', 0.0 ], [ 'C', 'C', 'C', 0.6 ], [ 'C', 'C', 'D', 0.15 ],
+    	 [ 'C', 'D', 'A', 0.8 ], [ 'C', 'D', 'B', 0.1 ], [ 'C', 'D', 'C', 0.05 ], [ 'C', 'D', 'D', 0.05 ],
+    	 [ 'D', 'A', 'A', 0.5 ], [ 'D', 'A', 'B', 0.0 ], [ 'D', 'A', 'C', 0.5 ], [ 'D', 'A', 'D', 0.0 ],
+    	 [ 'D', 'B', 'A', 0.35 ], [ 'D', 'B', 'B', 0.5 ], [ 'D', 'B', 'C', 0.1 ], [ 'D', 'B', 'D', 0.05 ],
+    	 [ 'D', 'C', 'A', 0.1 ], [ 'D', 'C', 'B', 0.45 ], [ 'D', 'C', 'C', 0.0 ], [ 'D', 'C', 'D', 0.45 ],
+    	 [ 'D', 'D', 'A', 0.2 ], [ 'D', 'D', 'B', 0.1 ], [ 'D', 'D', 'C', 0.1 ], [ 'D', 'D', 'D', 0.6 ]],
+    	 [ zeroth_dist, first_dist ] )
+    return data, weights, zeroth_dist, first_dist, second_dist
 
-	second_dist = ConditionalProbabilityTable(
-		[[ 'A', 'A', 'A', 0.05 ], [ 'A', 'A', 'B', 0.25 ], [ 'A', 'A', 'C', 0.15 ], [ 'A', 'A', 'D', 0.55 ],
-		 [ 'A', 'B', 'A', 0.05 ], [ 'A', 'B', 'B', 0.05 ], [ 'A', 'B', 'C', 0.85 ], [ 'A', 'B', 'D', 0.05 ],
-		 [ 'A', 'C', 'A', 0.7 ], [ 'A', 'C', 'B', 0.1 ], [ 'A', 'C', 'C', 0.1 ], [ 'A', 'C', 'D', 0.1 ],
-		 [ 'A', 'D', 'A', 0.2 ], [ 'A', 'D', 'B', 0.4 ], [ 'A', 'D', 'C', 0.35 ], [ 'A', 'D', 'D', 0.05 ],
-		 [ 'B', 'A', 'A', 0.3 ], [ 'B', 'A', 'B', 0.05 ], [ 'B', 'A', 'C', 0.15 ], [ 'B', 'A', 'D', 0.5 ],
-		 [ 'B', 'B', 'A', 0.8 ], [ 'B', 'B', 'B', 0.1 ], [ 'B', 'B', 'C', 0.1 ], [ 'B', 'B', 'D', 0.0 ],
-		 [ 'B', 'C', 'A', 0.1 ], [ 'B', 'C', 'B', 0.35 ], [ 'B', 'C', 'C', 0.3 ], [ 'B', 'C', 'D', 0.25 ],
-		 [ 'B', 'D', 'A', 0.3 ], [ 'B', 'D', 'B', 0.1 ], [ 'B', 'D', 'C', 0.2 ], [ 'B', 'D', 'D', 0.4 ],
-		 [ 'C', 'A', 'A', 0.2 ], [ 'C', 'A', 'B', 0.3 ], [ 'C', 'A', 'C', 0.3 ], [ 'C', 'A', 'D', 0.2 ],
-		 [ 'C', 'B', 'A', 0.35 ], [ 'C', 'B', 'B', 0.45 ], [ 'C', 'B', 'C', 0.0 ], [ 'C', 'B', 'D', 0.2 ],
-		 [ 'C', 'C', 'A', 0.25 ], [ 'C', 'C', 'B', 0.0 ], [ 'C', 'C', 'C', 0.6 ], [ 'C', 'C', 'D', 0.15 ],
-		 [ 'C', 'D', 'A', 0.8 ], [ 'C', 'D', 'B', 0.1 ], [ 'C', 'D', 'C', 0.05 ], [ 'C', 'D', 'D', 0.05 ],
-		 [ 'D', 'A', 'A', 0.5 ], [ 'D', 'A', 'B', 0.0 ], [ 'D', 'A', 'C', 0.5 ], [ 'D', 'A', 'D', 0.0 ],
-		 [ 'D', 'B', 'A', 0.35 ], [ 'D', 'B', 'B', 0.5 ], [ 'D', 'B', 'C', 0.1 ], [ 'D', 'B', 'D', 0.05 ],
-		 [ 'D', 'C', 'A', 0.1 ], [ 'D', 'C', 'B', 0.45 ], [ 'D', 'C', 'C', 0.0 ], [ 'D', 'C', 'D', 0.45 ],
-		 [ 'D', 'D', 'A', 0.2 ], [ 'D', 'D', 'B', 0.1 ], [ 'D', 'D', 'C', 0.1 ], [ 'D', 'D', 'D', 0.6 ]],
-		 [ zeroth_dist, first_dist ] )
-
-def teardown():
-	pass
-
-@with_setup( setup, teardown )
-def test_zeroth_dist():
+def test_zeroth_dist(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	assert_almost_equal( zeroth_dist.log_probability( 'A' ), -2.3025850929940455 )
 	assert_almost_equal( zeroth_dist.log_probability( 'B' ), -1.6094379124341003 )
 	assert_almost_equal( zeroth_dist.log_probability( 'C' ), -1.2039728043259361 )
 	assert_almost_equal( zeroth_dist.log_probability( 'D' ), -0.916290731874155 )
-	assert_almost_equal( zeroth_dist.log_probability( 'E' ), -float('inf') )
+	assert zeroth_dist.log_probability( 'E' ) == -float('inf')
 
-@with_setup( setup, teardown )
-def test_first_dist():
+def test_first_dist(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	assert_almost_equal( first_dist.log_probability( ('A', 'A') ), -0.22314355131420971 )
 	assert_almost_equal( first_dist.log_probability( ('A', 'B') ), -2.9957322735539909 )
 
@@ -85,8 +74,8 @@ def test_first_dist():
 	assert_almost_equal( first_dist.log_probability( ('D', 'D') ), -2.3025850929940455 )
 	assert_almost_equal( first_dist.log_probability( ('D', 'A') ), -1.3862943611198906 )
 
-@with_setup( setup, teardown )
-def test_second_dist():
+def test_second_dist(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	assert_almost_equal( second_dist.log_probability( ('A', 'A', 'C') ), -1.89711998489 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'A', 'A') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('A', 'B', 'A') ), -2.99573227355 )
@@ -100,7 +89,7 @@ def test_second_dist():
 	assert_almost_equal( second_dist.log_probability( ('B', 'A', 'B') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'A', 'D') ), -0.69314718056 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'B', 'B') ), -2.30258509299 )
-	assert_almost_equal( second_dist.log_probability( ('B', 'B', 'D') ), -float('inf') )
+	assert second_dist.log_probability( ('B', 'B', 'D') ) == -float('inf')
 
 	assert_almost_equal( second_dist.log_probability( ('B', 'C', 'A') ), -2.30258509299 )
 	assert_almost_equal( second_dist.log_probability( ('B', 'C', 'B') ), -1.0498221245 )
@@ -109,15 +98,15 @@ def test_second_dist():
 
 	assert_almost_equal( second_dist.log_probability( ('C', 'A', 'A') ), -1.60943791243 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'A', 'B') ), -1.20397280433 )
-	assert_almost_equal( second_dist.log_probability( ('C', 'B', 'C') ), -float('inf') )
+	assert second_dist.log_probability( ('C', 'B', 'C') ) == -float('inf')
 	assert_almost_equal( second_dist.log_probability( ('C', 'B', 'A') ), -1.0498221245 )
 
 	assert_almost_equal( second_dist.log_probability( ('C', 'C', 'D') ), -1.89711998489 )
-	assert_almost_equal( second_dist.log_probability( ('C', 'C', 'B') ), -float('inf') )
+	assert second_dist.log_probability( ('C', 'C', 'B') ) == -float('inf')
 	assert_almost_equal( second_dist.log_probability( ('C', 'D', 'A') ), -0.223143551314 )
 	assert_almost_equal( second_dist.log_probability( ('C', 'D', 'C') ), -2.99573227355 )
 
-	assert_almost_equal( second_dist.log_probability( ('D', 'A', 'D') ), -float('inf') )
+	assert second_dist.log_probability( ('D', 'A', 'D') ) == -float('inf')
 	assert_almost_equal( second_dist.log_probability( ('D', 'A', 'A') ), -0.69314718056 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'B', 'D') ), -2.99573227355 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'B', 'C') ), -2.30258509299 )
@@ -127,14 +116,14 @@ def test_second_dist():
 	assert_almost_equal( second_dist.log_probability( ('D', 'D', 'D') ), -0.510825623766 )
 	assert_almost_equal( second_dist.log_probability( ('D', 'D', 'A') ), -1.60943791243 )
 
-@with_setup( setup, teardown )
-def test_constructors():
+def test_constructors(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	# raises no errors
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 	second_chain = MarkovChain([ zeroth_dist, first_dist, second_dist ])
 
-@with_setup( setup, teardown )
-def test_first_log_probability():
+def test_first_log_probability(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	# test going one state back
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 
@@ -179,20 +168,20 @@ def test_first_log_probability():
 
 	assert_almost_equal( second_chain.log_probability( list('ABDD') ), -9.21034037198 )
 	assert_almost_equal( second_chain.log_probability( list('CCCD') ), -4.9982127741 )
-	assert_almost_equal( second_chain.log_probability( list('CCBD') ), -float('inf') )
+	assert second_chain.log_probability( list('CCBD') ) == -float('inf')
 	assert_almost_equal( second_chain.log_probability( list('ACAC') ), -6.85896511481 )
 
 	assert_almost_equal( second_chain.log_probability( list('ABDBCCDC') ), -18.9960448889 )
-	assert_almost_equal( second_chain.log_probability( list('DACCBDCB') ), -float('inf') )
+	assert second_chain.log_probability( list('DACCBDCB') ) == -float('inf')
 
 	assert_almost_equal( second_chain.log_probability( list('BCCCACBDBDBABACD') ), -29.1792463442 )
 
-	assert_almost_equal( second_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -float('inf') )
+	assert second_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ) == -float('inf')
 
 # if summarize and from summaries work, so does fit
 
-@with_setup( setup, teardown )
-def test_summarize_no_weights_no_inertia():
+def test_summarize_no_weights_no_inertia(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 
 	# split in four
@@ -236,8 +225,8 @@ def test_summarize_no_weights_no_inertia():
 	second_chain.summarize( data[30:] )
 	second_chain.from_summaries()
 
-@with_setup( setup, teardown )
-def test_summarize_no_weights_with_inertia():
+def test_summarize_no_weights_with_inertia(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 
 	first_chain.summarize( data[:10] )
@@ -270,8 +259,8 @@ def test_summarize_no_weights_with_inertia():
 
 	assert_almost_equal( first_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -44.8853484278 )
 
-@with_setup( setup, teardown )
-def test_summarize_with_weights_no_inertia():
+def test_summarize_with_weights_no_inertia(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 
 	# split in four
@@ -305,8 +294,8 @@ def test_summarize_with_weights_no_inertia():
 
 	assert_almost_equal( first_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -44.3127858762 )
 
-@with_setup( setup, teardown )
-def test_summarize_with_weights_with_inertia():
+def test_summarize_with_weights_with_inertia(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	first_chain = MarkovChain([ zeroth_dist, first_dist ])
 
 	# split in four
@@ -340,28 +329,28 @@ def test_summarize_with_weights_with_inertia():
 
 	assert_almost_equal( first_chain.log_probability( list('DABBCBDACAAADCBDCDBCBDCACBDABBAA') ), -45.1660985662 )
 
-@with_setup( setup, teardown )
-def test_raise_errors():
+def test_raise_errors(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	pass
 
-@with_setup( setup, teardown )
-def test_pickling():
+def test_pickling(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	chain1 = MarkovChain([ zeroth_dist, first_dist ])
 	chain2 = pickle.loads( pickle.dumps( chain1 ) )
 
 	assert_almost_equal( chain1.log_probability( list('BCCCACBDBDBABACD') ),
 	                     chain2.log_probability( list('BCCCACBDBDBABACD') ) )
 
-@with_setup( setup, teardown )
-def test_json():
+def test_json(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	chain1 = MarkovChain([ zeroth_dist, first_dist ])
 	chain2 = MarkovChain.from_json(chain1.to_json())
 
 	assert_almost_equal( chain1.log_probability( list('BCCCACBDBDBABACD') ),
 	                     chain2.log_probability( list('BCCCACBDBDBABACD') ) )
 
-@with_setup( setup, teardown )
-def test_robust_from_json():
+def test_robust_from_json(setup):
+	data, weights, zeroth_dist, first_dist, second_dist = setup
 	chain1 = MarkovChain([ zeroth_dist, first_dist ])
 	chain2 = from_json(chain1.to_json())
 


### PR DESCRIPTION
We need this for Debian as nose isn't working with Python 3.11

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1024045