### PR TITLE
Fix installation process by disallowing Cython version 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
 	description='A PyTorch implementation of probabilistic models.',
 	install_requires=[
 		'numpy >= 1.22.2', 
+		'Cython >= 0.29.35, <3.0.0',
 		'scipy >= 1.6.2',
 		'scikit-learn >= 1.0.2',
 		'torch >= 1.9.0',


### PR DESCRIPTION
Cython released [a major release (3.0)](https://pypi.org/project/Cython/#history) last week.
The installation process started failing around this time.

This release changed [some major things](https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html), and is almost certainly the cause of this error.

This is a temporary fix to disallow Cython 3.0 to be used for the build process.
A proper understanding of the code (which I lack) would be required for finding a way to accommodate Cython 3.0 instead of disallowing it.

 Resolves #1052