### PR TITLE
Fixed sample_weights not casted to tensor in Normal distribution

### DIFF
--- a/pomegranate/distributions/normal.py
+++ b/pomegranate/distributions/normal.py
@@ -257,7 +257,7 @@ class Normal(Distribution):
 
 		X, sample_weight = super().summarize(X, sample_weight=sample_weight)
 		X = _cast_as_tensor(X, dtype=self.means.dtype)
-
+		sample_weight = _cast_as_tensor(sample_weight, dtype=self.means.dtype)
 		if self.covariance_type == 'full':
 			self._w_sum += torch.sum(sample_weight, dim=0)
 			self._xw_sum += torch.sum(X * sample_weight, axis=0)


### PR DESCRIPTION
In the file distributions.normal, in the summarize function the input data was casted to tensor and the sample_weights were not. This raised an error later when computing self._xw_sum