### PR TITLE
Efficient Tensor conversion from list of numpy arrays

### DIFF
--- a/pomegranate/_utils.py
+++ b/pomegranate/_utils.py
@@ -56,7 +56,10 @@ def _cast_as_tensor(value, dtype=None):
 			return value
 		else:
 			return value.type(dtype)
-
+			
+	if isinstance(value, list) and all(isinstance(v, numpy.ndarray) for v in value):
+		value = numpy.array(value)
+		
 	if isinstance(value, (float, int, list, tuple, numpy.ndarray)):
 		if dtype is None:
 			return torch.tensor(value)


### PR DESCRIPTION
While playing around with pomegranate v1 I run into this warning:

`
/home/josalhor/Desktop/data-synt/venv/lib/python3.11/site-packages/pomegranate/_utils.py:62: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:261.)
`

I think my pull requests fixes that warning and should speed up the casting.