### PR TITLE
Fix API docs rendering

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,33 +62,32 @@ This returns the matrix of log posterior probabilities for numerical stability.
 API Reference
 -------------
 
+Distributions
+=========================
+
 .. automodule:: pomegranate.distributions
    :members: Bernoulli, Categorical, ConditionalCategorical, JointCategorical, DiracDelta, Exponential, Gamma, Normal, Poisson, StudentT, Uniform, ZeroInflated
 
-.. automodule:: pomegranate.bayes_classifier.BayesClassifier
-	:members:
-	:inherited-members:
+Models
+=========================
 
-.. automodule:: pomegranate.gmm.GeneralMixtureModel
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.bayes_classifier
+	:members: BayesClassifier
 
-.. automodule:: pomegranate.hmm.DenseHMM
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.gmm
+	:members: BayesClassifier
 
-.. automodule:: pomegranate.hmm.SparseHMM
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.hmm
+	:members: DenseHMM
 
-.. automodule:: pomegranate.markov_chain.MarkovChain
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.hmm
+	:members: SparseHMM
 
-.. automodule:: pomegranate.bayesian_network.BayesianNetwork
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.markov_chain
+	:members: MarkovChain
 
-.. automodule:: pomegranate.factor_graph.FactorGraph
-	:members:
-	:inherited-members:
+.. automodule:: pomegranate.bayesian_network.
+	:members: BayesianNetwork
+
+.. automodule:: pomegranate.factor_graph
+	:members: FactorGraph

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,31 +63,24 @@ API Reference
 -------------
 
 Distributions
-=========================
+=============
 
 .. automodule:: pomegranate.distributions
    :members: Bernoulli, Categorical, ConditionalCategorical, JointCategorical, DiracDelta, Exponential, Gamma, Normal, Poisson, StudentT, Uniform, ZeroInflated
 
 Models
-=========================
+======
 
-.. automodule:: pomegranate.bayes_classifier
-	:members: BayesClassifier
+.. autoclass:: pomegranate.bayes_classifier.BayesClassifier
 
-.. automodule:: pomegranate.gmm
-	:members: BayesClassifier
+.. autoclass:: pomegranate.gmm.GeneralMixtureModel
 
-.. automodule:: pomegranate.hmm
-	:members: DenseHMM
+.. autoclass:: pomegranate.hmm.DenseHMM
 
-.. automodule:: pomegranate.hmm
-	:members: SparseHMM
+.. autoclass:: pomegranate.hmm.SparseHMM
 
-.. automodule:: pomegranate.markov_chain
-	:members: MarkovChain
+.. autoclass:: pomegranate.markov_chain.MarkovChain
 
-.. automodule:: pomegranate.bayesian_network.
-	:members: BayesianNetwork
+.. autoclass:: pomegranate.bayesian_network.BayesianNetwork
 
-.. automodule:: pomegranate.factor_graph
-	:members: FactorGraph
+.. autoclass:: pomegranate.factor_graph.FactorGraph


### PR DESCRIPTION
## Description

Proposal to fix API rendering issue in the documentation, as described in #1040 .

## Solution

The proposed implementation uses `autoclass `in place of `automodule`. 
In addition to that, I split `Distributions` and `Models` sections, which results in the following rendering:

![pome-api-suggestion](https://github.com/jmschrei/pomegranate/assets/42817048/1e54ad11-ecb7-48b2-aa7f-b8f4d333b9fc)
